### PR TITLE
bugfix: fix Tomcat JWT header size

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,9 @@ nkd.sparql.timeout=10000
 spring.servlet.multipart.max-file-size=${MAX_UPLOAD_SIZE:10MB}
 spring.servlet.multipart.max-request-size=${MAX_UPLOAD_SIZE:10MB}
 
+# Tomcat header size limit (default 8KB is too small for large JWT tokens)
+server.max-http-request-header-size=32KB
+
 # RDF parsing timeout (seconds)
 rdf.parsing.timeout=60
 


### PR DESCRIPTION
  - Increases Tomcat max header size to 32KB to handle large JWT tokens