### PR TITLE
Feat/issue 102 lucene

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,16 +87,14 @@ services:
     restart: unless-stopped
 
   fuseki:
-    image: secoresearch/fuseki:latest
-    user: "0:0"
+    build:
+      context: ./docker/fuseki
     ports:
       - "3030:3030"
     volumes:
-      - ./data/tdb2:/opt/fuseki/databases/tdb2/ismd-tool-dataset
-      - ./data/lucene:/opt/fuseki/databases/lucene/ismd-tool-dataset
-      - ./fuseki-config.ttl:/fuseki-base/configuration/assembler.ttl
-    environment:
-      - ADMIN_PASSWORD=admin123
+      - fuseki_tdb2:/opt/fuseki/run/databases/tdb2/ismd-tool-dataset
+      - fuseki_lucene:/opt/fuseki/run/databases/lucene/ismd-tool-dataset
+      - ./fuseki-config.ttl:/opt/fuseki/config/assembler.ttl
     networks:
       - ismd-network
 
@@ -140,7 +138,9 @@ volumes:
     driver: local
   postgres_keycloak_data:
     driver: local
-  fuseki_data:
+  fuseki_tdb2:
+    driver: local
+  fuseki_lucene:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     volumes:
       - fuseki_tdb2:/opt/fuseki/run/databases/tdb2/ismd-tool-dataset
       - fuseki_lucene:/opt/fuseki/run/databases/lucene/ismd-tool-dataset
-      - ./fuseki-config.ttl:/opt/fuseki/config/assembler.ttl
+      - ./fuseki-config.ttl:/opt/fuseki/run/configuration/ismd-tool-dataset.ttl
     networks:
       - ismd-network
 

--- a/docker/fuseki/Dockerfile
+++ b/docker/fuseki/Dockerfile
@@ -1,0 +1,36 @@
+FROM eclipse-temurin:21-jre-alpine
+
+ARG JENA_VERSION=5.3.0
+ARG FUSEKI_HOME=/opt/fuseki
+ARG JENA_HOME=/opt/jena
+
+# Download official Fuseki distribution (includes jena-text + Lucene JARs)
+RUN apk add --no-cache curl bash && \
+    curl -fsSL "https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${JENA_VERSION}.tar.gz" \
+        | tar xz -C /opt && mv /opt/apache-jena-fuseki-${JENA_VERSION} ${FUSEKI_HOME} && \
+    curl -fsSL "https://archive.apache.org/dist/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz" \
+        | tar xz -C /opt && mv /opt/apache-jena-${JENA_VERSION} ${JENA_HOME}
+
+# Create run directory structure
+RUN mkdir -p ${FUSEKI_HOME}/run/databases/tdb2/ismd-tool-dataset \
+             ${FUSEKI_HOME}/run/databases/lucene/ismd-tool-dataset
+
+# Create non-root user
+RUN addgroup -S fuseki && adduser -S fuseki -G fuseki && \
+    chown -R fuseki:fuseki ${FUSEKI_HOME}/run
+
+ENV FUSEKI_HOME=${FUSEKI_HOME}
+ENV JENA_HOME=${JENA_HOME}
+
+EXPOSE 3030
+
+USER fuseki
+WORKDIR ${FUSEKI_HOME}
+
+# Use FusekiMainCmd (lightweight Fuseki) via java -cp, not the fuseki-server script.
+# The shell script launches the full webapp server (FusekiCmd) which auto-discovers
+# configs from run/configuration/ causing double-loading conflicts with --conf.
+# FusekiMainCmd loads config exactly once via --conf.
+ENTRYPOINT ["java", "-cp", "/opt/fuseki/fuseki-server.jar", \
+            "org.apache.jena.fuseki.main.cmds.FusekiMainCmd"]
+CMD ["--conf", "/opt/fuseki/config/assembler.ttl"]

--- a/docker/fuseki/Dockerfile
+++ b/docker/fuseki/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre-alpine
 
-ARG JENA_VERSION=5.3.0
+ARG JENA_VERSION=5.4.0
 ARG FUSEKI_HOME=/opt/fuseki
 ARG JENA_HOME=/opt/jena
 
@@ -13,7 +13,8 @@ RUN apk add --no-cache curl bash && \
 
 # Create run directory structure
 RUN mkdir -p ${FUSEKI_HOME}/run/databases/tdb2/ismd-tool-dataset \
-             ${FUSEKI_HOME}/run/databases/lucene/ismd-tool-dataset
+             ${FUSEKI_HOME}/run/databases/lucene/ismd-tool-dataset \
+             ${FUSEKI_HOME}/run/configuration
 
 # Create non-root user
 RUN addgroup -S fuseki && adduser -S fuseki -G fuseki && \
@@ -27,10 +28,9 @@ EXPOSE 3030
 USER fuseki
 WORKDIR ${FUSEKI_HOME}
 
-# Use FusekiMainCmd (lightweight Fuseki) via java -cp, not the fuseki-server script.
-# The shell script launches the full webapp server (FusekiCmd) which auto-discovers
-# configs from run/configuration/ causing double-loading conflicts with --conf.
-# FusekiMainCmd loads config exactly once via --conf.
-ENTRYPOINT ["java", "-cp", "/opt/fuseki/fuseki-server.jar", \
-            "org.apache.jena.fuseki.main.cmds.FusekiMainCmd"]
-CMD ["--conf", "/opt/fuseki/config/assembler.ttl"]
+# Use the fuseki-server shell script which auto-discovers config from
+# run/configuration/. Do NOT pass --conf — it causes double-loading
+# (--conf + auto-discovery both open the Lucene index, the second
+# fails with LockObtainFailedException that silently breaks text search).
+ENTRYPOINT ["/opt/fuseki/fuseki-server"]
+CMD []

--- a/fuseki-config.ttl
+++ b/fuseki-config.ttl
@@ -4,8 +4,17 @@
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix tdb2:    <http://jena.apache.org/2016/tdb#> .
 @prefix text:    <http://jena.apache.org/text#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 @prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+
+## ---------------------------------------------------------------
+## Explicit text module loading
+## ---------------------------------------------------------------
+
+[] ja:loadClass "org.apache.jena.query.text.TextQuery" .
+text:TextDataset  rdfs:subClassOf ja:RDFDataset .
+text:TextIndexLucene rdfs:subClassOf text:TextIndex .
 
 ## ---------------------------------------------------------------
 ## Fuseki Service
@@ -32,14 +41,14 @@
 ## ---------------------------------------------------------------
 
 :tdb_dataset rdf:type tdb2:DatasetTDB2 ;
-    tdb2:location "/opt/fuseki/databases/tdb2/ismd-tool-dataset" .
+    tdb2:location "/opt/fuseki/run/databases/tdb2/ismd-tool-dataset" .
 
 ## ---------------------------------------------------------------
 ## Lucene Text Index
 ## ---------------------------------------------------------------
 
 <#indexLucene> a text:TextIndexLucene ;
-    text:directory   <file:/opt/fuseki/databases/lucene/ismd-tool-dataset> ;
+    text:directory   <file:/opt/fuseki/run/databases/lucene/ismd-tool-dataset> ;
     text:entityMap   <#entMap> ;
     text:storeValues true ;
     text:analyzer    <#asciiFoldingAnalyzer> .

--- a/fuseki-config.ttl
+++ b/fuseki-config.ttl
@@ -17,16 +17,20 @@ text:TextDataset  rdfs:subClassOf ja:RDFDataset .
 text:TextIndexLucene rdfs:subClassOf text:TextIndex .
 
 ## ---------------------------------------------------------------
-## Fuseki Service
+## Fuseki Server + Service (modern endpoint syntax)
 ## ---------------------------------------------------------------
 
+[] rdf:type fuseki:Server ;
+   fuseki:services ( :ismd-service ) .
+
 :ismd-service rdf:type fuseki:Service ;
-    fuseki:name              "ismd-tool-dataset" ;
-    fuseki:serviceQuery      "sparql", "query" ;
-    fuseki:serviceUpdate     "update" ;
-    fuseki:serviceUpload     "upload" ;
-    fuseki:serviceReadWriteGraphStore "data" ;
-    fuseki:dataset           :text_dataset .
+    fuseki:name "ismd-tool-dataset" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "sparql" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; fuseki:name "update" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:upload ; fuseki:name "upload" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; fuseki:name "data" ] ;
+    fuseki:dataset :text_dataset .
 
 ## ---------------------------------------------------------------
 ## Text Dataset: wraps TDB2 dataset with a Lucene text index

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <java.version>17</java.version>
         <ismd-validator-common.version>1.0.12</ismd-validator-common.version>
-        <jena.version>5.3.0</jena.version>
+        <jena.version>5.4.0</jena.version>
         <jacoco.version>0.8.13</jacoco.version>
         <jacoco.line.minimum>0.55</jacoco.line.minimum>
         <jacoco.branch.minimum>0.45</jacoco.branch.minimum>

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/SearchResultDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/SearchResultDto.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.controller.dto;
 
 import com.dia.ismdtoolbackend.enums.ConceptType;
+import com.dia.ismdtoolbackend.enums.MatchedBy;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.enums.SearchType;
 import lombok.AllArgsConstructor;
@@ -25,4 +26,5 @@ public class SearchResultDto {
     private ConceptType conceptType;
     private String ontologyIri;
     private Boolean isPublished;
+    private MatchedBy matchedBy;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/enums/MatchedBy.java
+++ b/src/main/java/com/dia/ismdtoolbackend/enums/MatchedBy.java
@@ -1,0 +1,11 @@
+package com.dia.ismdtoolbackend.enums;
+
+/**
+ * Indicates which search backend matched a given result within the ISMD source.
+ * Useful for debugging and understanding search behavior.
+ */
+public enum MatchedBy {
+    PG,
+    SPARQL,
+    BOTH
+}

--- a/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
+++ b/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
@@ -49,6 +49,7 @@ public class JenaTDB2Repository {
     RDFConnection createConnection() {
         return RDFConnectionRemote.newBuilder()
                 .destination(fusekiEndpoint)
+                .queryEndpoint("sparql")
                 .gspEndpoint("data")
                 .updateEndpoint("update")
                 .httpClient(fusekiHttpClient)
@@ -516,10 +517,11 @@ public class JenaTDB2Repository {
      *
      * @param query             the search term
      * @param visibleGraphNames graphs the user has access to
+     * @param limit             maximum number of results to return
      * @return list of result maps with keys: conceptIri, graphName, prefLabel, prefLabelLang,
      *         altLabel, description, definition
      */
-    public List<Map<String, String>> searchByText(String query, List<String> visibleGraphNames) {
+    public List<Map<String, String>> searchByText(String query, List<String> visibleGraphNames, int limit) {
         if (visibleGraphNames == null || visibleGraphNames.isEmpty()) {
             return List.of();
         }
@@ -534,19 +536,21 @@ public class JenaTDB2Repository {
                 // Sanitize and build Lucene query term with wildcard for prefix matching
                 String sanitizedQuery = sanitizeLuceneQuery(query);
 
+                // text:query inside GRAPH — requires Jena 5.4+ where the property
+                // function is correctly wired through the TextDataset assembler.
                 String sparql = "PREFIX text: <http://jena.apache.org/text#> " +
                         "PREFIX skos: <http://www.w3.org/2004/02/skos/core#> " +
                         "PREFIX dcterms: <http://purl.org/dc/terms/> " +
                         "SELECT ?concept ?g ?prefLabel ?prefLabelLang ?altLabel ?description ?definition WHERE { " +
                         "  VALUES ?g { " + valuesClause + "} " +
                         "  GRAPH ?g { " +
-                        "    ?concept text:query ('" + sanitizedQuery + "*') . " +
+                        "    ?concept text:query (skos:prefLabel skos:altLabel dcterms:description skos:definition '" + sanitizedQuery + "*') . " +
                         "    OPTIONAL { ?concept skos:prefLabel ?prefLabel . BIND(LANG(?prefLabel) AS ?prefLabelLang) } " +
                         "    OPTIONAL { ?concept skos:altLabel ?altLabel } " +
                         "    OPTIONAL { ?concept dcterms:description ?description } " +
                         "    OPTIONAL { ?concept skos:definition ?definition } " +
                         "  } " +
-                        "}";
+                        "} LIMIT " + limit;
 
                 log.debug("Fuseki text search SPARQL: {}", sparql);
 

--- a/src/main/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProvider.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProvider.java
@@ -10,17 +10,18 @@ import com.dia.ismdtoolbackend.enums.SearchType;
 import com.dia.ismdtoolbackend.repository.ConceptMetadataRepository;
 import com.dia.ismdtoolbackend.repository.JenaTDB2Repository;
 import com.dia.ismdtoolbackend.repository.OntologyMetadataRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.rdf.model.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class IsmdSearchProvider implements SearchProvider {
 
     private static final String SKOS_PREF_LABEL = "http://www.w3.org/2004/02/skos/core#prefLabel";
@@ -31,6 +32,17 @@ public class IsmdSearchProvider implements SearchProvider {
     private final OntologyMetadataRepository ontologyMetadataRepository;
     private final ConceptMetadataRepository conceptMetadataRepository;
     private final JenaTDB2Repository jenaTDB2Repository;
+    private final long fusekiTimeoutMs;
+
+    public IsmdSearchProvider(OntologyMetadataRepository ontologyMetadataRepository,
+                              ConceptMetadataRepository conceptMetadataRepository,
+                              JenaTDB2Repository jenaTDB2Repository,
+                              @Value("${search.fuseki-timeout-ms:10000}") long fusekiTimeoutMs) {
+        this.ontologyMetadataRepository = ontologyMetadataRepository;
+        this.conceptMetadataRepository = conceptMetadataRepository;
+        this.jenaTDB2Repository = jenaTDB2Repository;
+        this.fusekiTimeoutMs = fusekiTimeoutMs;
+    }
 
     @Override
     public SearchProviderResult search(String query, SearchType type, int limit, int offset,
@@ -95,20 +107,60 @@ public class IsmdSearchProvider implements SearchProvider {
         boolean hasGraphFilter = ontologyIris != null && !ontologyIris.isEmpty();
         List<String> graphNames = hasGraphFilter ? ontologyIris : List.of();
 
-        // PG search only — Fuseki text search (text:query) is disabled until the
-        // Jena version is upgraded to fix the text property function registration.
-        // See docs/search-feature-plan.md for details.
-        fusekiDegraded.set(true);
+        // Get visible graph names for Fuseki search
+        List<String> visibleGraphNames = getVisibleGraphNames(userId);
 
-        List<ConceptMetadataEntity> entities = conceptMetadataRepository.searchByText(
-                query, userId, hasGraphFilter, graphNames);
-        List<SearchResultDto> mergedResults = new ArrayList<>(entities.stream()
-                .map(this::mapConceptEntity)
-                .toList());
-        log.debug("PG search returned {} results", mergedResults.size());
+        // Run PG and Fuseki text search in parallel
+        CompletableFuture<List<SearchResultDto>> pgFuture = CompletableFuture.supplyAsync(() -> {
+            List<ConceptMetadataEntity> entities = conceptMetadataRepository.searchByText(
+                    query, userId, hasGraphFilter, graphNames);
+            return entities.stream()
+                    .map(this::mapConceptEntity)
+                    .toList();
+        });
 
-        // Enrich results with labels from Fuseki (CONSTRUCT query, not text search — works fine)
-        if (!mergedResults.isEmpty()) {
+        CompletableFuture<List<SearchResultDto>> fusekiFuture = CompletableFuture.supplyAsync(() -> {
+            List<String> searchGraphs = hasGraphFilter
+                    ? ontologyIris.stream().filter(visibleGraphNames::contains).toList()
+                    : visibleGraphNames;
+            return searchFuseki(query, searchGraphs);
+        }).orTimeout(fusekiTimeoutMs, TimeUnit.MILLISECONDS);
+
+        List<SearchResultDto> pgResults = pgFuture.join();
+        log.debug("PG search returned {} results", pgResults.size());
+
+        List<SearchResultDto> fusekiResults;
+        try {
+            fusekiResults = fusekiFuture.join();
+            log.debug("Fuseki search returned {} results", fusekiResults.size());
+        } catch (Exception e) {
+            log.warn("Fuseki text search failed, degrading to PG-only results: {}", e.getMessage());
+            fusekiResults = List.of();
+            fusekiDegraded.set(true);
+        }
+
+        // Merge PG + Fuseki results: PG first, Fuseki enriches with non-null fields
+        LinkedHashMap<String, SearchResultDto> merged = new LinkedHashMap<>();
+        for (SearchResultDto dto : pgResults) {
+            if (dto.getIri() != null) {
+                merged.put(dto.getIri(), dto);
+            }
+        }
+        for (SearchResultDto dto : fusekiResults) {
+            if (dto.getIri() != null) {
+                merged.merge(dto.getIri(), dto, (existing, incoming) -> {
+                    mergeNonNullFields(existing, incoming);
+                    return existing;
+                });
+            }
+        }
+
+        List<SearchResultDto> mergedResults = new ArrayList<>(merged.values());
+        log.debug("After merge+dedup: {} results (PG={}, Fuseki={}, unique={})",
+                mergedResults.size(), pgResults.size(), fusekiResults.size(), merged.size());
+
+        // Enrich all results with labels from Fuseki
+        if (!fusekiDegraded.get() && !mergedResults.isEmpty()) {
             try {
                 log.debug("Enriching {} results with Fuseki labels (lang={})", mergedResults.size(), lang);
                 enrichWithLabels(mergedResults, lang);
@@ -136,6 +188,36 @@ public class IsmdSearchProvider implements SearchProvider {
         }
 
         return mergedResults;
+    }
+
+    private List<SearchResultDto> searchFuseki(String query, List<String> visibleGraphNames) {
+        if (visibleGraphNames.isEmpty()) {
+            log.debug("Fuseki search skipped: no visible graph names for user");
+            return List.of();
+        }
+
+        log.debug("Fuseki text search: query='{}', searching {} graphs",
+                query, visibleGraphNames.size());
+
+        List<Map<String, String>> rows = jenaTDB2Repository.searchByText(query, visibleGraphNames);
+
+        log.debug("Fuseki text search returned {} raw rows", rows.size());
+
+        List<SearchResultDto> results = new ArrayList<>();
+        for (Map<String, String> row : rows) {
+            results.add(SearchResultDto.builder()
+                    .iri(row.get("conceptIri"))
+                    .label(row.get("prefLabel"))
+                    .labelLang(row.get("prefLabelLang"))
+                    .altName(row.get("altLabel"))
+                    .description(row.get("description"))
+                    .definition(row.get("definition"))
+                    .ontologyIri(row.get("graphName"))
+                    .type(SearchType.CONCEPT)
+                    .source(SearchSource.ISMD)
+                    .build());
+        }
+        return results;
     }
 
     private void enrichWithLabels(List<SearchResultDto> results, String lang) {
@@ -205,6 +287,20 @@ public class IsmdSearchProvider implements SearchProvider {
             return stmt.getLiteral().getString();
         }
         return null;
+    }
+
+    private List<String> getVisibleGraphNames(String userId) {
+        List<OntologyMetadataEntity> ontologies = new ArrayList<>();
+        ontologies.addAll(ontologyMetadataRepository.findAllByIsPublished(true));
+        if (userId != null) {
+            List<OntologyMetadataEntity> userOntologies = ontologyMetadataRepository.findAllByUserIdAndIsPublished(userId, false);
+            ontologies.addAll(userOntologies);
+        }
+        return ontologies.stream()
+                .map(OntologyMetadataEntity::getGraphName)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     private SearchResultDto mapConceptEntity(ConceptMetadataEntity e) {

--- a/src/main/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProvider.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProvider.java
@@ -3,6 +3,7 @@ package com.dia.ismdtoolbackend.service.search;
 import com.dia.ismdtoolbackend.controller.dto.SearchResultDto;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
+import com.dia.ismdtoolbackend.enums.MatchedBy;
 import com.dia.ismdtoolbackend.enums.RelationType;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.enums.SearchSourceStatus;
@@ -56,7 +57,7 @@ public class IsmdSearchProvider implements SearchProvider {
         }
 
         if (type == null || type == SearchType.CONCEPT) {
-            allResults.addAll(searchConcepts(query, userId, lang, ontologyIris, relationTypes, fusekiDegraded));
+            allResults.addAll(searchConcepts(query, userId, lang, ontologyIris, relationTypes, fusekiDegraded, limit));
         }
 
         // Dedup by IRI
@@ -103,7 +104,7 @@ public class IsmdSearchProvider implements SearchProvider {
     private List<SearchResultDto> searchConcepts(String query, String userId, String lang,
                                                   List<String> ontologyIris,
                                                   List<RelationType> relationTypes,
-                                                  AtomicBoolean fusekiDegraded) {
+                                                  AtomicBoolean fusekiDegraded, int limit) {
         boolean hasGraphFilter = ontologyIris != null && !ontologyIris.isEmpty();
         List<String> graphNames = hasGraphFilter ? ontologyIris : List.of();
 
@@ -123,7 +124,7 @@ public class IsmdSearchProvider implements SearchProvider {
             List<String> searchGraphs = hasGraphFilter
                     ? ontologyIris.stream().filter(visibleGraphNames::contains).toList()
                     : visibleGraphNames;
-            return searchFuseki(query, searchGraphs);
+            return searchFuseki(query, searchGraphs, limit);
         }).orTimeout(fusekiTimeoutMs, TimeUnit.MILLISECONDS);
 
         List<SearchResultDto> pgResults = pgFuture.join();
@@ -139,10 +140,17 @@ public class IsmdSearchProvider implements SearchProvider {
             fusekiDegraded.set(true);
         }
 
+        // Track which IRIs were found by Fuseki (for matchedBy and enrichment skip)
+        Set<String> fusekiIris = new HashSet<>();
+        for (SearchResultDto dto : fusekiResults) {
+            if (dto.getIri() != null) fusekiIris.add(dto.getIri());
+        }
+
         // Merge PG + Fuseki results: PG first, Fuseki enriches with non-null fields
         LinkedHashMap<String, SearchResultDto> merged = new LinkedHashMap<>();
         for (SearchResultDto dto : pgResults) {
             if (dto.getIri() != null) {
+                dto.setMatchedBy(MatchedBy.PG);
                 merged.put(dto.getIri(), dto);
             }
         }
@@ -150,6 +158,7 @@ public class IsmdSearchProvider implements SearchProvider {
             if (dto.getIri() != null) {
                 merged.merge(dto.getIri(), dto, (existing, incoming) -> {
                     mergeNonNullFields(existing, incoming);
+                    existing.setMatchedBy(MatchedBy.BOTH);
                     return existing;
                 });
             }
@@ -159,13 +168,19 @@ public class IsmdSearchProvider implements SearchProvider {
         log.debug("After merge+dedup: {} results (PG={}, Fuseki={}, unique={})",
                 mergedResults.size(), pgResults.size(), fusekiResults.size(), merged.size());
 
-        // Enrich all results with labels from Fuseki
+        // Enrich PG-only results with labels from Fuseki (skip those already enriched by text search)
         if (!fusekiDegraded.get() && !mergedResults.isEmpty()) {
-            try {
-                log.debug("Enriching {} results with Fuseki labels (lang={})", mergedResults.size(), lang);
-                enrichWithLabels(mergedResults, lang);
-            } catch (Exception e) {
-                log.warn("Fuseki label enrichment failed, using existing labels: {}", e.getMessage());
+            List<SearchResultDto> needsEnrichment = mergedResults.stream()
+                    .filter(dto -> !fusekiIris.contains(dto.getIri()))
+                    .toList();
+            if (!needsEnrichment.isEmpty()) {
+                try {
+                    log.debug("Enriching {} PG-only results with Fuseki labels (lang={})",
+                            needsEnrichment.size(), lang);
+                    enrichWithLabels(needsEnrichment, lang);
+                } catch (Exception e) {
+                    log.warn("Fuseki label enrichment failed, using existing labels: {}", e.getMessage());
+                }
             }
         }
 
@@ -190,7 +205,7 @@ public class IsmdSearchProvider implements SearchProvider {
         return mergedResults;
     }
 
-    private List<SearchResultDto> searchFuseki(String query, List<String> visibleGraphNames) {
+    private List<SearchResultDto> searchFuseki(String query, List<String> visibleGraphNames, int limit) {
         if (visibleGraphNames.isEmpty()) {
             log.debug("Fuseki search skipped: no visible graph names for user");
             return List.of();
@@ -199,7 +214,7 @@ public class IsmdSearchProvider implements SearchProvider {
         log.debug("Fuseki text search: query='{}', searching {} graphs",
                 query, visibleGraphNames.size());
 
-        List<Map<String, String>> rows = jenaTDB2Repository.searchByText(query, visibleGraphNames);
+        List<Map<String, String>> rows = jenaTDB2Repository.searchByText(query, visibleGraphNames, limit);
 
         log.debug("Fuseki text search returned {} raw rows", rows.size());
 
@@ -215,6 +230,7 @@ public class IsmdSearchProvider implements SearchProvider {
                     .ontologyIri(row.get("graphName"))
                     .type(SearchType.CONCEPT)
                     .source(SearchSource.ISMD)
+                    .matchedBy(MatchedBy.SPARQL)
                     .build());
         }
         return results;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,7 @@ nkd.sparql.timeout=10000
 
 # Search configuration
 search.source-timeout-ms=${SEARCH_SOURCE_TIMEOUT_MS:10000}
+search.fuseki-timeout-ms=${SEARCH_FUSEKI_TIMEOUT_MS:10000}
 search.min-query-length=${SEARCH_MIN_QUERY_LENGTH:2}
 search.max-limit=${SEARCH_MAX_LIMIT:100}
 

--- a/src/test/java/com/dia/ismdtoolbackend/repository/JenaTDB2RepositorySearchTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/repository/JenaTDB2RepositorySearchTest.java
@@ -54,13 +54,13 @@ class JenaTDB2RepositorySearchTest {
 
     @Test
     void searchByText_emptyGraphNames_returnsEmptyList() {
-        List<Map<String, String>> results = repository.searchByText("test", List.of());
+        List<Map<String, String>> results = repository.searchByText("test", List.of(), 100);
         assertTrue(results.isEmpty());
     }
 
     @Test
     void searchByText_nullGraphNames_returnsEmptyList() {
-        List<Map<String, String>> results = repository.searchByText("test", null);
+        List<Map<String, String>> results = repository.searchByText("test", null, 100);
         assertTrue(results.isEmpty());
     }
 
@@ -96,7 +96,7 @@ class JenaTDB2RepositorySearchTest {
         when(mockQueryExecution.execSelect()).thenReturn(mockResultSet);
 
         List<Map<String, String>> results = repository.searchByText("osoba",
-                List.of("https://example.org/ontology/1"));
+                List.of("https://example.org/ontology/1"), 100);
 
         assertEquals(1, results.size());
         assertEquals("https://example.org/concept/osoba", results.get(0).get("conceptIri"));
@@ -114,7 +114,7 @@ class JenaTDB2RepositorySearchTest {
         when(mockConnection.query(sparqlCaptor.capture())).thenReturn(mockQueryExecution);
         when(mockQueryExecution.execSelect()).thenReturn(mockResultSet);
 
-        repository.searchByText("test'injection", List.of("https://example.org/ontology/1"));
+        repository.searchByText("test'injection", List.of("https://example.org/ontology/1"), 100);
 
         String executedSparql = sparqlCaptor.getValue();
         assertTrue(executedSparql.contains("test\\'injection"),

--- a/src/test/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProviderTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProviderTest.java
@@ -11,7 +11,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -33,10 +32,13 @@ class IsmdSearchProviderTest {
     @Mock
     private JenaTDB2Repository jenaTDB2Repository;
 
-    @InjectMocks
-    private IsmdSearchProvider ismdSearchProvider;
+    private IsmdSearchProvider createProvider() {
+        return new IsmdSearchProvider(
+                ontologyMetadataRepository, conceptMetadataRepository,
+                jenaTDB2Repository, 10_000L);
+    }
 
-    // --- Phase 3 tests (preserved) ---
+    // --- Phase 3 tests ---
 
     @Test
     void search_conceptType_returnsMappedResults() {
@@ -46,9 +48,11 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "osoba", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
@@ -71,7 +75,7 @@ class IsmdSearchProviderTest {
         when(ontologyMetadataRepository.searchByText("test", "user1"))
                 .thenReturn(List.of(ontology));
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "test", SearchType.ONTOLOGY, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
@@ -95,9 +99,11 @@ class IsmdSearchProviderTest {
                 .thenReturn(List.of(ontology));
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "osoba", null, 20, 0, "cs", null, null, "user1");
 
         assertEquals(2, result.results().size());
@@ -110,9 +116,11 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(true), eq(ontologyIris)))
                 .thenReturn(List.of());
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        ismdSearchProvider.search("osoba", SearchType.CONCEPT, 20, 0, "cs", ontologyIris, null, "user1");
+        createProvider().search("osoba", SearchType.CONCEPT, 20, 0, "cs", ontologyIris, null, "user1");
 
         verify(conceptMetadataRepository).searchByText("osoba", "user1", true, ontologyIris);
     }
@@ -129,9 +137,11 @@ class IsmdSearchProviderTest {
                 .thenReturn(List.of(ontology));
         when(conceptMetadataRepository.searchByText(eq("shared"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "shared", null, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
@@ -143,9 +153,11 @@ class IsmdSearchProviderTest {
                 .thenReturn(List.of());
         when(conceptMetadataRepository.searchByText(eq("xyz"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of());
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "xyz", null, 20, 0, "cs", null, null, "user1");
 
         assertEquals(0, result.results().size());
@@ -160,9 +172,11 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("concept"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept1, concept2, concept3));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "concept", SearchType.CONCEPT, 2, 1, "cs", null, null, "user1");
 
         assertEquals(2, result.results().size());
@@ -171,25 +185,124 @@ class IsmdSearchProviderTest {
         assertEquals(3, result.totalCount());
     }
 
-    // --- Phase 4 tests: Fuseki enrichment (text search disabled until Jena upgrade) ---
+    // --- Phase 4 tests: Fuseki text search + merge ---
 
     @Test
-    void search_conceptSearch_alwaysReportsDegraded() {
+    void search_mergesPgAndFusekiResults() {
+        // PG returns concept with slug but no description
         ConceptMetadataEntity pgConcept = createConcept(
                 "https://example.org/concept/osoba", "osoba", "Osoba",
                 ConceptType.TRIDA, "https://example.org/ontology/1", true);
 
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(pgConcept));
+
+        // Fuseki returns same concept with description
+        Map<String, String> fusekiRow = new HashMap<>();
+        fusekiRow.put("conceptIri", "https://example.org/concept/osoba");
+        fusekiRow.put("prefLabel", "Osoba");
+        fusekiRow.put("prefLabelLang", "cs");
+        fusekiRow.put("description", "Fyzická osoba");
+        fusekiRow.put("graphName", "https://example.org/ontology/1");
+
+        OntologyMetadataEntity published = createOntology("https://example.org/ontology/1", "ont1", true);
+        when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
+        when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
+
+        when(jenaTDB2Repository.searchByText(eq("osoba"), anyList()))
+                .thenReturn(List.of(fusekiRow));
         stubEmptyFetchConceptLabels();
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
+                "osoba", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
+
+        assertEquals(1, result.results().size());
+        SearchResultDto dto = result.results().get(0);
+        assertEquals("https://example.org/concept/osoba", dto.getIri());
+        assertEquals("osoba", dto.getSlug()); // from PG
+        assertEquals("Fyzická osoba", dto.getDescription()); // merged from Fuseki
+        assertEquals(ConceptType.TRIDA, dto.getConceptType()); // from PG
+        assertEquals(SearchSourceStatus.OK, result.status());
+    }
+
+    @Test
+    void search_fusekiAddsNewConceptsNotInPg() {
+        when(conceptMetadataRepository.searchByText(eq("test"), eq("user1"), eq(false), anyList()))
+                .thenReturn(List.of());
+
+        // Fuseki finds a concept that PG missed
+        Map<String, String> fusekiRow = new HashMap<>();
+        fusekiRow.put("conceptIri", "https://example.org/concept/fuseki-only");
+        fusekiRow.put("prefLabel", "Fuseki Only Concept");
+        fusekiRow.put("prefLabelLang", "en");
+        fusekiRow.put("graphName", "https://example.org/ontology/1");
+
+        OntologyMetadataEntity published = createOntology("https://example.org/ontology/1", "ont1", true);
+        when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
+        when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
+
+        when(jenaTDB2Repository.searchByText(eq("test"), anyList()))
+                .thenReturn(List.of(fusekiRow));
+        stubEmptyFetchConceptLabels();
+
+        SearchProvider.SearchProviderResult result = createProvider().search(
+                "test", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
+
+        assertEquals(1, result.results().size());
+        assertEquals("https://example.org/concept/fuseki-only", result.results().get(0).getIri());
+        assertEquals("Fuseki Only Concept", result.results().get(0).getLabel());
+    }
+
+    @Test
+    void search_fusekiDown_degradesToPgOnly() {
+        ConceptMetadataEntity pgConcept = createConcept(
+                "https://example.org/concept/osoba", "osoba", "Osoba",
+                ConceptType.TRIDA, "https://example.org/ontology/1", true);
+
+        when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
+                .thenReturn(List.of(pgConcept));
+
+        OntologyMetadataEntity published = createOntology("https://example.org/ontology/1", "ont1", true);
+        when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
+        when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
+
+        // Fuseki throws exception
+        when(jenaTDB2Repository.searchByText(anyString(), anyList()))
+                .thenThrow(new RuntimeException("Connection refused"));
+
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "osoba", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
         assertEquals("https://example.org/concept/osoba", result.results().get(0).getIri());
         assertEquals(SearchSourceStatus.DEGRADED, result.status());
+        assertNotNull(result.statusMessage());
     }
+
+    @Test
+    void search_visibleGraphsIncludeUserAndPublished() {
+        OntologyMetadataEntity published = createOntology("https://example.org/ontology/public", "public", true);
+        OntologyMetadataEntity userOwned = createOntology("https://example.org/ontology/private", "private", false);
+
+        when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
+        when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of(userOwned));
+
+        when(conceptMetadataRepository.searchByText(eq("test"), eq("user1"), eq(false), anyList()))
+                .thenReturn(List.of());
+        when(jenaTDB2Repository.searchByText(eq("test"), anyList()))
+                .thenReturn(List.of());
+        stubEmptyFetchConceptLabels();
+
+        createProvider().search("test", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
+
+        // Fuseki should be called with both published and user-owned graphs
+        verify(jenaTDB2Repository).searchByText(eq("test"), argThat(graphs ->
+                graphs.contains("https://example.org/ontology/public") &&
+                graphs.contains("https://example.org/ontology/private") &&
+                graphs.size() == 2));
+    }
+
+    // --- Phase 4 tests: Fuseki enrichment ---
 
     @Test
     void search_withRelationTypeFilter_filtersResults() {
@@ -202,13 +315,15 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("concept"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept1, concept2));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
         // Only concept/1 has SUBCLASS relation
         when(jenaTDB2Repository.filterByRelationTypes(anyList(), eq(List.of(RelationType.SUBCLASS))))
                 .thenReturn(Set.of("https://example.org/concept/1"));
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "concept", SearchType.CONCEPT, 20, 0, "cs", null,
                 List.of(RelationType.SUBCLASS), "user1");
 
@@ -224,12 +339,14 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("concept"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(concept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
         stubEmptyFetchConceptLabels();
 
         when(jenaTDB2Repository.filterByRelationTypes(anyList(), anyList()))
                 .thenThrow(new RuntimeException("Fuseki down"));
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "concept", SearchType.CONCEPT, 20, 0, "cs", null,
                 List.of(RelationType.SUBCLASS), "user1");
 
@@ -244,6 +361,8 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(pgConcept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
 
         Model labelsModel = ModelFactory.createDefaultModel();
         org.apache.jena.rdf.model.Resource concept = labelsModel.createResource("https://example.org/concept/osoba");
@@ -256,7 +375,7 @@ class IsmdSearchProviderTest {
 
         when(jenaTDB2Repository.fetchConceptLabels(anyList())).thenReturn(labelsModel);
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "osoba", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
@@ -274,11 +393,13 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("osoba"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of(pgConcept));
+        stubVisibleGraphs("user1", List.of());
+        stubEmptyFusekiSearch();
 
         when(jenaTDB2Repository.fetchConceptLabels(anyList()))
                 .thenThrow(new RuntimeException("Fuseki down"));
 
-        SearchProvider.SearchProviderResult result = ismdSearchProvider.search(
+        SearchProvider.SearchProviderResult result = createProvider().search(
                 "osoba", SearchType.CONCEPT, 20, 0, "cs", null, null, "user1");
 
         assertEquals(1, result.results().size());
@@ -305,6 +426,15 @@ class IsmdSearchProviderTest {
         entity.setSlug(slug);
         entity.setIsPublished(published);
         return entity;
+    }
+
+    private void stubVisibleGraphs(String userId, List<OntologyMetadataEntity> extra) {
+        lenient().when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of());
+        lenient().when(ontologyMetadataRepository.findAllByUserIdAndIsPublished(userId, false)).thenReturn(extra);
+    }
+
+    private void stubEmptyFusekiSearch() {
+        lenient().when(jenaTDB2Repository.searchByText(anyString(), anyList())).thenReturn(List.of());
     }
 
     private void stubEmptyFetchConceptLabels() {

--- a/src/test/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProviderTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/search/IsmdSearchProviderTest.java
@@ -209,7 +209,7 @@ class IsmdSearchProviderTest {
         when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
         when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
 
-        when(jenaTDB2Repository.searchByText(eq("osoba"), anyList()))
+        when(jenaTDB2Repository.searchByText(eq("osoba"), anyList(), anyInt()))
                 .thenReturn(List.of(fusekiRow));
         stubEmptyFetchConceptLabels();
 
@@ -222,6 +222,7 @@ class IsmdSearchProviderTest {
         assertEquals("osoba", dto.getSlug()); // from PG
         assertEquals("Fyzická osoba", dto.getDescription()); // merged from Fuseki
         assertEquals(ConceptType.TRIDA, dto.getConceptType()); // from PG
+        assertEquals(MatchedBy.BOTH, dto.getMatchedBy()); // found by both PG and Fuseki
         assertEquals(SearchSourceStatus.OK, result.status());
     }
 
@@ -241,7 +242,7 @@ class IsmdSearchProviderTest {
         when(ontologyMetadataRepository.findAllByIsPublished(true)).thenReturn(List.of(published));
         when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
 
-        when(jenaTDB2Repository.searchByText(eq("test"), anyList()))
+        when(jenaTDB2Repository.searchByText(eq("test"), anyList(), anyInt()))
                 .thenReturn(List.of(fusekiRow));
         stubEmptyFetchConceptLabels();
 
@@ -251,6 +252,7 @@ class IsmdSearchProviderTest {
         assertEquals(1, result.results().size());
         assertEquals("https://example.org/concept/fuseki-only", result.results().get(0).getIri());
         assertEquals("Fuseki Only Concept", result.results().get(0).getLabel());
+        assertEquals(MatchedBy.SPARQL, result.results().get(0).getMatchedBy());
     }
 
     @Test
@@ -267,7 +269,7 @@ class IsmdSearchProviderTest {
         when(ontologyMetadataRepository.findAllByUserIdAndIsPublished("user1", false)).thenReturn(List.of());
 
         // Fuseki throws exception
-        when(jenaTDB2Repository.searchByText(anyString(), anyList()))
+        when(jenaTDB2Repository.searchByText(anyString(), anyList(), anyInt()))
                 .thenThrow(new RuntimeException("Connection refused"));
 
         SearchProvider.SearchProviderResult result = createProvider().search(
@@ -275,6 +277,7 @@ class IsmdSearchProviderTest {
 
         assertEquals(1, result.results().size());
         assertEquals("https://example.org/concept/osoba", result.results().get(0).getIri());
+        assertEquals(MatchedBy.PG, result.results().get(0).getMatchedBy()); // Fuseki failed, PG only
         assertEquals(SearchSourceStatus.DEGRADED, result.status());
         assertNotNull(result.statusMessage());
     }
@@ -289,7 +292,7 @@ class IsmdSearchProviderTest {
 
         when(conceptMetadataRepository.searchByText(eq("test"), eq("user1"), eq(false), anyList()))
                 .thenReturn(List.of());
-        when(jenaTDB2Repository.searchByText(eq("test"), anyList()))
+        when(jenaTDB2Repository.searchByText(eq("test"), anyList(), anyInt()))
                 .thenReturn(List.of());
         stubEmptyFetchConceptLabels();
 
@@ -299,7 +302,7 @@ class IsmdSearchProviderTest {
         verify(jenaTDB2Repository).searchByText(eq("test"), argThat(graphs ->
                 graphs.contains("https://example.org/ontology/public") &&
                 graphs.contains("https://example.org/ontology/private") &&
-                graphs.size() == 2));
+                graphs.size() == 2), anyInt());
     }
 
     // --- Phase 4 tests: Fuseki enrichment ---
@@ -434,7 +437,7 @@ class IsmdSearchProviderTest {
     }
 
     private void stubEmptyFusekiSearch() {
-        lenient().when(jenaTDB2Repository.searchByText(anyString(), anyList())).thenReturn(List.of());
+        lenient().when(jenaTDB2Repository.searchByText(anyString(), anyList(), anyInt())).thenReturn(List.of());
     }
 
     private void stubEmptyFetchConceptLabels() {


### PR DESCRIPTION
PR pro Lucene text search implementaci ke stávajícímu PR issue-102, které obsahuje řešení známé regrese Apache Jena verze 5.3

Description

  ## Summary

  - Upgrade Apache Jena from 5.3.0 to **5.4.0** to fix the text:query property function
    registration bug (jena-text assembler wiring was broken on 5.2–5.3)
  - Enable Fuseki Lucene fulltext search across **all four indexed fields**:
    skos:prefLabel, skos:altLabel, dcterms:description, skos:definition
  - Add `matchedBy` field (PG / SPARQL / BOTH) to search results so frontend/debugging
    can distinguish which backend matched each result
  - Add LIMIT to Fuseki text search SPARQL (was unbounded)
  - Skip redundant label enrichment for results already enriched by text search
  - Fuseki Dockerfile and config updated for 5.4.0 standard assembler with auto-discovery

  ## Infrastructure / DevOps changes

  ### Fuseki Docker image — rebuilt from scratch
  - **Base image**: `eclipse-temurin:21-jre-alpine` (unchanged)
  - **Jena version**: 5.3.0 → **5.4.0** (both Fuseki distribution and Jena CLI tools)
  - **Entrypoint**: `fuseki-server` shell script (auto-discovers config from `run/configuration/`)

  ### Docker volumes — unchanged
  Two named volumes, same paths as before:
  - `fuseki_tdb2` → `/opt/fuseki/run/databases/tdb2/ismd-tool-dataset`
  - `fuseki_lucene` → `/opt/fuseki/run/databases/lucene/ismd-tool-dataset`

  ### Config mount path changed
  Before

  ./fuseki-config.ttl:/opt/fuseki/config/assembler.ttl

  After

  ./fuseki-config.ttl:/opt/fuseki/run/configuration/ismd-tool-dataset.ttl
  Config is now mounted into `run/configuration/` for Fuseki auto-discovery.
  Do NOT pass `--conf` flag — it causes double-loading and silently breaks text search
  (LockObtainFailedException on the Lucene index).

  ### Fuseki config format updated
  Service definition uses modern `fuseki:endpoint` syntax (with `fuseki:operation`)
  instead of deprecated `fuseki:serviceQuery` style. Named endpoints: `sparql`, `query`,
  `update`, `data`.

  ### Deployment considerations
  1. **Fresh Lucene index on first deploy**: If deploying with existing TDB2 data but
     new/empty Lucene volumes, the text index will be empty. Either:
     - Re-upload ontologies (index builds automatically on write), or
     - Run textindexer: `docker exec fuseki java -cp /opt/fuseki/fuseki-server.jar
       jena.textindexer --desc=/opt/fuseki/run/configuration/ismd-tool-dataset.ttl`
     - Consider wiping existing tdb2/postgres ontology data and reupload on fresh instance
  2. **Backend RDFConnection**: Now explicitly uses `queryEndpoint("sparql")` — the
     new config doesn't expose an unnamed base endpoint for queries
  3. **No breaking API changes** — `matchedBy` is a new additive field in search responses
