### PR TITLE
feat: add full-backend Docker profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,25 @@
-# CAAIS Identity Provider Configuration
 # Copy this file to .env and fill in your actual values
 
-# CAAIS Client ID (provided by CAAIS during registration)
+# ── GitHub Packages authentication ────────────────────────────────────────────
+# Required for the full-backend Docker profile (builds the backend image locally)
+# Generate a token at https://github.com/settings/tokens with read:packages scope
+GITHUB_TOKEN=your-github-token-here
+GITHUB_ACTOR=your-github-username-here
+
+# ── Database (only needed when running backend outside Docker) ─────────────────
+POSTGRES_URL=jdbc:postgresql://localhost:5432/ismd_tool_db
+POSTGRES_USER=ismd_user
+POSTGRES_PASSWORD=ismd_password
+
+# ── Fuseki (only needed when running backend outside Docker) ───────────────────
+FUSEKI_URL=http://localhost:3030/ismd-tool-dataset
+
+# ── Keycloak ───────────────────────────────────────────────────────────────────
+KEYCLOAK_CLIENT_SECRET=secret123
+# KEYCLOAK_ISSUER_URI defaults to http://localhost:8080/realms/ismd if not set
+
+# ── CORS (only needed when running backend outside Docker) ─────────────────────
+CORS_ALLOWED_ORIGINS=http://localhost:3001
+
+# ── CAAIS Identity Provider (only needed with the caais Docker profile) ────────
 CAAIS_CLIENT_ID=your-client-id-here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,10 @@ services:
       POSTGRES_USER: ismd_user
       POSTGRES_PASSWORD: ismd_password
       FUSEKI_URL: http://fuseki:3030/ismd-tool-dataset
-      KEYCLOAK_ISSUER_URI: http://localhost:8080/realms/ismd
+      KEYCLOAK_ISSUER_URI: http://ismd-keycloak-dev:8080/realms/ismd
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://localhost:8080/realms/ismd
+      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://ismd-keycloak-dev:8080/realms/ismd/protocol/openid-connect/certs
+      KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_CLIENT_SECRET}
       CORS_ALLOWED_ORIGINS: http://localhost:3001
     extra_hosts:
       - "localhost:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,38 @@ services:
     networks:
       - ismd-network
 
+  backend:
+    build:
+      context: .
+      args:
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+        GITHUB_ACTOR: ${GITHUB_ACTOR}
+    container_name: ismd-tool-backend
+    profiles:
+      - full-backend
+    ports:
+      - "8081:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      POSTGRES_URL: jdbc:postgresql://ismd-postgres-dev:5432/ismd_tool_db
+      POSTGRES_USER: ismd_user
+      POSTGRES_PASSWORD: ismd_password
+      FUSEKI_URL: http://fuseki:3030/ismd-tool-dataset
+      KEYCLOAK_ISSUER_URI: http://localhost:8080/realms/ismd
+      CORS_ALLOWED_ORIGINS: http://localhost:3001
+    extra_hosts:
+      - "localhost:host-gateway"
+    networks:
+      - ismd-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      keycloak:
+        condition: service_started
+      fuseki:
+        condition: service_started
+    restart: unless-stopped
+
 volumes:
   postgres_data:
     driver: local

--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -1,0 +1,76 @@
+# Docker Instructions
+
+## Local Development Setup
+
+There are two ways to run the tool backend locally:
+
+### Option A: Native (backend developers)
+
+Run infra dependencies in Docker, Spring Boot directly on the host:
+
+```bash
+# Start Postgres, Fuseki, Keycloak
+docker-compose up -d
+
+# Run the backend
+./mvnw spring-boot:run
+```
+
+### Option B: Full backend in Docker (frontend developers)
+
+Run everything in Docker — no JDK required.
+
+#### Prerequisites
+
+1. **Copy and fill in `.env`:**
+   ```bash
+   cp .env.example .env
+   ```
+   Set `GITHUB_TOKEN` (GitHub PAT with `read:packages` scope — generate at https://github.com/settings/tokens) and `GITHUB_ACTOR` (your GitHub username).
+
+2. **First run builds the backend image from source** (~1-2 min).
+
+#### Start
+
+**Windows (PowerShell):**
+```powershell
+.\start-full-backend.ps1
+# Force rebuild after code changes:
+.\start-full-backend.ps1 --build
+```
+
+**Linux/macOS:**
+```bash
+chmod +x start-full-backend.sh
+./start-full-backend.sh
+# Force rebuild after code changes:
+./start-full-backend.sh --build
+```
+
+#### Check it's running
+
+```bash
+docker-compose --profile full-backend ps
+docker logs ismd-tool-backend -f
+```
+
+Look for `Started IsmdToolBackendApplication` in the logs.
+
+#### Connect the frontend
+
+In `tool-frontend/.env.local`:
+```
+BE_URL=http://localhost:8081/popisujeme
+```
+
+Then run the frontend:
+```bash
+cd ../tool-frontend
+npm run dev
+```
+
+#### Stop
+
+```bash
+docker-compose --profile full-backend down
+```

--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -26,7 +26,10 @@ Run everything in Docker — no JDK required.
    ```bash
    cp .env.example .env
    ```
-   Set `GITHUB_TOKEN` (GitHub PAT with `read:packages` scope — generate at https://github.com/settings/tokens) and `GITHUB_ACTOR` (your GitHub username).
+   Required values:
+   - `GITHUB_TOKEN` — GitHub PAT with `read:packages` scope (generate at https://github.com/settings/tokens)
+   - `GITHUB_ACTOR` — your GitHub username
+   - `KEYCLOAK_CLIENT_SECRET` — client secret from the local Keycloak admin UI (`http://localhost:8080`, realm `ismd`, client `ismd-backend`, Credentials tab)
 
 2. **First run builds the backend image from source** (~1-2 min).
 
@@ -60,8 +63,9 @@ Look for `Started IsmdToolBackendApplication` in the logs.
 
 In `tool-frontend/.env.local`:
 ```
-BE_URL=http://localhost:8081/popisujeme
+BE_URL=http://127.0.0.1:8081/popisujeme
 ```
+Use `127.0.0.1` rather than `localhost` — Node.js resolves `localhost` to `::1` (IPv6) on newer versions, which will fail if the backend only listens on IPv4.
 
 Then run the frontend:
 ```bash

--- a/start-full-backend.ps1
+++ b/start-full-backend.ps1
@@ -1,0 +1,8 @@
+# Loads .env and starts the full-backend profile (includes Spring Boot backend)
+Get-Content .env | ForEach-Object {
+    if ($_ -match '^\s*([^#][^=]+)=(.*)$') {
+        [System.Environment]::SetEnvironmentVariable($matches[1].Trim(), $matches[2].Trim())
+    }
+}
+
+docker-compose --profile full-backend up -d @args

--- a/start-full-backend.sh
+++ b/start-full-backend.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Loads .env and starts the full-backend profile (includes Spring Boot backend)
+set -a
+source .env
+set +a
+
+docker-compose --profile full-backend up -d "$@"


### PR DESCRIPTION
  ## Summary

  - Adds `full-backend` docker-compose profile to run the Spring Boot backend in Docker,
  so frontend devs can work without a local JDK
  - Documents setup in `docker-instructions.md` with PowerShell and bash scripts
  - Fixes three issues that prevented the containerised backend from connecting to
  Keycloak at startup:
    - `KEYCLOAK_CLIENT_SECRET` was not forwarded to the container environment
    - OIDC discovery at startup failed because `localhost` does not resolve to the Docker
  host on Windows; fixed by using the internal Docker network hostname
  (`ismd-keycloak-dev`) for `KEYCLOAK_ISSUER_URI`
    - JWT `iss` claim validation would fail with the internal hostname (tokens carry
  `http://localhost:8080/realms/ismd`); fixed by overriding the resource server JWT
  properties separately so iss validation and JWK key fetching use the correct hostnames
  independently