### PR TITLE
ci(security): add CodeQL + Trivy scans, align checkout pin, doc refresh

### DIFF
--- a/.github/workflows/code-quality-report.yml
+++ b/.github/workflows/code-quality-report.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# GitHub-native SAST for Java. CodeQL needs to observe a real Maven build to
+# build its database, so we replicate the same setup as reusable-test.yml
+# (JDK 17 + mvnw package).
+# Findings appear in Security -> Code scanning.
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: '0 6 * * 1'   # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  packages: read
+
+jobs:
+  analyze:
+    name: Analyze (java)
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          queries: security-extended
+          build-mode: manual
+
+      - name: Build tool-backend
+        run: ./mvnw -DskipTests clean package
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           queries: security-extended
@@ -59,6 +59,6 @@ jobs:
         run: ./mvnw -DskipTests clean package
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java-kotlin"

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -26,7 +26,7 @@ jobs:
       should_build: ${{ steps.determine-version.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -82,7 +82,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -24,7 +24,7 @@ jobs:
       new_version: ${{ steps.new-version.outputs.version }}
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to get tags
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -36,7 +36,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/trigger-deployment.yml
+++ b/.github/workflows/trigger-deployment.yml
@@ -45,7 +45,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -165,7 +165,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -231,7 +231,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment
@@ -297,7 +297,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6
       
       - name: Create GitHub Deployment
         id: create_deployment

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,65 @@
+name: Trivy Image Scan
+
+# Calls the reusable Trivy scanner owned by infrastructure repo.
+# Findings appear in this repo's Security -> Code scanning tab.
+#
+# Image taxonomy (see reusable-docker-build.yml):
+#   dev branch  -> ghcr.io/datagov-cz/ismd-tool-backend-dev:latest    (deployed to dev env)
+#   main branch -> ghcr.io/datagov-cz/ismd-tool-backend:latest        (deployed to test + prod)
+#
+# Triggers:
+#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Docker on Main" completes -> scan main image
+#   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
+#   * Manual dispatch                        -> pick dev/main/both
+
+on:
+  workflow_run:
+    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    types: [completed]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      image_variant:
+        description: 'Which image(s) to scan'
+        required: true
+        type: choice
+        options: [dev, main, both]
+        default: both
+      soft_fail:
+        description: 'Non-blocking: workflow stays green even if findings exist (default). Uncheck to make scan blocking for this run.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  scan-dev:
+    name: Scan dev image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-tool-backend-dev:latest
+      # Default non-blocking. Only a manual dispatch with soft_fail=false flips it.
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit
+
+  scan-main:
+    name: Scan main image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Main' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'main' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-tool-backend:latest
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit

--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -37,23 +37,23 @@ Run everything in Docker — no JDK required.
 
 **Windows (PowerShell):**
 ```powershell
-.\start-full-backend.ps1
+.\full-backend.ps1 up
 # Force rebuild after code changes:
-.\start-full-backend.ps1 --build
+.\full-backend.ps1 up --build
 ```
 
 **Linux/macOS:**
 ```bash
-chmod +x start-full-backend.sh
-./start-full-backend.sh
+chmod +x full-backend.sh
+./full-backend.sh up
 # Force rebuild after code changes:
-./start-full-backend.sh --build
+./full-backend.sh up --build
 ```
 
 #### Check it's running
 
 ```bash
-docker-compose --profile full-backend ps
+docker compose --profile full-backend ps
 docker logs ismd-tool-backend -f
 ```
 
@@ -63,9 +63,9 @@ Look for `Started IsmdToolBackendApplication` in the logs.
 
 In `tool-frontend/.env.local`:
 ```
-BE_URL=http://127.0.0.1:8081/popisujeme
+BE_URL=http://host.docker.internal:8081/popisujeme
 ```
-Use `127.0.0.1` rather than `localhost` — Node.js resolves `localhost` to `::1` (IPv6) on newer versions, which will fail if the backend only listens on IPv4.
+Prefer `host.docker.internal` over `localhost` / `127.0.0.1` — it works whether `npm run dev` runs in WSL, PowerShell, or Git Bash, and whether the backend is in Docker or IDEA. (`localhost` resolves to `::1` on newer Node and breaks against IPv4-only backends.) Linux + Docker Engine only (no Docker Desktop)? Use `127.0.0.1` instead — `host.docker.internal` is provided by Docker Desktop and won't resolve on native Docker Engine without extra config.
 
 Then run the frontend:
 ```bash
@@ -76,5 +76,10 @@ npm run dev
 #### Stop
 
 ```bash
-docker-compose --profile full-backend down
+# PowerShell
+.\full-backend.ps1 down
+# Bash
+./full-backend.sh down
+# Or directly:
+docker compose --profile full-backend down
 ```


### PR DESCRIPTION
Security:
- CodeQL Java scan: SAST on push/PR to dev+main, weekly cron. Replicates reusable-test.yml build chain (JDK 17 + mvnw + Spring Boot package), build-mode: manual.
- Trivy image scan stub calling reusable in datagov-cz/ismd-infrastructure. Scans both -dev and prod-bound images after their respective Build Docker workflows complete, plus weekly drift cron and manual dispatch. Findings appear in Security -> Code scanning.

Workflow hygiene:
- actions/checkout pins aligned to @v6 (was @v6.0.2 across reusable-test, reusable-docker-build, release-version, push-to-main, trigger-deployment, and code-quality-report).

Docs:
- Refresh docker-instructions.md for renamed full-backend.{ps1,sh} entrypoints with up/down subcommands, modernize to docker compose (v2 syntax), and clarify host resolution (host.docker.internal vs 127.0.0.1) for WSL/PowerShell/Git Bash and native Docker Engine on Linux.