### PR TITLE
fix(fuseki): bake assembler config into the image

### DIFF
--- a/.github/workflows/build-fuseki.yml
+++ b/.github/workflows/build-fuseki.yml
@@ -83,7 +83,7 @@ jobs:
             -f docker/fuseki/Dockerfile \
             -t "${IMAGE_NAME}:${VERSION}" \
             -t "${IMAGE_NAME}:latest" \
-            docker/fuseki
+            .
 
           docker push "${IMAGE_NAME}:${VERSION}"
           docker push "${IMAGE_NAME}:latest"

--- a/docker/fuseki/Dockerfile
+++ b/docker/fuseki/Dockerfile
@@ -37,6 +37,11 @@ RUN mkdir -p ${FUSEKI_HOME}/run/databases/tdb2/ismd-tool-dataset \
 RUN addgroup -S fuseki && adduser -S fuseki -G fuseki && \
     chown -R fuseki:fuseki ${FUSEKI_HOME}/run
 
+# Bake in the Fuseki assembler config so auto-discovery loads it on startup.
+# Without this, fuseki-server starts with no datasets configured and the
+# default /ds endpoint behaves read-only.
+COPY --chown=fuseki:fuseki fuseki-config.ttl ${FUSEKI_HOME}/run/configuration/config.ttl
+
 ENV FUSEKI_HOME=${FUSEKI_HOME}
 ENV JENA_HOME=${JENA_HOME}
 


### PR DESCRIPTION
The Fuseki Dockerfile created an empty run/configuration/ directory but never copied fuseki-config.ttl into it, so fuseki-server started with no datasets configured and fell back to a default read-only /ds endpoint. Writes against the deployed service returned 405 "Read-only".
- Copy fuseki-config.ttl to /opt/fuseki/run/configuration/ so auto-discovery loads it on startup
- Build context changed to repo root so the COPY can reach fuseki-config.ttl, which lives at the top level (still used by docker-compose for local dev) After this, the dataset is exposed under /ismd-tool-dataset with sparql/query/update/upload/data endpoints and the Lucene text index defined in the assembler.