### PR TITLE
Feat/issue 101

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
             <artifactId>json</artifactId>
             <version>20250517</version>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/dia/ismdtoolbackend/actuator/RppHealthIndicator.java
+++ b/src/main/java/com/dia/ismdtoolbackend/actuator/RppHealthIndicator.java
@@ -1,0 +1,39 @@
+package com.dia.ismdtoolbackend.actuator;
+
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+
+@Component("rpp")
+public class RppHealthIndicator implements HealthIndicator {
+
+    private final RppSnapshotHolder holder;
+    private final Clock clock;
+
+    public RppHealthIndicator(RppSnapshotHolder holder, Clock clock) {
+        this.holder = holder;
+        this.clock = clock;
+    }
+
+    @Override
+    public Health health() {
+        RppSnapshot snap = holder.peek();
+        if (snap.isEmpty()) {
+            return Health.unknown()
+                    .withDetail("reason", "not-yet-loaded")
+                    .build();
+        }
+        long ageSeconds = Duration.between(snap.getLoadedAt(), clock.instant()).toSeconds();
+        return Health.up()
+                .withDetail("loadedAt", snap.getLoadedAt().toString())
+                .withDetail("ageSeconds", ageSeconds)
+                .withDetail("agendaCount", snap.getAgendas().size())
+                .withDetail("isvsCount", snap.getIsvs().size())
+                .build();
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/client/RppSparqlClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/RppSparqlClient.java
@@ -1,0 +1,115 @@
+package com.dia.ismdtoolbackend.client;
+
+import com.dia.ismdtoolbackend.exception.RppUnavailableException;
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.query.RppSPARQLQuery;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+@Component
+@Slf4j
+public class RppSparqlClient {
+
+    @Value("${rpp.sparql.endpoint:}")
+    private String rppEndpoint;
+
+    @Value("${rpp.sparql.timeout:10000}")
+    private int rppSparqlTimeout;
+
+    public List<RppAgenda> fetchAllAgendas() {
+        return executeSelect("agenda", RppSPARQLQuery.buildAgendaListQuery(), this::mapAgendaRows);
+    }
+
+    public List<RppIsvs> fetchAllIsvs() {
+        return executeSelect("isvs", RppSPARQLQuery.buildIsvsListQuery(), this::mapIsvsRows);
+    }
+
+    private <T> List<T> executeSelect(String label, String query, Function<ResultSet, List<T>> mapper) {
+        requireEndpoint();
+        try (QueryExecution qe = QueryExecutionHTTPBuilder.service(rppEndpoint)
+                .query(query)
+                .timeout(rppSparqlTimeout, TimeUnit.MILLISECONDS)
+                .build()) {
+            return mapper.apply(qe.execSelect());
+        } catch (QueryExceptionHTTP | HttpException e) {
+            throw new RppUnavailableException("RPP " + label + " fetch failed: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new RppUnavailableException("RPP " + label + " mapping failed: " + e.getMessage(), e);
+        }
+    }
+
+    private List<RppAgenda> mapAgendaRows(ResultSet rs) {
+        List<RppAgenda> out = new ArrayList<>();
+        while (rs.hasNext()) {
+            QuerySolution sol = rs.next();
+            String iri = resourceUri(sol, "agenda");
+            String code = literalString(sol, "code");
+            String nazev = literalString(sol, "nazev");
+            if (code == null || nazev == null) {
+                log.warn("RPP agenda row missing code/nazev; iri={}", iri);
+                continue;
+            }
+            out.add(new RppAgenda(iri, code, nazev));
+        }
+        return out;
+    }
+
+    private List<RppIsvs> mapIsvsRows(ResultSet rs) {
+        LinkedHashMap<String, RppIsvs> byIri = new LinkedHashMap<>();
+        while (rs.hasNext()) {
+            QuerySolution sol = rs.next();
+            String iri = resourceUri(sol, "isvs");
+            String code = literalString(sol, "code");
+            String nazev = literalString(sol, "nazev");
+            String agendaIri = resourceUri(sol, "agenda");
+            if (iri == null || code == null || nazev == null) {
+                log.warn("RPP isvs row missing iri/code/nazev; iri={}", iri);
+                continue;
+            }
+            collapseIsvsRow(byIri, iri, code, nazev, agendaIri);
+        }
+        return new ArrayList<>(byIri.values());
+    }
+
+    private static void collapseIsvsRow(LinkedHashMap<String, RppIsvs> byIri,
+                                        String iri, String code, String nazev, String agendaIri) {
+        RppIsvs existing = byIri.get(iri);
+        if (existing == null) {
+            List<String> agendas = new ArrayList<>();
+            if (agendaIri != null) {
+                agendas.add(agendaIri);
+            }
+            byIri.put(iri, new RppIsvs(iri, code, nazev, agendas));
+        } else if (agendaIri != null && !existing.getAgendaIris().contains(agendaIri)) {
+            existing.getAgendaIris().add(agendaIri);
+        }
+    }
+
+    private void requireEndpoint() {
+        if (rppEndpoint == null || rppEndpoint.trim().isEmpty()) {
+            throw new RppUnavailableException("RPP endpoint not configured");
+        }
+    }
+
+    private static String resourceUri(QuerySolution sol, String var) {
+        return (sol.contains(var) && sol.get(var).isResource()) ? sol.getResource(var).getURI() : null;
+    }
+
+    private static String literalString(QuerySolution sol, String var) {
+        return (sol.contains(var) && sol.get(var).isLiteral()) ? sol.getLiteral(var).getString() : null;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.apache.jena.ontology.OntologyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -89,12 +90,8 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ApiResponseDto.error(e.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler({
-            MethodArgumentTypeMismatchException.class,
-            TypeMismatchException.class,
-            MissingServletRequestParameterException.class
-    })
-    public ResponseEntity<ApiResponseDto> handleRequestBindingException(Exception e) {
+    @ExceptionHandler(TypeMismatchException.class)
+    public ResponseEntity<ApiResponseDto> handleTypeMismatch(TypeMismatchException e) {
         log.warn("Bad request: {}", e.getMessage());
         return new ResponseEntity<>(ApiResponseDto.error(e.getMessage()), HttpStatus.BAD_REQUEST);
     }
@@ -203,5 +200,25 @@ public class GlobalExceptionHandler {
         log.error("RPP unavailable: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(ApiResponseDto.error("RPP data nejsou momentálně dostupná."));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("Type mismatch for parameter '{}': value='{}'", e.getName(), e.getValue());
+        String msg = "Parametr '" + e.getName() + "' má neplatnou hodnotu.";
+        return ResponseEntity.badRequest().body(ApiResponseDto.error(msg));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleMissingParameter(MissingServletRequestParameterException e) {
+        log.warn("Missing required parameter '{}'", e.getParameterName());
+        String msg = "Chybí povinný parametr '" + e.getParameterName() + "'.";
+        return ResponseEntity.badRequest().body(ApiResponseDto.error(msg));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Request body unreadable: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(ApiResponseDto.error("Požadavek má neplatný formát."));
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
@@ -197,4 +197,11 @@ public class GlobalExceptionHandler {
         log.warn("NKD endpoint error: {}", e.getMessage());
         return new ResponseEntity<>(ApiResponseDto.error(e.getMessage()), HttpStatus.SERVICE_UNAVAILABLE);
     }
+
+    @ExceptionHandler(RppUnavailableException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleRppUnavailable(RppUnavailableException e) {
+        log.error("RPP unavailable: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponseDto.error("RPP data nejsou momentálně dostupná."));
+    }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/config/RppConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/RppConfig.java
@@ -1,0 +1,32 @@
+package com.dia.ismdtoolbackend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "rpp")
+public class RppConfig {
+
+    private Sparql sparql = new Sparql();
+    private Cache cache = new Cache();
+    private Search search = new Search();
+
+    @Data
+    public static class Sparql {
+        private String endpoint = "";
+        private int timeout = 10000;
+    }
+
+    @Data
+    public static class Cache {
+        private long ttlHours = 24;
+    }
+
+    @Data
+    public static class Search {
+        private int maxLimit = 50;
+        private int defaultLimit = 20;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -137,6 +137,7 @@ public class SecurityConfig {
                 // Only apply this chain to public endpoints
                 .securityMatcher(
                         "/actuator/health",
+                        "/actuator/health/*",
                         "/actuator/info",
                         "/api/ontology/*/download",
                         "/api/ontology/*/detail",

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -201,6 +201,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/concept/*/delete").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/comment/post").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/comment/*/delete").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/rpp/agenda/search").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/rpp/ais/search").authenticated()
                         .anyRequest().denyAll()
                 )
                 // Disable CSRF for stateless JWT API

--- a/src/main/java/com/dia/ismdtoolbackend/controller/RppController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/RppController.java
@@ -1,0 +1,88 @@
+package com.dia.ismdtoolbackend.controller;
+
+import com.dia.ismdtoolbackend.config.RppConfig;
+import com.dia.ismdtoolbackend.controller.dto.ApiResponseDto;
+import com.dia.ismdtoolbackend.controller.dto.RppSearchResultDto;
+import com.dia.ismdtoolbackend.service.RppService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.dia.constants.FormatConstants.Converter.LOG_REQUEST_ID;
+
+@RestController
+@RequestMapping("/api/rpp")
+@RequiredArgsConstructor
+@Slf4j
+@PreAuthorize("isAuthenticated()")
+public class RppController {
+
+    private final RppService rppService;
+    private final RppConfig rppConfig;
+
+    @Operation(
+            summary = "Vyhledávání agend v RPP",
+            description = "Vrací seznam agend z Registru práv a povinností filtrovaný " +
+                    "dle dotazu (kód nebo název, bez diakritiky)."
+    )
+    @GetMapping("/agenda/search")
+    public ResponseEntity<ApiResponseDto<List<RppSearchResultDto>>> searchAgendas(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Integer limit) {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(LOG_REQUEST_ID, requestId);
+        try {
+            int resolved = resolveLimit(limit);
+            log.info("RPP agenda search, q: {}, limit: {}", q, resolved);
+            List<RppSearchResultDto> results = rppService.searchAgendas(q, resolved);
+            return ResponseEntity.ok(ApiResponseDto.success(results,
+                    "Vyhledávání agend úspěšně provedeno."));
+        } finally {
+            MDC.remove(LOG_REQUEST_ID);
+        }
+    }
+
+    @Operation(
+            summary = "Vyhledávání informačních systémů (ISVS) v RPP",
+            description = "Vrací seznam ISVS z Registru práv a povinností. " +
+                    "Pokud je uveden preferredAgendaCode, ISVS obsluhující tuto agendu jsou řazeny první."
+    )
+    @GetMapping("/ais/search")
+    public ResponseEntity<ApiResponseDto<List<RppSearchResultDto>>> searchIsvs(
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) String preferredAgendaCode) {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(LOG_REQUEST_ID, requestId);
+        try {
+            int resolved = resolveLimit(limit);
+            log.info("RPP ISVS search, q: {}, limit: {}, preferredAgendaCode: {}",
+                    q, resolved, preferredAgendaCode);
+            List<RppSearchResultDto> results = rppService.searchIsvs(q, resolved, preferredAgendaCode);
+            return ResponseEntity.ok(ApiResponseDto.success(results,
+                    "Vyhledávání informačních systémů úspěšně provedeno."));
+        } finally {
+            MDC.remove(LOG_REQUEST_ID);
+        }
+    }
+
+    private int resolveLimit(Integer limit) {
+        int max = rppConfig.getSearch().getMaxLimit();
+        if (limit == null) return rppConfig.getSearch().getDefaultLimit();
+        if (limit < 1 || limit > max) {
+            throw new IllegalArgumentException(
+                    "Parametr limit musí být v rozsahu 1 až " + max + ".");
+        }
+        return limit;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/GetOntologyDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/GetOntologyDto.java
@@ -3,13 +3,11 @@ package com.dia.ismdtoolbackend.controller.dto;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.models.PublishedOntologyDeviationModel;
-import com.dia.ismdtoolbackend.models.concept.ConceptMetadataModel;
 import com.dia.ismdtoolbackend.models.concept.PublishedConceptDeviationModel;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
 import java.util.Map;
 
 @Data
@@ -18,7 +16,6 @@ import java.util.Map;
 public class GetOntologyDto {
     private OntologyMetadataModel ontologyMetadata;
     private OntologyDetailModel ontologyDetail;
-    private List<ConceptMetadataModel> conceptMetadataModelList;
     private PublishedOntologyDeviationModel publishedOntologyDeviationModel;
     private Map<String, PublishedConceptDeviationModel> publishedConceptDeviations;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/RppSearchResultDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/RppSearchResultDto.java
@@ -1,0 +1,14 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RppSearchResultDto {
+    private String iri;
+    private String code;
+    private String nazev;
+}

--- a/src/main/java/com/dia/ismdtoolbackend/exception/RppUnavailableException.java
+++ b/src/main/java/com/dia/ismdtoolbackend/exception/RppUnavailableException.java
@@ -1,0 +1,11 @@
+package com.dia.ismdtoolbackend.exception;
+
+public class RppUnavailableException extends RuntimeException {
+    public RppUnavailableException(String message) {
+        super(message);
+    }
+
+    public RppUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppAgenda.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppAgenda.java
@@ -1,0 +1,12 @@
+package com.dia.ismdtoolbackend.models.rpp;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RppAgenda {
+    private String iri;
+    private String code;
+    private String nazev;
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppCodeComparator.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppCodeComparator.java
@@ -1,0 +1,19 @@
+package com.dia.ismdtoolbackend.models.rpp;
+
+import java.util.Comparator;
+
+public final class RppCodeComparator implements Comparator<String> {
+
+    public static final RppCodeComparator INSTANCE = new RppCodeComparator();
+
+    private RppCodeComparator() {}
+
+    @Override
+    public int compare(String a, String b) {
+        try {
+            return Integer.compare(Integer.parseInt(a), Integer.parseInt(b));
+        } catch (NumberFormatException nfe) {
+            return a.compareTo(b);
+        }
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppIsvs.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppIsvs.java
@@ -1,0 +1,15 @@
+package com.dia.ismdtoolbackend.models.rpp;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class RppIsvs {
+    private String iri;
+    private String code;
+    private String nazev;
+    private List<String> agendaIris;
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppSnapshot.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/rpp/RppSnapshot.java
@@ -1,0 +1,29 @@
+package com.dia.ismdtoolbackend.models.rpp;
+
+import lombok.Value;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Value
+public class RppSnapshot {
+    Instant loadedAt;
+    List<RppAgenda> agendas;
+    List<RppIsvs> isvs;
+    Map<String, List<String>> agendaIrisByIsvsIri;
+
+    public static RppSnapshot empty() {
+        return new RppSnapshot(Instant.EPOCH, List.of(), List.of(), Map.of());
+    }
+
+    public boolean isEmpty() {
+        return agendas.isEmpty() && isvs.isEmpty();
+    }
+
+    public boolean isStale(Duration ttl, Clock clock) {
+        return loadedAt.plus(ttl).isBefore(clock.instant());
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/query/RppSPARQLQuery.java
+++ b/src/main/java/com/dia/ismdtoolbackend/query/RppSPARQLQuery.java
@@ -4,12 +4,14 @@ import org.apache.jena.query.ParameterizedSparqlString;
 
 public class RppSPARQLQuery {
 
-    // Locked by spec — do NOT adjust without updating .planning/rpp-integration-analysis.md:
-    //   Agenda type: https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/agenda
-    //   ISVS type:   https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy
-    // TODO (Phase 2 smoke test): verify the four predicate IRIs (má-kód-agendy, má-název-agendy,
-    // má-kód-isvs, má-název-isvs) and the OPTIONAL predicate (poskytuje-služby-pro-agendu) against
-    // live RPP. They follow the RPP naming pattern but are not referenced elsewhere in this repo.
+    // Predicate IRIs verified 2026-04-21 against https://rpp-opendata.egon.gov.cz/odrpp/sparql:
+    //   Agenda  type: legislativní/sbírka/111/2009/pojem/agenda
+    //   Agenda  code: legislativní/sbírka/111/2009/pojem/má-kód-agendy        (returns A-prefixed codes)
+    //   Agenda  name: legislativní/sbírka/111/2009/pojem/má-název-agendy
+    //   ISVS    type: legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy
+    //   ISVS    code: agendový/104/pojem/má-identifikátor-isvs                (numeric string id)
+    //   ISVS    name: legislativní/sbírka/329/2020/pojem/název-isvs           (note: no "má-" prefix)
+    //   ISVS→Agenda:  legislativní/sbírka/329/2020/pojem/poskytuje-služby-pro-výkon-agendy
 
     public static String buildAgendaListQuery() {
         ParameterizedSparqlString pss = new ParameterizedSparqlString();
@@ -34,10 +36,10 @@ public class RppSPARQLQuery {
                 SELECT ?isvs ?code ?nazev ?agenda
                 WHERE {
                   ?isvs a <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy> ;
-                        <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/má-kód-isvs> ?code ;
-                        <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/má-název-isvs> ?nazev .
+                        <https://slovník.gov.cz/agendový/104/pojem/má-identifikátor-isvs> ?code ;
+                        <https://slovník.gov.cz/legislativní/sbírka/329/2020/pojem/název-isvs> ?nazev .
                   OPTIONAL {
-                    ?isvs <https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/poskytuje-služby-pro-agendu> ?agenda .
+                    ?isvs <https://slovník.gov.cz/legislativní/sbírka/329/2020/pojem/poskytuje-služby-pro-výkon-agendy> ?agenda .
                   }
                 }
                 """);

--- a/src/main/java/com/dia/ismdtoolbackend/query/RppSPARQLQuery.java
+++ b/src/main/java/com/dia/ismdtoolbackend/query/RppSPARQLQuery.java
@@ -1,0 +1,48 @@
+package com.dia.ismdtoolbackend.query;
+
+import org.apache.jena.query.ParameterizedSparqlString;
+
+public class RppSPARQLQuery {
+
+    // Locked by spec — do NOT adjust without updating .planning/rpp-integration-analysis.md:
+    //   Agenda type: https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/agenda
+    //   ISVS type:   https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy
+    // TODO (Phase 2 smoke test): verify the four predicate IRIs (má-kód-agendy, má-název-agendy,
+    // má-kód-isvs, má-název-isvs) and the OPTIONAL predicate (poskytuje-služby-pro-agendu) against
+    // live RPP. They follow the RPP naming pattern but are not referenced elsewhere in this repo.
+
+    public static String buildAgendaListQuery() {
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.setCommandText("""
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+                SELECT ?agenda ?code ?nazev
+                WHERE {
+                  ?agenda a <https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/agenda> ;
+                          <https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/má-kód-agendy> ?code ;
+                          <https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/má-název-agendy> ?nazev .
+                }
+                """);
+        return pss.toString();
+    }
+
+    public static String buildIsvsListQuery() {
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.setCommandText("""
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+                SELECT ?isvs ?code ?nazev ?agenda
+                WHERE {
+                  ?isvs a <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy> ;
+                        <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/má-kód-isvs> ?code ;
+                        <https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/má-název-isvs> ?nazev .
+                  OPTIONAL {
+                    ?isvs <https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/poskytuje-služby-pro-agendu> ?agenda .
+                  }
+                }
+                """);
+        return pss.toString();
+    }
+
+    private RppSPARQLQuery() {}
+}

--- a/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
+++ b/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
@@ -406,7 +406,9 @@ public class JenaTDB2Repository {
                 log.info("Graph name: {}", graphName);
                 log.info("Model size: {} statements", model.size());
 
-                conn.load(graphName, model);
+                // PUT replaces the graph; LOAD only appends, which silently
+                // drops deletions made in-memory by the editor.
+                conn.put(graphName, model);
                 log.info("Successfully saved ontology model to TDB2 with graph name: {}", graphName);
             });
         } catch (QueryExceptionHTTP e) {

--- a/src/main/java/com/dia/ismdtoolbackend/service/RppService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/RppService.java
@@ -1,0 +1,10 @@
+package com.dia.ismdtoolbackend.service;
+
+import com.dia.ismdtoolbackend.controller.dto.RppSearchResultDto;
+
+import java.util.List;
+
+public interface RppService {
+    List<RppSearchResultDto> searchAgendas(String q, int limit);
+    List<RppSearchResultDto> searchIsvs(String q, int limit, String preferredAgendaCode);
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
@@ -167,10 +167,11 @@ public class OntologyServiceImpl implements OntologyService {
         metadataModel.setComments(ontologyMetadataMapper.commentEntitiesToModels(commentEntities));
 
         List<ConceptMetadataEntity> conceptMetadataEntities = conceptMetadataRepository.findByGraphName(graphName);
-
+        List<com.dia.ismdtoolbackend.models.concept.ConceptMetadataModel> conceptModels =
+                conceptMetadataEntities.stream().map(conceptMetadataMapper::toDto).toList();
+        metadataModel.setConcepts(conceptModels);
 
         GetOntologyDto result = new GetOntologyDto();
-        result.setConceptMetadataModelList(conceptMetadataEntities.stream().map(conceptMetadataMapper::toDto).toList());
         // Single source of truth: conceptCount on both projections of the
         // ontology comes from the same authoritative PG list we just loaded.
         int conceptCount = conceptMetadataEntities.size();

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/RppServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/RppServiceImpl.java
@@ -1,0 +1,90 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.controller.dto.RppSearchResultDto;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import com.dia.ismdtoolbackend.service.RppService;
+import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
+import com.dia.utility.DataTypeConverter;
+import com.dia.utility.UtilityMethods;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RppServiceImpl implements RppService {
+
+    private final RppSnapshotHolder snapshotHolder;
+
+    @Override
+    public List<RppSearchResultDto> searchAgendas(String q, int limit) {
+        RppSnapshot snap = snapshotHolder.get();
+        if (snap.isEmpty()) return List.of();
+        String needle = isBlank(q) ? null : normalize(q);
+        return snap.getAgendas().stream()
+                .filter(a -> needle == null || matches(a.getCode(), a.getNazev(), needle))
+                .limit(limit)
+                .map(a -> new RppSearchResultDto(a.getIri(), a.getCode(), a.getNazev()))
+                .toList();
+    }
+
+    @Override
+    public List<RppSearchResultDto> searchIsvs(String q, int limit, String preferredAgendaCode) {
+        RppSnapshot snap = snapshotHolder.get();
+        if (snap.isEmpty()) return List.of();
+        String needle = isBlank(q) ? null : normalize(q);
+        String preferredIri = resolvePreferredAgendaIri(preferredAgendaCode);
+
+        List<RppIsvs> filtered = snap.getIsvs().stream()
+                .filter(i -> needle == null || matches(i.getCode(), i.getNazev(), needle))
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (preferredIri != null) {
+            final String pref = preferredIri;
+            filtered.sort(Comparator.comparingInt(
+                    i -> i.getAgendaIris().contains(pref) ? 0 : 1));
+        }
+
+        return filtered.stream().limit(limit)
+                .map(i -> new RppSearchResultDto(i.getIri(), i.getCode(), i.getNazev()))
+                .toList();
+    }
+
+    private String resolvePreferredAgendaIri(String code) {
+        if (isBlank(code)) return null;
+        if (!UtilityMethods.isValidAgendaValue(code)) {
+            log.debug("preferredAgendaCode rejected by isValidAgendaValue: {}", code);
+            return null;
+        }
+        String transformed = UtilityMethods.transformAgendaValue(code);
+        if (!DataTypeConverter.isUri(transformed)) {
+            log.debug("transformAgendaValue produced non-URI for code={}: {}", code, transformed);
+            return null;
+        }
+        return transformed;
+    }
+
+    private static boolean matches(String code, String nazev, String needle) {
+        return (code != null && normalize(code).contains(needle))
+                || (nazev != null && normalize(nazev).contains(needle));
+    }
+
+    private static String normalize(String s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "")
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolder.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolder.java
@@ -1,0 +1,91 @@
+package com.dia.ismdtoolbackend.service.rpp;
+
+import com.dia.ismdtoolbackend.client.RppSparqlClient;
+import com.dia.ismdtoolbackend.config.RppConfig;
+import com.dia.ismdtoolbackend.exception.RppUnavailableException;
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppCodeComparator;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class RppSnapshotHolder {
+
+    private final RppSparqlClient client;
+    private final Clock clock;
+    private final Duration ttl;
+
+    private final AtomicReference<RppSnapshot> current = new AtomicReference<>(RppSnapshot.empty());
+    private final Object refreshLock = new Object();
+
+    public RppSnapshotHolder(RppSparqlClient client, Clock clock, RppConfig config) {
+        this.client = client;
+        this.clock = clock;
+        this.ttl = Duration.ofHours(config.getCache().getTtlHours());
+    }
+
+    public RppSnapshot get() {
+        RppSnapshot snap = current.get();
+        if (isFresh(snap)) {
+            return snap;
+        }
+        return refreshUnderLock();
+    }
+
+    private RppSnapshot refreshUnderLock() {
+        synchronized (refreshLock) {
+            RppSnapshot snap = current.get();
+            if (isFresh(snap)) {
+                return snap;
+            }
+            return attemptRefresh(snap);
+        }
+    }
+
+    private RppSnapshot attemptRefresh(RppSnapshot existing) {
+        try {
+            RppSnapshot fresh = buildFresh();
+            current.set(fresh);
+            return fresh;
+        } catch (RppUnavailableException e) {
+            if (!existing.isEmpty()) {
+                log.warn("RPP refresh failed; serving stale snapshot loadedAt={}. cause={}",
+                        existing.getLoadedAt(), e.getMessage());
+                return existing;
+            }
+            throw e;
+        }
+    }
+
+    private boolean isFresh(RppSnapshot snap) {
+        return !snap.isEmpty() && !snap.isStale(ttl, clock);
+    }
+
+    private RppSnapshot buildFresh() {
+        List<RppAgenda> agendas = new ArrayList<>(client.fetchAllAgendas());
+        List<RppIsvs> isvs = new ArrayList<>(client.fetchAllIsvs());
+        agendas.sort(Comparator.comparing(RppAgenda::getCode, RppCodeComparator.INSTANCE));
+        isvs.sort(Comparator.comparing(RppIsvs::getCode, RppCodeComparator.INSTANCE));
+
+        Map<String, List<String>> byIsvs = isvs.stream()
+                .filter(i -> i.getIri() != null)
+                .collect(Collectors.toUnmodifiableMap(
+                        RppIsvs::getIri,
+                        i -> List.copyOf(i.getAgendaIris()),
+                        (a, b) -> a));
+
+        return new RppSnapshot(clock.instant(), List.copyOf(agendas), List.copyOf(isvs), byIsvs);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolder.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolder.java
@@ -44,6 +44,10 @@ public class RppSnapshotHolder {
         return refreshUnderLock();
     }
 
+    public RppSnapshot peek() {
+        return current.get();
+    }
+
     private RppSnapshot refreshUnderLock() {
         synchronized (refreshLock) {
             RppSnapshot snap = current.get();

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -32,6 +32,7 @@ logging.level.com.dia.ismdtoolbackend.repository.JenaTDB2Repository=DEBUG
 logging.level.com.dia.ismdtoolbackend.utility=DEBUG
 logging.level.org.apache.jena.sparql.exec.http=DEBUG
 logging.level.org.apache.jena.http=DEBUG
+logging.level.com.dia.ismdtoolbackend.service.rpp=DEBUG
 
 # Management Endpoints Configuration
 management.endpoints.web.exposure.include=health,info,metrics

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -73,3 +73,6 @@ validation.rules.enable-ontology-violation-download=false
 # NKD SPARQL test endpoint
 nkd.sparql.endpoint=https://data.gov.cz/slovn%C3%ADky/sparql
 nkd.sparql.timeout=10000
+
+# RPP SPARQL endpoint
+rpp.sparql.endpoint=https://rpp-opendata.egon.gov.cz/odrpp/sparql

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,13 @@ search.fuseki-timeout-ms=${SEARCH_FUSEKI_TIMEOUT_MS:10000}
 search.min-query-length=${SEARCH_MIN_QUERY_LENGTH:2}
 search.max-limit=${SEARCH_MAX_LIMIT:100}
 
+# RPP (Registr práv a povinností) SPARQL endpoint + cache + search limits
+rpp.sparql.endpoint=
+rpp.sparql.timeout=10000
+rpp.cache.ttl-hours=24
+rpp.search.max-limit=50
+rpp.search.default-limit=20
+
 # File upload limits
 spring.servlet.multipart.max-file-size=${MAX_UPLOAD_SIZE:10MB}
 spring.servlet.multipart.max-request-size=${MAX_UPLOAD_SIZE:10MB}

--- a/src/test/java/com/dia/ismdtoolbackend/actuator/RppHealthIndicatorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/actuator/RppHealthIndicatorTest.java
@@ -1,0 +1,72 @@
+package com.dia.ismdtoolbackend.actuator;
+
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RppHealthIndicatorTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-23T12:00:00Z");
+    private static final Clock FIXED = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Mock
+    private RppSnapshotHolder holder;
+
+    @Test
+    void emptySnapshotReportsUnknown() {
+        when(holder.peek()).thenReturn(RppSnapshot.empty());
+
+        Health health = new RppHealthIndicator(holder, FIXED).health();
+
+        assertEquals(Status.UNKNOWN, health.getStatus());
+        assertEquals("not-yet-loaded", health.getDetails().get("reason"));
+    }
+
+    @Test
+    void freshSnapshotReportsUpWithAgeAndCounts() {
+        Instant loadedAt = NOW.minusSeconds(600);
+        RppAgenda agenda = new RppAgenda("iri:a", "A1", "Agenda 1");
+        RppIsvs isvs = new RppIsvs("iri:i", "1", "ISVS 1", List.of());
+        RppSnapshot snap = new RppSnapshot(loadedAt, List.of(agenda), List.of(isvs), Map.of("iri:i", List.of()));
+        when(holder.peek()).thenReturn(snap);
+
+        Health health = new RppHealthIndicator(holder, FIXED).health();
+
+        assertEquals(Status.UP, health.getStatus());
+        Map<String, Object> details = health.getDetails();
+        assertEquals(loadedAt.toString(), details.get("loadedAt"));
+        assertEquals(600L, details.get("ageSeconds"));
+        assertEquals(1, details.get("agendaCount"));
+        assertEquals(1, details.get("isvsCount"));
+    }
+
+    @Test
+    void staleSnapshotStillReportsUp() {
+        Instant loadedAt = NOW.minusSeconds(7 * 24 * 3600);
+        RppAgenda agenda = new RppAgenda("iri:a", "A1", "Agenda 1");
+        RppSnapshot snap = new RppSnapshot(loadedAt, List.of(agenda), List.of(), Map.of());
+        when(holder.peek()).thenReturn(snap);
+
+        Health health = new RppHealthIndicator(holder, FIXED).health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals(7 * 24 * 3600L, health.getDetails().get("ageSeconds"));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/client/RppSparqlClientTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/RppSparqlClientTest.java
@@ -1,0 +1,187 @@
+package com.dia.ismdtoolbackend.client;
+
+import com.dia.ismdtoolbackend.exception.RppUnavailableException;
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RppSparqlClientTest {
+
+    private WireMockServer wm;
+    private RppSparqlClient client;
+
+    @BeforeAll
+    void startServer() {
+        wm = new WireMockServer(wireMockConfig().dynamicPort());
+        wm.start();
+        com.github.tomakehurst.wiremock.client.WireMock.configureFor("localhost", wm.port());
+    }
+
+    @AfterAll
+    void stopServer() {
+        wm.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        wm.resetAll();
+        client = new RppSparqlClient();
+        ReflectionTestUtils.setField(client, "rppEndpoint", wm.baseUrl() + "/sparql");
+        ReflectionTestUtils.setField(client, "rppSparqlTimeout", 2000);
+    }
+
+    @AfterEach
+    void tearDown() {
+        wm.resetAll();
+    }
+
+    @Test
+    void emptyResultSetReturnsEmptyList() {
+        stubSparql(emptyResults());
+        List<RppAgenda> out = client.fetchAllAgendas();
+        assertEquals(0, out.size());
+    }
+
+    @Test
+    void isvsCollapseZeroAgendas() {
+        String json = """
+                {
+                  "head": { "vars": ["isvs", "code", "nazev", "agenda"] },
+                  "results": { "bindings": [
+                    { "isvs": {"type":"uri","value":"http://example.org/i/1"},
+                      "code":  {"type":"literal","value":"100"},
+                      "nazev":{"type":"literal","value":"Alfa"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+        List<RppIsvs> out = client.fetchAllIsvs();
+        assertEquals(1, out.size());
+        assertEquals("http://example.org/i/1", out.get(0).getIri());
+        assertEquals(0, out.get(0).getAgendaIris().size());
+    }
+
+    @Test
+    void isvsCollapseOneAgenda() {
+        String json = """
+                {
+                  "head": { "vars": ["isvs", "code", "nazev", "agenda"] },
+                  "results": { "bindings": [
+                    { "isvs":  {"type":"uri","value":"http://example.org/i/1"},
+                      "code":   {"type":"literal","value":"100"},
+                      "nazev": {"type":"literal","value":"Alfa"},
+                      "agenda":{"type":"uri","value":"http://example.org/a/A1"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+        List<RppIsvs> out = client.fetchAllIsvs();
+        assertEquals(1, out.size());
+        assertEquals(List.of("http://example.org/a/A1"), out.get(0).getAgendaIris());
+    }
+
+    @Test
+    void isvsCollapseMultipleAgendas() {
+        String json = """
+                {
+                  "head": { "vars": ["isvs", "code", "nazev", "agenda"] },
+                  "results": { "bindings": [
+                    { "isvs":  {"type":"uri","value":"http://example.org/i/1"},
+                      "code":   {"type":"literal","value":"100"},
+                      "nazev": {"type":"literal","value":"Alfa"},
+                      "agenda":{"type":"uri","value":"http://example.org/a/A1"} },
+                    { "isvs":  {"type":"uri","value":"http://example.org/i/1"},
+                      "code":   {"type":"literal","value":"100"},
+                      "nazev": {"type":"literal","value":"Alfa"},
+                      "agenda":{"type":"uri","value":"http://example.org/a/A2"} },
+                    { "isvs":  {"type":"uri","value":"http://example.org/i/1"},
+                      "code":   {"type":"literal","value":"100"},
+                      "nazev": {"type":"literal","value":"Alfa"},
+                      "agenda":{"type":"uri","value":"http://example.org/a/A1"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+        List<RppIsvs> out = client.fetchAllIsvs();
+        assertEquals(1, out.size());
+        assertEquals(List.of("http://example.org/a/A1", "http://example.org/a/A2"), out.get(0).getAgendaIris());
+    }
+
+    @Test
+    void malformedRowIsSkipped() {
+        String json = """
+                {
+                  "head": { "vars": ["agenda", "code", "nazev"] },
+                  "results": { "bindings": [
+                    { "agenda": {"type":"uri","value":"http://example.org/a/A1"},
+                      "nazev":  {"type":"literal","value":"Missing code"} },
+                    { "agenda": {"type":"uri","value":"http://example.org/a/A2"},
+                      "code":    {"type":"literal","value":"2"},
+                      "nazev":  {"type":"literal","value":"Valid"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+        List<RppAgenda> out = client.fetchAllAgendas();
+        assertEquals(1, out.size());
+        assertEquals("2", out.get(0).getCode());
+    }
+
+    @Test
+    void upstream500ThrowsRppUnavailable() {
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(500)));
+        assertThrows(RppUnavailableException.class, () -> client.fetchAllAgendas());
+    }
+
+    @Test
+    void upstreamTimeoutThrowsRppUnavailable() {
+        stubFor(any(anyUrl()).willReturn(aResponse()
+                .withHeader("Content-Type", "application/sparql-results+json")
+                .withFixedDelay(5000)
+                .withBody(emptyResults())));
+        RppUnavailableException ex = assertThrows(RppUnavailableException.class, () -> client.fetchAllAgendas());
+        assertNotNull(ex.getMessage());
+    }
+
+    @Test
+    void unconfiguredEndpointThrowsRppUnavailable() {
+        ReflectionTestUtils.setField(client, "rppEndpoint", "");
+        RppUnavailableException ex = assertThrows(RppUnavailableException.class, () -> client.fetchAllAgendas());
+        assertTrue(ex.getMessage().contains("not configured"));
+    }
+
+    private static void stubSparql(String body) {
+        stubFor(any(anyUrl()).willReturn(aResponse()
+                .withHeader("Content-Type", "application/sparql-results+json")
+                .withBody(body)));
+    }
+
+    private static String emptyResults() {
+        return """
+                {
+                  "head": { "vars": ["agenda", "code", "nazev"] },
+                  "results": { "bindings": [] }
+                }
+                """;
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/controller/RppControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/RppControllerTest.java
@@ -1,0 +1,149 @@
+package com.dia.ismdtoolbackend.controller;
+
+import com.dia.ismdtoolbackend.config.GlobalExceptionHandler;
+import com.dia.ismdtoolbackend.config.RppConfig;
+import com.dia.ismdtoolbackend.config.security.TestOntologySecurityService;
+import com.dia.ismdtoolbackend.config.security.TestSecurityConfig;
+import com.dia.ismdtoolbackend.config.security.WithMockSecurityUser;
+import com.dia.ismdtoolbackend.controller.dto.RppSearchResultDto;
+import com.dia.ismdtoolbackend.service.RppService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RppController.class,
+        excludeAutoConfiguration = {
+                org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientWebSecurityAutoConfiguration.class,
+                org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration.class
+        })
+@Import({TestSecurityConfig.class, TestOntologySecurityService.class, GlobalExceptionHandler.class})
+@ActiveProfiles("test")
+class RppControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RppService rppService;
+
+    @MockitoBean
+    private RppConfig rppConfig;
+
+    @BeforeEach
+    void setUp() {
+        RppConfig.Search search = new RppConfig.Search();
+        search.setDefaultLimit(20);
+        search.setMaxLimit(50);
+        when(rppConfig.getSearch()).thenReturn(search);
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void agendaSearchHappyPathReturnsEnvelope() throws Exception {
+        when(rppService.searchAgendas(eq("spr"), eq(5)))
+                .thenReturn(List.of(
+                        new RppSearchResultDto("iri-1", "1", "Správa daní"),
+                        new RppSearchResultDto("iri-2", "2", "Sprava něco")));
+
+        mockMvc.perform(get("/api/rpp/agenda/search").param("q", "spr").param("limit", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].iri").value("iri-1"))
+                .andExpect(jsonPath("$.data[0].code").value("1"))
+                .andExpect(jsonPath("$.data[0].nazev").value("Správa daní"))
+                .andExpect(jsonPath("$.message").value("Vyhledávání agend úspěšně provedeno."));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void isvsSearchForwardsAllParams() throws Exception {
+        when(rppService.searchIsvs(any(), anyInt(), any()))
+                .thenReturn(List.of(new RppSearchResultDto("iri-1", "1", "ISVS 1")));
+
+        mockMvc.perform(get("/api/rpp/ais/search")
+                        .param("q", "alfa")
+                        .param("limit", "10")
+                        .param("preferredAgendaCode", "A1382"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.message").value("Vyhledávání informačních systémů úspěšně provedeno."));
+
+        ArgumentCaptor<String> qCap = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> limitCap = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<String> prefCap = ArgumentCaptor.forClass(String.class);
+        verify(rppService).searchIsvs(qCap.capture(), limitCap.capture(), prefCap.capture());
+        org.junit.jupiter.api.Assertions.assertEquals("alfa", qCap.getValue());
+        org.junit.jupiter.api.Assertions.assertEquals(10, limitCap.getValue());
+        org.junit.jupiter.api.Assertions.assertEquals("A1382", prefCap.getValue());
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void defaultLimitAppliedWhenMissing() throws Exception {
+        when(rppService.searchAgendas(any(), anyInt())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/rpp/agenda/search"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Integer> limitCap = ArgumentCaptor.forClass(Integer.class);
+        verify(rppService).searchAgendas(any(), limitCap.capture());
+        org.junit.jupiter.api.Assertions.assertEquals(20, limitCap.getValue());
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void limitZeroReturns400() throws Exception {
+        mockMvc.perform(get("/api/rpp/agenda/search").param("limit", "0"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Parametr limit musí být v rozsahu 1 až 50."));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void limitAboveMaxReturns400() throws Exception {
+        mockMvc.perform(get("/api/rpp/agenda/search").param("limit", "51"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void unauthenticatedReturns403() throws Exception {
+        mockMvc.perform(get("/api/rpp/agenda/search"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void missingQueryForwardedAsNull() throws Exception {
+        when(rppService.searchAgendas(any(), anyInt())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/rpp/agenda/search").param("limit", "10"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<String> qCap = ArgumentCaptor.forClass(String.class);
+        verify(rppService).searchAgendas(qCap.capture(), anyInt());
+        org.junit.jupiter.api.Assertions.assertNull(qCap.getValue());
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/models/rpp/RppSnapshotTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/models/rpp/RppSnapshotTest.java
@@ -1,0 +1,45 @@
+package com.dia.ismdtoolbackend.models.rpp;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RppSnapshotTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-21T12:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Test
+    void emptySentinelIsEmpty() {
+        RppSnapshot snap = RppSnapshot.empty();
+        assertTrue(snap.isEmpty());
+        assertTrue(snap.isStale(Duration.ofHours(24), FIXED_CLOCK));
+    }
+
+    @Test
+    void populatedSnapshotWithinTtlIsFresh() {
+        RppSnapshot snap = populated(NOW.minus(Duration.ofHours(23)));
+        assertFalse(snap.isEmpty());
+        assertFalse(snap.isStale(Duration.ofHours(24), FIXED_CLOCK));
+    }
+
+    @Test
+    void populatedSnapshotPastTtlIsStale() {
+        RppSnapshot snap = populated(NOW.minus(Duration.ofHours(25)));
+        assertTrue(snap.isStale(Duration.ofHours(24), FIXED_CLOCK));
+    }
+
+    private static RppSnapshot populated(Instant loadedAt) {
+        RppAgenda a = new RppAgenda("iri-a", "1", "Agenda 1");
+        RppIsvs i = new RppIsvs("iri-i", "10", "ISVS 10", List.of());
+        return new RppSnapshot(loadedAt, List.of(a), List.of(i), Map.of());
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/query/RppSPARQLQueryTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/query/RppSPARQLQueryTest.java
@@ -1,0 +1,25 @@
+package com.dia.ismdtoolbackend.query;
+
+import org.apache.jena.query.QueryFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RppSPARQLQueryTest {
+
+    @Test
+    void agendaQueryParsesAndContainsTypeIri() {
+        String q = RppSPARQLQuery.buildAgendaListQuery();
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        assertTrue(q.contains("https://slovník.gov.cz/legislativní/sbírka/111/2009/pojem/agenda"));
+    }
+
+    @Test
+    void isvsQueryParsesContainsTypeIriAndOptional() {
+        String q = RppSPARQLQuery.buildIsvsListQuery();
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        assertTrue(q.contains("https://slovník.gov.cz/legislativní/sbírka/365/2000/pojem/informační-systém-veřejné-správy"));
+        assertTrue(q.contains("OPTIONAL"));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/repository/JenaTDB2RepositorySearchTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/repository/JenaTDB2RepositorySearchTest.java
@@ -383,4 +383,25 @@ class JenaTDB2RepositorySearchTest {
         assertEquals(1, result.size());
         assertTrue(result.contains("https://example.org/concept/1"));
     }
+
+    /**
+     * Regression: saveOntologyModel must replace the graph (PUT), not append (LOAD).
+     *
+     * The edit flow mutates an in-memory copy of the graph — including removing
+     * triples — and then calls saveOntologyModel to persist. If this method appends
+     * instead of replacing, deletions are silently dropped: the removed triples
+     * survive in TDB, the edit appears to succeed, and the next read returns the
+     * pre-edit state. We hit exactly that bug with dcterms:description on ontology
+     * edits; this test pins the contract so it cannot regress.
+     */
+    @Test
+    void saveOntologyModel_replacesGraph_doesNotAppend() {
+        Model model = ModelFactory.createDefaultModel();
+        String graphName = "https://example.org/graph/test";
+
+        repository.saveOntologyModel(graphName, model);
+
+        verify(mockConnection).put(graphName, model);
+        verify(mockConnection, never()).load(eq(graphName), any(Model.class));
+    }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyServiceImplTest.java
@@ -272,8 +272,8 @@ class OntologyServiceImplTest {
         assertNotNull(result);
         assertNotNull(result.getOntologyMetadata());
         assertNotNull(result.getOntologyDetail());
-        assertNotNull(result.getConceptMetadataModelList());
-        assertEquals(1, result.getConceptMetadataModelList().size());
+        assertNotNull(result.getOntologyMetadata().getConcepts());
+        assertEquals(1, result.getOntologyMetadata().getConcepts().size());
         assertEquals(TEST_ONTOLOGY_SLUG, result.getOntologyMetadata().getSlug());
         assertEquals(TEST_GRAPH_NAME, result.getOntologyDetail().getIri());
         // fetchGraph is called once: enrichMetadataFromModel reuses the already-fetched rawModel

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/RppServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/RppServiceImplTest.java
@@ -1,0 +1,208 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.controller.dto.RppSearchResultDto;
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RppServiceImplTest {
+
+    @Mock
+    private RppSnapshotHolder snapshotHolder;
+
+    @InjectMocks
+    private RppServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        // Each test stubs snapshotHolder.get() with its own fixture.
+    }
+
+    @Test
+    void emptySnapshotReturnsEmptyListForAgendaSearch() {
+        when(snapshotHolder.get()).thenReturn(RppSnapshot.empty());
+        assertEquals(List.of(), service.searchAgendas("anything", 20));
+    }
+
+    @Test
+    void emptySnapshotReturnsEmptyListForIsvsSearch() {
+        when(snapshotHolder.get()).thenReturn(RppSnapshot.empty());
+        assertEquals(List.of(), service.searchIsvs("anything", 20, "A1382"));
+    }
+
+    @Test
+    void emptyQueryReturnsFirstLimitAgendasInSnapshotOrder() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(
+                        new RppAgenda("iri-1", "1", "Alfa"),
+                        new RppAgenda("iri-2", "2", "Beta"),
+                        new RppAgenda("iri-3", "3", "Gama")),
+                List.of()));
+        List<RppSearchResultDto> out = service.searchAgendas(null, 2);
+        assertEquals(List.of("1", "2"), codes(out));
+    }
+
+    @Test
+    void blankQueryBehavesLikeNull() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("iri-1", "1", "Alfa")),
+                List.of()));
+        assertEquals(1, service.searchAgendas("   ", 10).size());
+    }
+
+    @Test
+    void diacriticInsensitiveMatchOnNazev() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("iri-1", "1", "Správa daní"),
+                        new RppAgenda("iri-2", "2", "Jiné něco")),
+                List.of()));
+        List<RppSearchResultDto> out = service.searchAgendas("sprava", 10);
+        assertEquals(List.of("1"), codes(out));
+    }
+
+    @Test
+    void caseInsensitiveMatchOnNazev() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("iri-1", "1", "Daň z příjmu")),
+                List.of()));
+        assertEquals(1, service.searchAgendas("DAN", 10).size());
+    }
+
+    @Test
+    void codeFieldMatches() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("iri-1", "A1382", "něco"),
+                        new RppAgenda("iri-2", "B999", "jiné")),
+                List.of()));
+        List<RppSearchResultDto> out = service.searchAgendas("a1", 10);
+        assertEquals(List.of("A1382"), codes(out));
+    }
+
+    @Test
+    void limitTruncatesMatches() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(
+                        new RppAgenda("i1", "1", "match a"),
+                        new RppAgenda("i2", "2", "match b"),
+                        new RppAgenda("i3", "3", "match c"),
+                        new RppAgenda("i4", "4", "match d"),
+                        new RppAgenda("i5", "5", "match e")),
+                List.of()));
+        assertEquals(2, service.searchAgendas("match", 2).size());
+    }
+
+    @Test
+    void limitLargerThanMatchesReturnsAll() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("i1", "1", "match"),
+                        new RppAgenda("i2", "2", "nope")),
+                List.of()));
+        assertEquals(1, service.searchAgendas("match", 50).size());
+    }
+
+    @Test
+    void isvsPreferredAgendaBringsMatchingToFront() {
+        RppIsvs i1 = new RppIsvs("isvs-1", "1", "Alfa", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        RppIsvs i2 = new RppIsvs("isvs-2", "2", "Beta", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A9999"));
+        RppIsvs i3 = new RppIsvs("isvs-3", "3", "Gama", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        when(snapshotHolder.get()).thenReturn(snapshot(List.of(), List.of(i1, i2, i3)));
+
+        List<RppSearchResultDto> out = service.searchIsvs(null, 10, "A1382");
+        assertEquals(List.of("1", "3", "2"), codes(out));
+    }
+
+    @Test
+    void isvsPreferredOrderingIsStableWithinGroup() {
+        RppIsvs i1 = new RppIsvs("isvs-1", "1", "Alfa", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        RppIsvs i2 = new RppIsvs("isvs-2", "2", "Beta", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        RppIsvs i3 = new RppIsvs("isvs-3", "3", "Gama", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A9999"));
+        when(snapshotHolder.get()).thenReturn(snapshot(List.of(), List.of(i1, i2, i3)));
+
+        List<RppSearchResultDto> out = service.searchIsvs(null, 10, "A1382");
+        assertEquals(List.of("1", "2", "3"), codes(out));
+    }
+
+    @Test
+    void invalidPreferredAgendaFallsBackSilently() {
+        RppIsvs i1 = new RppIsvs("isvs-1", "1", "Alfa", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        RppIsvs i2 = new RppIsvs("isvs-2", "2", "Beta", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A9999"));
+        when(snapshotHolder.get()).thenReturn(snapshot(List.of(), List.of(i1, i2)));
+
+        List<RppSearchResultDto> out = service.searchIsvs(null, 10, "###not-valid###");
+        assertEquals(List.of("1", "2"), codes(out));
+    }
+
+    @Test
+    void blankPreferredAgendaSkipsOrdering() {
+        RppIsvs i1 = new RppIsvs("isvs-1", "1", "Alfa", List.of());
+        RppIsvs i2 = new RppIsvs("isvs-2", "2", "Beta", List.of());
+        when(snapshotHolder.get()).thenReturn(snapshot(List.of(), List.of(i1, i2)));
+
+        assertEquals(List.of("1", "2"), codes(service.searchIsvs(null, 10, "")));
+        assertEquals(List.of("1", "2"), codes(service.searchIsvs(null, 10, null)));
+    }
+
+    @Test
+    void numericCodeOrderingPreservedFromSnapshot() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("i1", "9", "n9"),
+                        new RppAgenda("i2", "10", "n10"),
+                        new RppAgenda("i3", "100", "n100")),
+                List.of()));
+        assertEquals(List.of("9", "10", "100"), codes(service.searchAgendas(null, 10)));
+    }
+
+    @Test
+    void dtoMappingProducesIriCodeNazev() {
+        when(snapshotHolder.get()).thenReturn(snapshot(
+                List.of(new RppAgenda("iri-x", "42", "Název X")),
+                List.of()));
+        RppSearchResultDto dto = service.searchAgendas(null, 10).get(0);
+        assertEquals("iri-x", dto.getIri());
+        assertEquals("42", dto.getCode());
+        assertEquals("Název X", dto.getNazev());
+    }
+
+    @Test
+    void preferredAgendaLimitAppliesAfterPartition() {
+        RppIsvs i1 = new RppIsvs("isvs-1", "1", "Alfa", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A9999"));
+        RppIsvs i2 = new RppIsvs("isvs-2", "2", "Beta", List.of("https://rpp-opendata.egon.gov.cz/odrpp/zdroj/agenda/A1382"));
+        when(snapshotHolder.get()).thenReturn(snapshot(List.of(), List.of(i1, i2)));
+
+        List<RppSearchResultDto> out = service.searchIsvs(null, 1, "A1382");
+        assertEquals(1, out.size());
+        assertEquals("2", out.get(0).getCode(), "preferred match should win the single limit slot");
+    }
+
+    private static List<String> codes(List<RppSearchResultDto> rows) {
+        return rows.stream().map(RppSearchResultDto::getCode).toList();
+    }
+
+    private static RppSnapshot snapshot(List<RppAgenda> agendas, List<RppIsvs> isvs) {
+        Map<String, List<String>> byIsvs = isvs.stream()
+                .filter(i -> i.getIri() != null)
+                .collect(Collectors.toUnmodifiableMap(
+                        RppIsvs::getIri,
+                        i -> List.copyOf(i.getAgendaIris()),
+                        (a, b) -> a));
+        return new RppSnapshot(Instant.parse("2026-04-21T12:00:00Z"),
+                List.copyOf(agendas), List.copyOf(isvs), byIsvs);
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolderTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/rpp/RppSnapshotHolderTest.java
@@ -1,0 +1,114 @@
+package com.dia.ismdtoolbackend.service.rpp;
+
+import com.dia.ismdtoolbackend.client.RppSparqlClient;
+import com.dia.ismdtoolbackend.config.RppConfig;
+import com.dia.ismdtoolbackend.exception.RppUnavailableException;
+import com.dia.ismdtoolbackend.models.rpp.RppAgenda;
+import com.dia.ismdtoolbackend.models.rpp.RppIsvs;
+import com.dia.ismdtoolbackend.models.rpp.RppSnapshot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RppSnapshotHolderTest {
+
+    private static final Instant T0 = Instant.parse("2026-04-21T12:00:00Z");
+
+    @Mock
+    private RppSparqlClient client;
+
+    private AtomicReference<Instant> now;
+    private Clock clock;
+    private RppSnapshotHolder holder;
+
+    @BeforeEach
+    void setUp() {
+        now = new AtomicReference<>(T0);
+        clock = new Clock() {
+            @Override public ZoneOffset getZone() { return ZoneOffset.UTC; }
+            @Override public Clock withZone(java.time.ZoneId z) { return this; }
+            @Override public Instant instant() { return now.get(); }
+        };
+        RppConfig config = new RppConfig();
+        config.getCache().setTtlHours(24);
+        holder = new RppSnapshotHolder(client, clock, config);
+    }
+
+    @Test
+    void coldFetchPopulatesCache() {
+        when(client.fetchAllAgendas()).thenReturn(List.of(new RppAgenda("a-iri", "1", "Ag")));
+        when(client.fetchAllIsvs()).thenReturn(List.of(new RppIsvs("i-iri", "10", "Is", List.of())));
+
+        RppSnapshot snap = holder.get();
+
+        assertEquals(T0, snap.getLoadedAt());
+        assertEquals(1, snap.getAgendas().size());
+        assertEquals(1, snap.getIsvs().size());
+        verify(client, times(1)).fetchAllAgendas();
+        verify(client, times(1)).fetchAllIsvs();
+    }
+
+    @Test
+    void withinTtlReturnsCachedSnapshot() {
+        when(client.fetchAllAgendas()).thenReturn(List.of(new RppAgenda("a-iri", "1", "Ag")));
+        when(client.fetchAllIsvs()).thenReturn(List.of(new RppIsvs("i-iri", "10", "Is", List.of())));
+
+        RppSnapshot first = holder.get();
+        now.set(T0.plusSeconds(3600));
+        RppSnapshot second = holder.get();
+
+        assertSame(first, second);
+        verify(client, times(1)).fetchAllAgendas();
+        verify(client, times(1)).fetchAllIsvs();
+    }
+
+    @Test
+    void pastTtlTriggersRefetch() {
+        when(client.fetchAllAgendas()).thenReturn(List.of(new RppAgenda("a-iri", "1", "Ag")));
+        when(client.fetchAllIsvs()).thenReturn(List.of(new RppIsvs("i-iri", "10", "Is", List.of())));
+
+        holder.get();
+        now.set(T0.plusSeconds(25 * 3600));
+        holder.get();
+
+        verify(client, times(2)).fetchAllAgendas();
+        verify(client, times(2)).fetchAllIsvs();
+    }
+
+    @Test
+    void refetchFailureWithNonEmptyCacheServesStale() {
+        when(client.fetchAllAgendas())
+                .thenReturn(List.of(new RppAgenda("a-iri", "1", "Ag")))
+                .thenThrow(new RppUnavailableException("upstream down"));
+        when(client.fetchAllIsvs()).thenReturn(List.of(new RppIsvs("i-iri", "10", "Is", List.of())));
+
+        RppSnapshot stale = holder.get();
+        now.set(T0.plusSeconds(25 * 3600));
+        RppSnapshot served = holder.get();
+
+        assertSame(stale, served);
+    }
+
+    @Test
+    void refetchFailureWithEmptyCacheThrows() {
+        when(client.fetchAllAgendas()).thenThrow(new RppUnavailableException("upstream down"));
+
+        assertThrows(RppUnavailableException.class, () -> holder.get());
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                    
   
  Adds RPP SPARQL integration: two authenticated                                                                                                    
  search endpoints backed by a cached snapshot of agendas and ISVS, plus a
  public health probe. Includes one unrelated fix to GlobalExceptionHandler                                                                                                     
  discovered during testing.                                                                                                                                                    
                                                                                                                                                                                
  ### Endpoints                                                                                                                                                                 
  - `GET /api/rpp/agenda/search?q=&limit=` — diacritic-insensitive search over
    agendas by code or name (auth required).                                                                                                                                    
  - `GET /api/rpp/ais/search?q=&limit=&preferredAgendaCode=` — same for ISVS;
    systems serving the preferred agenda are sorted first.                                                                                                                      
  - `GET /actuator/health/rpp` — public; reports cache `loadedAt`, `ageSeconds`,                                                                                                
    `agendaCount`, `isvsCount`.                                                                                                                                                 
                                                                                                                                                                                
  ### Architecture                                                                                                                                                              
  - `RppSparqlClient` runs two SELECTs against the upstream Jena endpoint.                                                                                                      
  - `RppSnapshotHolder` caches results in an `AtomicReference` with a 24h TTL,                                                                                                  
    single-flight refresh, and stale-on-failure fallback.                                                                                                                       
  - Search filters in-memory over the cached snapshot (~405 agendas, ~649 ISVS).                                                                                                
  - Failures surface as `503 "RPP data nejsou momentálně dostupná."`.                                                                                                           
  - Configurable: `rpp.sparql.endpoint`, `rpp.sparql.timeout`, `rpp.cache.ttl-hours`,                                                                                           
    `rpp.search.{default,max}-limit`.                                                                                                                                           
                                                                                                                                                                                
  ### Drive-by fix                                                                                                                                                              
  `GlobalExceptionHandler` now maps `MethodArgumentTypeMismatchException`,                                                                                                      
  `MissingServletRequestParameterException`, and `HttpMessageNotReadableException`                                                                                              
  to **400** (previously fell through to 500). Improves every controller, not                                                                                                   
  just RPP.                                                                                                                                                                     
                                                                                                                                                                                
  ## Test plan                                                                                                                                                                  
                                                                          
  Tested manually via curl against a local instance (UI not yet available).                                                                                                     
                                                                          
  **Unit tests** — `Rpp*` suite (7 classes) green.                                                                                                                              
                                                                          
  **Live SPARQL sanity** — both queries verified directly against                                                                                                               
  `https://rpp-opendata.egon.gov.cz/odrpp/sparql`: 405 agendas, 649 distinct
  ISVS, no rows missing required fields.                                                                                                                                        
                                                                                                                                                                                
  **Endpoint behavior (15 scenarios)** — all pass:                                                                                                                              
  - [x] Anonymous calls → 401                                                                                                                                                   
  - [x] First auth call triggers cold load; health flips `UNKNOWN` → `UP`                                                                                                       
  - [x] Code search (`q=A1086`) returns the exact agenda                                                                                                                        
  - [x] Diacritic + case insensitivity (`zdravotni`, `ZDRAVOTNI`, `Zdravotní`                                                                                                   
        return identical results)                                                                                                                                               
  - [x] `limit=1`, `limit=50` honored; `limit={0,-1,51}` → 400 with friendly                                                                                                    
        Czech message; `limit=abc` → 400 (was 500 before fix)                                                                                                                   
  - [x] Empty / whitespace `q` treated as null                                                                                                                                  
  - [x] No-match query returns empty list with `success: true`                                                                                                                  
  - [x] `preferredAgendaCode=A1086` re-orders ISVS list dramatically; invalid                                                                                                   
        and empty codes silently fall back to default order                                                                                                                     
  - [x] Three warm calls in 2–3 ms each; `loadedAt` unchanged across calls                                                                                                      
                                                                                                                                                                                
  **Failure modes** — all return clean 503, no snapshot pollution:                                                                                                              
  - [x] Endpoint unreachable, cold cache (port 9)                                                                                                                               
  - [x] Endpoint slow (`rpp.sparql.timeout=1`)                                                                                                                                  
  - [x] Endpoint blank (`rpp.sparql.endpoint=`) — distinct log message                                                                                                          
        `"RPP endpoint not configured"`                                                                                                                                         
  - Stale-on-failure (warm cache + upstream down) covered by                                                                                                                    
    `RppSnapshotHolderTest`.                                                                                                                                                    
                                                                                                                                                                                
  ## Notes for reviewers                                                                                                                                                        
  - First authenticated call after restart blocks ~1–3 s on two upstream                                                                                                        
    fetches. Acceptable for the current FE; consider warm-on-startup if it                                                                                                      
    bites.                                                                                                                                                                      
  - All three failure modes return identical user-facing message; ops alerting                                                                                                  
    should key off the structured log message, not the response body.                                                                                                           
  - Cache has no manual flush — 24h TTL or restart only. Fine for low-velocity                                                                                                  
    reference data. 