### PR TITLE
chore: update workflows in main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+registries:
+  validator-packages:
+    type: maven-repository
+    url: https://maven.pkg.github.com/datagov-cz/ismd-validator-backend
+    username: x-access-token
+    password: ${{ secrets.PACKAGES_READ_TOKEN }}
+
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    registries:
+      - validator-packages

--- a/.github/workflows/build-fuseki.yml
+++ b/.github/workflows/build-fuseki.yml
@@ -1,0 +1,91 @@
+name: Build Fuseki Image
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - 'docker/fuseki/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build for'
+        required: true
+        type: choice
+        options:
+          - dev
+          - main
+        default: dev
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-fuseki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Determine branch
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "branch=${{ inputs.branch }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get version info
+        id: version
+        run: |
+          GIT_SHA=$(git rev-parse --short HEAD)
+          BRANCH="${{ steps.branch.outputs.branch }}"
+
+          TAG=$(git describe --tags --abbrev=0 --match "v[0-9]*" 2>/dev/null || echo "")
+          BASE_VERSION=$([ -n "$TAG" ] && echo "$TAG" | sed 's/^v//' || echo "0.0.1")
+
+          if [ "$BRANCH" = "main" ]; then
+            VERSION="$BASE_VERSION"
+          else
+            VERSION="${BASE_VERSION}-${GIT_SHA}"
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build and push Fuseki image
+        run: |
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if [ "$BRANCH" = "main" ]; then
+            IMAGE_NAME="ghcr.io/${REPO_OWNER}/ismd-tool-fuseki"
+          else
+            IMAGE_NAME="ghcr.io/${REPO_OWNER}/ismd-tool-fuseki-${BRANCH}"
+          fi
+
+          docker build \
+            -f docker/fuseki/Dockerfile \
+            -t "${IMAGE_NAME}:${VERSION}" \
+            -t "${IMAGE_NAME}:latest" \
+            docker/fuseki
+
+          docker push "${IMAGE_NAME}:${VERSION}"
+          docker push "${IMAGE_NAME}:latest"
+
+          echo "Pushed: ${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -1,0 +1,30 @@
+name: Check Coverage
+
+on:
+  workflow_dispatch:
+    inputs:
+      coverage_line:
+        description: "JaCoCo line coverage minimum ratio (0.00-1.00)"
+        required: false
+        type: string
+        default: "0.55"
+      coverage_branch:
+        description: "JaCoCo branch coverage minimum ratio (0.00-1.00)"
+        required: false
+        type: string
+        default: "0.45"
+      coverage_complexity:
+        description: "JaCoCo complexity coverage minimum ratio (0.00-1.00)"
+        required: false
+        type: string
+        default: "0.45"
+
+jobs:
+  check-coverage:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      enforce_coverage: true
+      coverage_line: ${{ inputs.coverage_line }}
+      coverage_branch: ${{ inputs.coverage_branch }}
+      coverage_complexity: ${{ inputs.coverage_complexity }}
+    secrets: inherit

--- a/.github/workflows/code-quality-report.yml
+++ b/.github/workflows/code-quality-report.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload quality reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tool-backend-quality-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# GitHub-native SAST for Java. CodeQL needs to observe a real Maven build to
+# build its database, so we replicate the same setup as reusable-test.yml
+# (JDK 17 + mvnw package).
+# Findings appear in Security -> Code scanning.
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  schedule:
+    - cron: '0 6 * * 1'   # Weekly Monday 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  packages: read
+
+jobs:
+  analyze:
+    name: Analyze (java)
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-codeql-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          queries: security-extended
+          build-mode: manual
+
+      - name: Build tool-backend
+        run: ./mvnw -DskipTests clean package
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,5 +15,7 @@ jobs:
   run-tests:
     uses: ./.github/workflows/reusable-test.yml
     with:
-      coverage_minimum: ${{ vars.JACOCO_LINE_MINIMUM != '' && vars.JACOCO_LINE_MINIMUM || '0.00' }}
+      coverage_line: ${{ vars.JACOCO_LINE_MINIMUM || '0.55' }}
+      coverage_branch: ${{ vars.JACOCO_BRANCH_MINIMUM || '0.45' }}
+      coverage_complexity: ${{ vars.JACOCO_COMPLEXITY_MINIMUM || '0.45' }}
     secrets: inherit

--- a/.github/workflows/push-to-dev.yml
+++ b/.github/workflows/push-to-dev.yml
@@ -11,11 +11,6 @@ on:
         required: false
         type: boolean
         default: false
-      coverage_minimum:
-        description: "JaCoCo line coverage minimum ratio (0.00-1.00)"
-        required: false
-        type: string
-        default: "0.00"
 
 permissions:
   contents: write
@@ -27,7 +22,6 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       enforce_coverage: ${{ github.event_name == 'workflow_dispatch' && inputs.enforce_coverage || false }}
-      coverage_minimum: ${{ github.event_name == 'workflow_dispatch' && inputs.coverage_minimum || (vars.JACOCO_LINE_MINIMUM != '' && vars.JACOCO_LINE_MINIMUM || '0.00') }}
     secrets: inherit
 
   build-docker:

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -26,7 +26,7 @@ jobs:
       should_build: ${{ steps.determine-version.outputs.should_build }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -82,7 +82,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -24,7 +24,7 @@ jobs:
       new_version: ${{ steps.new-version.outputs.version }}
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to get tags
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with: 
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up repository path
         id: repo-setup
@@ -81,7 +81,7 @@ jobs:
           
           docker build \
             -f Dockerfile \
-            --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+            --build-arg GITHUB_TOKEN="${{ secrets.PACKAGES_READ_TOKEN }}" \
             --build-arg GITHUB_ACTOR="${{ github.actor }}" \
             -t $IMAGE_TAG \
             -t $LATEST_TAG \

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -8,11 +8,21 @@ on:
         required: false
         type: boolean
         default: true
-      coverage_minimum:
+      coverage_line:
         description: "JaCoCo line coverage minimum ratio (0.00-1.00)"
         required: false
         type: string
-        default: "0.00"
+        default: "0.55"
+      coverage_branch:
+        description: "JaCoCo branch coverage minimum ratio (0.00-1.00)"
+        required: false
+        type: string
+        default: "0.45"
+      coverage_complexity:
+        description: "JaCoCo complexity coverage minimum ratio (0.00-1.00)"
+        required: false
+        type: string
+        default: "0.45"
 
 permissions:
   contents: read
@@ -23,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -48,14 +58,20 @@ jobs:
       - name: Run tests with coverage
         run: |
           if [ "${{ inputs.enforce_coverage }}" = "true" ]; then
-            ./mvnw clean verify -Djacoco.line.minimum=${{ inputs.coverage_minimum }}
+            ./mvnw clean verify \
+              -Djacoco.line.minimum=${{ inputs.coverage_line }} \
+              -Djacoco.branch.minimum=${{ inputs.coverage_branch }} \
+              -Djacoco.complexity.minimum=${{ inputs.coverage_complexity }}
           else
-            ./mvnw clean test jacoco:report -Djacoco.line.minimum=${{ inputs.coverage_minimum }}
+            ./mvnw clean test jacoco:report \
+              -Djacoco.line.minimum=${{ inputs.coverage_line }} \
+              -Djacoco.branch.minimum=${{ inputs.coverage_branch }} \
+              -Djacoco.complexity.minimum=${{ inputs.coverage_complexity }}
           fi
 
       - name: Upload JaCoCo coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tool-backend-jacoco-report-${{ github.run_id }}
           path: target/site/jacoco

--- a/.github/workflows/trigger-fuseki-deployment.yml
+++ b/.github/workflows/trigger-fuseki-deployment.yml
@@ -1,13 +1,11 @@
-name: Trigger Deployment
+name: Trigger Fuseki Deployment
 
 on:
-  # Triggered when a new image is published
   workflow_run:
-    workflows: [Build Docker on Main, Build Dev Branch]
+    workflows: [Build Fuseki Image]
     types: [completed]
     branches: [main, dev]
-  
-  # Manual trigger with environment and version selection
+
   workflow_dispatch:
     inputs:
       environment:
@@ -31,7 +29,7 @@ permissions:
   packages: read
 
 env:
-  COMPONENT_NAME: tool-backend
+  COMPONENT_NAME: fuseki
 
 jobs:
   determine-params:
@@ -42,71 +40,57 @@ jobs:
       environment: ${{ steps.determine_params.outputs.environment }}
       image_tag: ${{ steps.determine_params.outputs.image_tag }}
       ref: ${{ steps.determine_params.outputs.ref }}
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      
+
       - name: Determine environment and version
         id: determine_params
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             ENVIRONMENT="${{ github.event.inputs.environment }}"
             ENVIRONMENT="${ENVIRONMENT^^}"
-            
+
             if [ -n "${{ github.event.inputs.version }}" ]; then
               IMAGE_TAG="${{ github.event.inputs.version }}"
             else
-              # Query GitHub Packages API for the latest available image tag
               REPO_OWNER='${{ github.repository_owner }}'
-              
               if [ "$ENVIRONMENT" = "DEV" ]; then
-                PACKAGE_NAME="ismd-tool-backend-dev"
+                PACKAGE_NAME="ismd-tool-fuseki-dev"
               else
-                PACKAGE_NAME="ismd-tool-backend"
+                PACKAGE_NAME="ismd-tool-fuseki"
               fi
-              
-              echo "Querying GitHub Packages API for most recent image in ${PACKAGE_NAME}..."
-              
-              LATEST_TAG=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+
+              IMAGE_TAG=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "https://api.github.com/orgs/${REPO_OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=1" 2>/dev/null | \
                 jq -r '.[0].metadata.container.tags[] | select(. != "latest")' | head -1)
-              
-              if [ -n "$LATEST_TAG" ]; then
-                IMAGE_TAG="$LATEST_TAG"
-              else
-                IMAGE_TAG="latest"
-              fi
+              IMAGE_TAG="${IMAGE_TAG:-latest}"
             fi
           else
-            # For automated triggers, determine environment from branch
             if [ "${{ github.event.workflow_run.head_branch }}" == "main" ]; then
               ENVIRONMENT="TEST"
             else
               ENVIRONMENT="DEV"
             fi
-            
+
             REPO_OWNER='${{ github.repository_owner }}'
-            
             if [ "$ENVIRONMENT" = "DEV" ]; then
-              PACKAGE_NAME="ismd-tool-backend-dev"
+              PACKAGE_NAME="ismd-tool-fuseki-dev"
             else
-              PACKAGE_NAME="ismd-tool-backend"
+              PACKAGE_NAME="ismd-tool-fuseki"
             fi
-            
+
             IMAGE_TAG=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/orgs/${REPO_OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=1" 2>/dev/null | \
               jq -r '.[0].metadata.container.tags[] | select(. != "latest")' | head -1)
-            
-            if [ -z "$IMAGE_TAG" ]; then
-              IMAGE_TAG="latest"
-            fi
+            IMAGE_TAG="${IMAGE_TAG:-latest}"
           fi
 
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
@@ -114,59 +98,23 @@ jobs:
           else
             REF="${GITHUB_SHA}"
           fi
-          
-          echo "Environment: ${ENVIRONMENT}"
-          echo "Image tag: ${IMAGE_TAG}"
-          echo "Ref: ${REF}"
-          
+
           echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "ref=${REF}" >> $GITHUB_OUTPUT
 
-  validate-image:
-    name: Validate Image Tag Exists
-    runs-on: ubuntu-latest
-    needs: determine-params
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check manifest exists
-        run: |
-          ENV_UPPER='${{ needs.determine-params.outputs.environment }}'
-          ENV_LOWER=$(echo "$ENV_UPPER" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG='${{ needs.determine-params.outputs.image_tag }}'
-          REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
-          
-          if [ "$ENV_UPPER" = "DEV" ]; then
-            IMAGE="ghcr.io/${REPO_OWNER}/ismd-tool-backend-${ENV_LOWER}:${IMAGE_TAG}"
-          else
-            IMAGE="ghcr.io/${REPO_OWNER}/ismd-tool-backend:${IMAGE_TAG}"
-          fi
-          
-          echo "Validating image: $IMAGE"
-          if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "ERROR: Image manifest not found for $IMAGE" >&2
-            exit 1
-          fi
-          echo "Image exists: $IMAGE"
-      
   deploy-to-dev:
-    name: Deploy to Dev
-    needs: [determine-params, validate-image]
+    name: Deploy Fuseki to Dev
+    needs: [determine-params]
     if: needs.determine-params.outputs.environment == 'DEV'
     runs-on: ubuntu-latest
     environment:
       name: DEV
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@v6.0.2
+
       - name: Create GitHub Deployment
         id: create_deployment
         uses: chrnorm/deployment-action@v2
@@ -184,25 +132,25 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "pending"
           description: "Preparing to deploy"
-      
+
       - name: Azure Login
         uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      
-      - name: Deploy to Azure Container App
+
+      - name: Deploy Fuseki to Azure Container App
         run: |
-          IMAGE="ghcr.io/datagov-cz/ismd-tool-backend-dev:${{ needs.determine-params.outputs.image_tag }}"
-          echo "Deploying $IMAGE to ismd-tool-backend-dev"
-          
+          IMAGE="ghcr.io/datagov-cz/ismd-tool-fuseki-dev:${{ needs.determine-params.outputs.image_tag }}"
+          echo "Deploying $IMAGE to ismd-tool-fuseki-dev"
+
           az containerapp update \
-            --name ismd-tool-backend-dev \
+            --name ismd-tool-fuseki-dev \
             --resource-group ismd-tool-dev \
             --image "$IMAGE" \
             --output table
-          
+
           echo "✅ Deployment complete"
-      
+
       - name: Update Deployment Status - Success
         if: success()
         uses: chrnorm/deployment-status@v2
@@ -211,7 +159,7 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "success"
           description: "Deployed successfully"
-      
+
       - name: Update Deployment Status - Failure
         if: failure()
         uses: chrnorm/deployment-status@v2
@@ -220,19 +168,19 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "failure"
           description: "Deployment failed"
-  
+
   deploy-to-test:
-    name: Deploy to Test
-    needs: [determine-params, validate-image]
+    name: Deploy Fuseki to Test
+    needs: [determine-params]
     if: needs.determine-params.outputs.environment == 'TEST'
     runs-on: ubuntu-latest
     environment:
       name: TEST
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@v6.0.2
+
       - name: Create GitHub Deployment
         id: create_deployment
         uses: chrnorm/deployment-action@v2
@@ -250,25 +198,25 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "pending"
           description: "Preparing to deploy"
-      
+
       - name: Azure Login
         uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      
-      - name: Deploy to Azure Container App
+
+      - name: Deploy Fuseki to Azure Container App
         run: |
-          IMAGE="ghcr.io/datagov-cz/ismd-tool-backend:${{ needs.determine-params.outputs.image_tag }}"
-          echo "Deploying $IMAGE to ismd-tool-backend-test"
-          
+          IMAGE="ghcr.io/datagov-cz/ismd-tool-fuseki:${{ needs.determine-params.outputs.image_tag }}"
+          echo "Deploying $IMAGE to ismd-tool-fuseki-test"
+
           az containerapp update \
-            --name ismd-tool-backend-test \
+            --name ismd-tool-fuseki-test \
             --resource-group ismd-tool-test \
             --image "$IMAGE" \
             --output table
-          
+
           echo "✅ Deployment complete"
-      
+
       - name: Update Deployment Status - Success
         if: success()
         uses: chrnorm/deployment-status@v2
@@ -277,7 +225,7 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "success"
           description: "Deployed successfully"
-      
+
       - name: Update Deployment Status - Failure
         if: failure()
         uses: chrnorm/deployment-status@v2
@@ -286,19 +234,19 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "failure"
           description: "Deployment failed"
-  
+
   deploy-to-prod:
-    name: Deploy to Production
-    needs: [determine-params, validate-image]
+    name: Deploy Fuseki to Production
+    needs: [determine-params]
     if: needs.determine-params.outputs.environment == 'PROD'
     runs-on: ubuntu-latest
     environment:
       name: PROD
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
-      
+        uses: actions/checkout@v6.0.2
+
       - name: Create GitHub Deployment
         id: create_deployment
         uses: chrnorm/deployment-action@v2
@@ -316,25 +264,25 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "pending"
           description: "Preparing to deploy"
-      
+
       - name: Azure Login
         uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-      
-      - name: Deploy to Azure Container App
+
+      - name: Deploy Fuseki to Azure Container App
         run: |
-          IMAGE="ghcr.io/datagov-cz/ismd-tool-backend:${{ needs.determine-params.outputs.image_tag }}"
-          echo "Deploying $IMAGE to ismd-tool-backend-prod"
-          
+          IMAGE="ghcr.io/datagov-cz/ismd-tool-fuseki:${{ needs.determine-params.outputs.image_tag }}"
+          echo "Deploying $IMAGE to ismd-tool-fuseki-prod"
+
           az containerapp update \
-            --name ismd-tool-backend-prod \
+            --name ismd-tool-fuseki-prod \
             --resource-group ismd-tool-prod \
             --image "$IMAGE" \
             --output table
-          
+
           echo "✅ Deployment complete"
-      
+
       - name: Update Deployment Status - Success
         if: success()
         uses: chrnorm/deployment-status@v2
@@ -343,7 +291,7 @@ jobs:
           deployment-id: ${{ steps.create_deployment.outputs.deployment_id }}
           state: "success"
           description: "Deployed successfully"
-      
+
       - name: Update Deployment Status - Failure
         if: failure()
         uses: chrnorm/deployment-status@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,65 @@
+name: Trivy Image Scan
+
+# Calls the reusable Trivy scanner owned by infrastructure repo.
+# Findings appear in this repo's Security -> Code scanning tab.
+#
+# Image taxonomy (see reusable-docker-build.yml):
+#   dev branch  -> ghcr.io/datagov-cz/ismd-tool-backend-dev:latest    (deployed to dev env)
+#   main branch -> ghcr.io/datagov-cz/ismd-tool-backend:latest        (deployed to test + prod)
+#
+# Triggers:
+#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Docker on Main" completes -> scan main image
+#   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
+#   * Manual dispatch                        -> pick dev/main/both
+
+on:
+  workflow_run:
+    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    types: [completed]
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      image_variant:
+        description: 'Which image(s) to scan'
+        required: true
+        type: choice
+        options: [dev, main, both]
+        default: both
+      soft_fail:
+        description: 'Non-blocking: workflow stays green even if findings exist (default). Uncheck to make scan blocking for this run.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  scan-dev:
+    name: Scan dev image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-tool-backend-dev:latest
+      # Default non-blocking. Only a manual dispatch with soft_fail=false flips it.
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit
+
+  scan-main:
+    name: Scan main image
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Main' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'main' || inputs.image_variant == 'both'))
+    uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev
+    with:
+      image_ref: ghcr.io/datagov-cz/ismd-tool-backend:latest
+      soft_fail: ${{ !(github.event_name == 'workflow_dispatch' && inputs.soft_fail == false) }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Promotes `.github/` workflow changes from `dev` to `main`, including the cross-repo Maven package access fix (`PACKAGES_READ_TOKEN`) that unblocks CI on `main`. App code on `dev` stays on `dev`.

## What's included
- **New**: `dependabot.yml` (private registry access for `ismd-validator-common`; only takes effect on default branch)
- **New**: `codeql.yml`, `trivy.yml` (security scans)
- **New**: `build-fuseki.yml`, `trigger-fuseki-deployment.yml`, `check-coverage.yml`
- **CI Maven package fix**: `reusable-test.yml` and `reusable-docker-build.yml` swap `GITHUB_TOKEN` → `PACKAGES_READ_TOKEN` for resolving `ismd-validator-common`
- **Action version + pin alignment**: `code-quality-report.yml`, `pr.yml`, `push-to-dev.yml`, `push-to-main.yml`, `release-version.yml`, `trigger-deployment.yml`

## Pre-merge verification (already done)
- ✅ `PACKAGES_READ_TOKEN` is set as repo secret
- ✅ `PACKAGES_READ_TOKEN` is set as Dependabot secret