### PR TITLE
chore(tool-backend): rename start-full-backend scripts, fix PowerShell arg parsing

### DIFF
--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -37,23 +37,23 @@ Run everything in Docker — no JDK required.
 
 **Windows (PowerShell):**
 ```powershell
-.\start-full-backend.ps1
+.\full-backend.ps1 up
 # Force rebuild after code changes:
-.\start-full-backend.ps1 --build
+.\full-backend.ps1 up --build
 ```
 
 **Linux/macOS:**
 ```bash
-chmod +x start-full-backend.sh
-./start-full-backend.sh
+chmod +x full-backend.sh
+./full-backend.sh up
 # Force rebuild after code changes:
-./start-full-backend.sh --build
+./full-backend.sh up --build
 ```
 
 #### Check it's running
 
 ```bash
-docker-compose --profile full-backend ps
+docker compose --profile full-backend ps
 docker logs ismd-tool-backend -f
 ```
 
@@ -63,9 +63,9 @@ Look for `Started IsmdToolBackendApplication` in the logs.
 
 In `tool-frontend/.env.local`:
 ```
-BE_URL=http://127.0.0.1:8081/popisujeme
+BE_URL=http://host.docker.internal:8081/popisujeme
 ```
-Use `127.0.0.1` rather than `localhost` — Node.js resolves `localhost` to `::1` (IPv6) on newer versions, which will fail if the backend only listens on IPv4.
+Prefer `host.docker.internal` over `localhost` / `127.0.0.1` — it works whether `npm run dev` runs in WSL, PowerShell, or Git Bash, and whether the backend is in Docker or IDEA. (`localhost` resolves to `::1` on newer Node and breaks against IPv4-only backends.)
 
 Then run the frontend:
 ```bash
@@ -76,5 +76,10 @@ npm run dev
 #### Stop
 
 ```bash
-docker-compose --profile full-backend down
+# PowerShell
+.\full-backend.ps1 down
+# Bash
+./full-backend.sh down
+# Or directly:
+docker compose --profile full-backend down
 ```

--- a/docker/keycloak/ismd-realm.json
+++ b/docker/keycloak/ismd-realm.json
@@ -1,6 +1,7 @@
 {
   "realm": "ismd",
   "enabled": true,
+  "sslRequired": "none",
   "clients": [
     {
       "clientId": "ismd-app",

--- a/full-backend.ps1
+++ b/full-backend.ps1
@@ -1,0 +1,29 @@
+# Usage:
+#   .\full-backend.ps1 up   [docker compose up options]    (e.g. --build, --wait, --remove-orphans)
+#   .\full-backend.ps1 down [docker compose down options]  (e.g. -v, --remove-orphans)
+#
+# A param() block + ValueFromRemainingArguments is required because PowerShell
+# otherwise eats short switches like -v (binds to the common -Verbose parameter)
+# before $args ever sees them.
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('up', 'down')]
+    [string]$Command = 'up',
+
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Rest
+)
+
+Get-Content .env | ForEach-Object {
+    if ($_ -match '^\s*([^#][^=]+)=(.*)$') {
+        [System.Environment]::SetEnvironmentVariable($matches[1].Trim(), $matches[2].Trim())
+    }
+}
+
+$extra = if ($Rest) { $Rest } else { @() }
+
+switch ($Command) {
+    'up'   { docker compose --profile full-backend up -d @extra }
+    'down' { docker compose --profile full-backend down @extra }
+}

--- a/full-backend.sh
+++ b/full-backend.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage:
+#   ./full-backend.sh up   [docker compose up options]    (e.g. --build, --wait, --remove-orphans)
+#   ./full-backend.sh down [docker compose down options]  (e.g. -v, --remove-orphans)
+set -a
+source .env
+set +a
+
+COMMAND="${1:-up}"
+shift || true
+
+case "$COMMAND" in
+  up)
+    docker compose --profile full-backend up -d "$@"
+    ;;
+  down)
+    docker compose --profile full-backend down "$@"
+    ;;
+  *)
+    echo "Usage: $0 up [options] | down [options]"
+    exit 1
+    ;;
+esac

--- a/start-full-backend.ps1
+++ b/start-full-backend.ps1
@@ -1,8 +1,0 @@
-# Loads .env and starts the full-backend profile (includes Spring Boot backend)
-Get-Content .env | ForEach-Object {
-    if ($_ -match '^\s*([^#][^=]+)=(.*)$') {
-        [System.Environment]::SetEnvironmentVariable($matches[1].Trim(), $matches[2].Trim())
-    }
-}
-
-docker-compose --profile full-backend up -d @args

--- a/start-full-backend.sh
+++ b/start-full-backend.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# Loads .env and starts the full-backend profile (includes Spring Boot backend)
-set -a
-source .env
-set +a
-
-docker-compose --profile full-backend up -d "$@"


### PR DESCRIPTION
- rename start-full-backend.{ps1,sh} → full-backend.{ps1,sh}
- full-backend.ps1: use a param() block with ValueFromRemainingArguments
  so short switches like -v and -d reach docker compose instead of being
  consumed by PowerShell's common parameter binding (-Verbose alias);
  validate the up/down command up-front
- full-backend.sh: align usage comment with the .ps1; tolerate missing
  args via `shift || true`
- docker-instructions.md: update script names, modernize docker-compose
  → docker compose, align BE_URL guidance with .env.local.example
- docker/keycloak/ismd-realm.json: sslRequired=none so the local realm
  works over plain HTTP without browser SSL warnings