### PR TITLE
feat: refactor docker-compose and fix validator service URL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+registries:
+  validator-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/datagov-cz/ismd-validator-backend
+    username: x-access-token
+    password: ${{ secrets.PACKAGES_READ_TOKEN }}
+
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    registries:
+      - validator-packages

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
           
           docker build \
             -f Dockerfile \
-            --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            --build-arg GITHUB_TOKEN="${{ secrets.PACKAGES_READ_TOKEN }}" \
             --build-arg GITHUB_ACTOR="${{ github.actor }}" \
             -t $IMAGE_TAG \
             -t $LATEST_TAG \

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,20 @@
+# ==============================================
+# ISMD Tool Backend - Build Override
+# ==============================================
+# Use with the base file to build the backend image from local source:
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.build.yml \
+#                  --profile full-backend up --build
+#
+# Requires GITHUB_TOKEN + GITHUB_ACTOR for Maven access to GitHub Packages.
+# ==============================================
+
+services:
+  backend:
+    image: ismd-tool-backend:local
+    pull_policy: never
+    build:
+      context: .
+      args:
+        GITHUB_TOKEN: ${GITHUB_TOKEN}
+        GITHUB_ACTOR: ${GITHUB_ACTOR}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,11 +106,10 @@ services:
       - ismd-network
 
   backend:
-    build:
-      context: .
-      args:
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
-        GITHUB_ACTOR: ${GITHUB_ACTOR}
+    # Default: pull pre-built dev image from GHCR.
+    # To build from local source, use docker-compose.build.yml override.
+    image: ${TOOL_BACKEND_IMAGE:-ghcr.io/datagov-cz/ismd-tool-backend-dev:latest}
+    pull_policy: ${TOOL_BACKEND_PULL_POLICY:-missing}
     container_name: ismd-tool-backend
     profiles:
       - full-backend
@@ -152,4 +151,5 @@ volumes:
 
 networks:
   ismd-network:
+    name: ismd-network
     driver: bridge

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -66,7 +66,9 @@ spring.security.oauth2.client.registration.keycloak.redirect-uri={baseUrl}/login
 spring.security.oauth2.client.provider.keycloak.issuer-uri=http://localhost:8080/realms/ismd
 
 # Validator API url
-validation.service.url:http://localhost:8080/validujeme
+# Local profile: BE runs on host (e.g. from IDE) and reaches validator BE
+# on host port 8082 (mapped from container's 8080).
+validation.service.url=${VALIDATION_SERVICE_URL:http://localhost:8082/validujeme}
 
 # Ontology containing VIOLATION download settings
 validation.rules.enable-ontology-violation-download=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,9 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_ISSUER_URI:http:
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/ismd}/protocol/openid-connect/certs
 
 # Validator API url
-validation.service.url:http://localhost:8080/validujeme
+# Default targets the validator BE container on the shared docker network.
+# Override with VALIDATION_SERVICE_URL when running outside docker.
+validation.service.url=${VALIDATION_SERVICE_URL:http://ismd-validator-backend:8080/validujeme}
 
 # Ontology containing VIOLATION download settings
 validation.rules.enable-ontology-violation-download=false


### PR DESCRIPTION
Switch to GHCR dev image by default and add shared docker network for cross-repo compose. Fix validator URL to target the container instead of colliding localhost:8080.