### PR TITLE
chore(docker): modernize build pipeline and switch fuseki to GHCR pull

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Build artifacts
+target/
+*.class
+
+# IDE / editor
+.idea/
+.vscode/
+*.iml
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Docker / compose (not needed inside the build context)
+docker-compose*.yml
+Dockerfile
+.dockerignore
+docker/
+
+# Local env / secrets
+.env
+.env.*
+!.env.example
+
+# Misc
+*.md
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,44 +2,46 @@
 FROM eclipse-temurin:17-jdk-alpine AS builder
 WORKDIR /app
 
-# Install bash
 RUN apk add --no-cache bash
 
-# Copy tool-backend source
-COPY . .
+ARG GITHUB_ACTOR=""
 
-# Make mvnw executable
+# Copy build manifests first so dependency layers cache across source changes.
+COPY mvnw pom.xml ./
+COPY .mvn .mvn
 RUN chmod +x mvnw
 
-# Build arguments
-ARG GITHUB_TOKEN
-ARG GITHUB_ACTOR
+# Maven settings.xml references the token via ${env.GITHUB_TOKEN}, which is
+# resolved at Maven runtime from the secret mount below — never embedded
+# in the image or build log.
+RUN mkdir -p /root/.m2 && \
+    printf '%s\n' \
+      '<settings><servers><server>' \
+      '<id>github</id>' \
+      "<username>${GITHUB_ACTOR}</username>" \
+      '<password>${env.GITHUB_TOKEN}</password>' \
+      '</server></servers></settings>' \
+      > /root/.m2/settings.xml
 
-# Configure Maven to authenticate with GitHub Packages (if needed)
-RUN if [ -n "${GITHUB_TOKEN}" ] && [ -n "${GITHUB_ACTOR}" ]; then \
-      echo "Configuring Maven for GitHub Packages..."; \
-      mkdir -p ~/.m2 && \
-      echo '<settings><servers><server>' > ~/.m2/settings.xml && \
-      echo '<id>github</id>' >> ~/.m2/settings.xml && \
-      echo "<username>${GITHUB_ACTOR}</username>" >> ~/.m2/settings.xml && \
-      echo "<password>${GITHUB_TOKEN}</password>" >> ~/.m2/settings.xml && \
-      echo '</server></servers></settings>' >> ~/.m2/settings.xml; \
-    fi
+# Copy source after manifests so source changes don't bust the dep cache layer.
+COPY src src
 
-# Build the application
-RUN ./mvnw clean install -DskipTests
+# Build with:
+#   - persistent BuildKit cache for /root/.m2/repository
+#     (dependencies are downloaded once, reused across builds)
+#   - GITHUB_TOKEN exposed only as a secret env var inside this RUN
+RUN --mount=type=cache,target=/root/.m2/repository \
+    --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    ./mvnw clean install -DskipTests -B
 
 ### Runtime stage
 FROM eclipse-temurin:17-jre-alpine AS runtime
 WORKDIR /app
 
-# Set environment variables
 ENV SPRING_PROFILES_ACTIVE=production
 
-# Copy the built JAR
 COPY --from=builder /app/target/ismd-tool-backend-*.jar app.jar
 
-# Add labels
 LABEL org.opencontainers.image.title="ISMD Tool Backend"
 
 EXPOSE 8080

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -7,6 +7,8 @@
 #                  --profile full-backend up --build
 #
 # Requires GITHUB_TOKEN + GITHUB_ACTOR for Maven access to GitHub Packages.
+# GITHUB_TOKEN is passed as a BuildKit secret (not a build arg) so it does
+# not leak into image history or build logs.
 # ==============================================
 
 services:
@@ -14,7 +16,15 @@ services:
     image: ismd-tool-backend:local
     pull_policy: never
     build:
-      context: .
+      # Default `.` works when running from this directory directly.
+      # When composed from ismd-infrastructure via `-f`, set TOOL_BACKEND_PATH
+      # to the path of this repo (e.g. ../ismd-tool-backend).
+      context: ${TOOL_BACKEND_PATH:-.}
       args:
-        GITHUB_TOKEN: ${GITHUB_TOKEN}
         GITHUB_ACTOR: ${GITHUB_ACTOR}
+      secrets:
+        - github_token
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN

--- a/docker-compose.fuseki-build.yml
+++ b/docker-compose.fuseki-build.yml
@@ -1,0 +1,22 @@
+# ==============================================
+# ISMD Tool Fuseki - Build Override
+# ==============================================
+# Use with the base file to build the fuseki image from local source instead
+# of pulling the pre-built image from GHCR. Only needed when modifying the
+# Fuseki Dockerfile or fuseki-config.ttl.
+#
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.fuseki-build.yml \
+#                  --profile full-backend up --build
+#
+# When composed from ismd-infrastructure via `-f`, set TOOL_BACKEND_PATH
+# to the path of this repo (e.g. ../ismd-tool-backend).
+# ==============================================
+
+services:
+  fuseki:
+    image: ismd-tool-fuseki:local
+    pull_policy: never
+    build:
+      context: ${TOOL_BACKEND_PATH:-.}
+      dockerfile: docker/fuseki/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,10 @@ services:
     restart: unless-stopped
 
   fuseki:
-    build:
-      context: ./docker/fuseki
+    # Default: pull pre-built image from GHCR (~10s vs ~15min local build).
+    # To build from local source, use docker-compose.fuseki-build.yml override.
+    image: ${TOOL_FUSEKI_IMAGE:-ghcr.io/datagov-cz/ismd-tool-fuseki-dev:latest}
+    pull_policy: ${TOOL_FUSEKI_PULL_POLICY:-missing}
     # Bind to loopback only: Fuseki ships without authentication in this
     # compose setup (no shiro.ini), so its management API and SPARQL
     # endpoints would be fully open. 0.0.0.0 would expose the unauth

--- a/docker-instructions.md
+++ b/docker-instructions.md
@@ -26,28 +26,53 @@ Run everything in Docker — no JDK required.
    ```bash
    cp .env.example .env
    ```
-   Required values:
-   - `GITHUB_TOKEN` — GitHub PAT with `read:packages` scope (generate at https://github.com/settings/tokens)
-   - `GITHUB_ACTOR` — your GitHub username
+   Required for the Keycloak login flow:
    - `KEYCLOAK_CLIENT_SECRET` — client secret from the local Keycloak admin UI (`http://localhost:8080`, realm `ismd`, client `ismd-backend`, Credentials tab)
 
-2. **First run builds the backend image from source** (~1-2 min).
+   Required **only if you build the backend image locally** (see below):
+   - `GITHUB_TOKEN` — GitHub PAT with `read:packages` scope (generate at https://github.com/settings/tokens)
+   - `GITHUB_ACTOR` — your GitHub username
 
-#### Start
+2. **By default, all images are pulled from GHCR** (backend, fuseki, etc.).
+   First run pulls ~a few hundred MB; subsequent runs are instant.
+
+#### Start (default — pull from GHCR)
 
 **Windows (PowerShell):**
 ```powershell
 .\full-backend.ps1 up
-# Force rebuild after code changes:
-.\full-backend.ps1 up --build
 ```
 
 **Linux/macOS:**
 ```bash
 chmod +x full-backend.sh
 ./full-backend.sh up
-# Force rebuild after code changes:
-./full-backend.sh up --build
+```
+
+#### Build the backend image from local source
+
+Use the build override when working on backend code:
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.build.yml \
+               --profile full-backend up --build
+```
+
+Builds the backend, pulls everything else (postgres, keycloak, fuseki).
+The `GITHUB_TOKEN` is passed to the build via a BuildKit secret mount — it
+will not appear in the build log or image history. The Maven dependency
+cache is persisted across builds via a BuildKit cache mount, so the second
+build is much faster than the first.
+
+#### Rebuild fuseki from local source (rare)
+
+Only needed when modifying the Fuseki Dockerfile or `fuseki-config.ttl`:
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.fuseki-build.yml \
+               --profile full-backend up --build
 ```
 
 #### Check it's running


### PR DESCRIPTION
- fuseki: pull from GHCR by default; local builds gated behind new docker-compose.fuseki-build.yml override (~15min → ~10s cold start). Also fix local-build context to match CI (broken since a11f691).
- backend Dockerfile: pass GITHUB_TOKEN as BuildKit secret (was leaking into image history + build logs), add Maven cache mount (warm builds ~170s → ~30-60s), reorder COPYs for layer caching, add .dockerignore.
- Parametrize build context via TOOL_BACKEND_PATH for cross-repo use from ismd-infrastructure. Default `.` keeps standalone use unchanged.
- Rewrite docker-instructions.md Option B for pull-by-default flow.