### PR TITLE
Feat/issue 158

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClient.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.client;
 
 import com.dia.ismdtoolbackend.models.eli.FragmentModel;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
 import com.dia.ismdtoolbackend.models.eli.LawModel;
 import com.dia.ismdtoolbackend.models.eli.LawVersionModel;
 import com.dia.ismdtoolbackend.query.EsbirkaSPARQLQuery;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 @Component
@@ -57,6 +59,20 @@ public class EsbirkaSparqlClient {
         return executeSelect("fragment tree",
                 EsbirkaSPARQLQuery.buildFragmentTreeQuery(versionIri),
                 this::mapFragmentRows);
+    }
+
+    /**
+     * Resolve a single fragment IRI to its display citation + parent version
+     * end-of-validity date + is-latest flag. Returns empty Optional when SPARQL
+     * returns zero rows (fragment not in dataset). Propagates
+     * {@link com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException}
+     * on connection failures via the executor.
+     */
+    public Optional<FragmentResolutionModel> resolveFragment(String fragmentIri, String versionIri, String lawIri) {
+        List<FragmentResolutionModel> rows = executeSelect("fragment resolution",
+                EsbirkaSPARQLQuery.buildResolveFragmentQuery(fragmentIri, versionIri, lawIri),
+                this::mapResolutionRows);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
     }
 
     private <T> List<T> executeSelect(String label, String query, Function<ResultSet, List<T>> mapper) {
@@ -120,6 +136,18 @@ public class EsbirkaSparqlClient {
             }
             String kind = parseKindFromIri(iri);
             out.add(new FragmentModel(iri, parent, citation, kind, order));
+        }
+        return out;
+    }
+
+    private List<FragmentResolutionModel> mapResolutionRows(ResultSet rs) {
+        List<FragmentResolutionModel> out = new ArrayList<>();
+        while (rs.hasNext()) {
+            QuerySolution sol = rs.next();
+            String citation = SparqlSolutions.literalString(sol, "citace");
+            LocalDate validUntil = SparqlSolutions.literalDate(sol, "ucinnostDo");
+            boolean isLatest = SparqlSolutions.literalBool(sol, "isLatest");
+            out.add(new FragmentResolutionModel(citation, validUntil, isLatest));
         }
         return out;
     }

--- a/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
@@ -7,28 +7,52 @@ import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Caffeine-backed cache for read-only e-Sbírka catalogue endpoints.
- * 60-minute TTL on {@code esbirkaLawSearch} and {@code esbirkaLawVersions};
- * fragments are not cached (large payload, rarely re-requested per session).
+ * Caffeine-backed caches for read-only e-Sbírka SPARQL operations.
+ *
+ * <p>Three caches with distinct lifetimes:
+ * <ul>
+ *   <li>{@code esbirkaLawSearch} — law-search results, 60 min TTL (catalogue evolves daily).</li>
+ *   <li>{@code esbirkaLawVersions} — version lists per law, 60 min TTL.</li>
+ *   <li>{@code esbirkaFragmentResolution} — fragment citation + version metadata,
+ *       24 h TTL (fragments are immutable; only is-latest can shift when a new
+ *       version is published).</li>
+ * </ul>
+ *
+ * <p>Per-cache specs require {@code registerCustomCache} rather than the shared
+ * {@code setCaffeine}.
  */
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
-    static final long ESBIRKA_TTL_MINUTES = 60;
-    static final long ESBIRKA_MAX_ENTRIES = 1_000;
+    static final long ESBIRKA_CATALOGUE_TTL_MINUTES = 60;
+    static final long ESBIRKA_CATALOGUE_MAX_ENTRIES = 1_000;
+
+    static final long ESBIRKA_RESOLUTION_TTL_HOURS = 24;
+    static final long ESBIRKA_RESOLUTION_MAX_ENTRIES = 5_000;
 
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager mgr = new CaffeineCacheManager();
-        mgr.setCacheNames(List.of("esbirkaLawSearch", "esbirkaLawVersions"));
-        mgr.setCaffeine(Caffeine.newBuilder()
-                .expireAfterWrite(ESBIRKA_TTL_MINUTES, TimeUnit.MINUTES)
-                .maximumSize(ESBIRKA_MAX_ENTRIES));
+
+        mgr.registerCustomCache("esbirkaLawSearch", Caffeine.newBuilder()
+                .expireAfterWrite(ESBIRKA_CATALOGUE_TTL_MINUTES, TimeUnit.MINUTES)
+                .maximumSize(ESBIRKA_CATALOGUE_MAX_ENTRIES)
+                .build());
+
+        mgr.registerCustomCache("esbirkaLawVersions", Caffeine.newBuilder()
+                .expireAfterWrite(ESBIRKA_CATALOGUE_TTL_MINUTES, TimeUnit.MINUTES)
+                .maximumSize(ESBIRKA_CATALOGUE_MAX_ENTRIES)
+                .build());
+
+        mgr.registerCustomCache("esbirkaFragmentResolution", Caffeine.newBuilder()
+                .expireAfterWrite(ESBIRKA_RESOLUTION_TTL_HOURS, TimeUnit.HOURS)
+                .maximumSize(ESBIRKA_RESOLUTION_MAX_ENTRIES)
+                .build());
+
         return mgr;
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -207,6 +207,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/search").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/versions").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/fragments").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/eli/resolve").authenticated()
                         .anyRequest().denyAll()
                 )
                 // Disable CSRF for stateless JWT API

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -105,7 +105,6 @@ public class SecurityConfig {
                                 response.setContentType("application/json");
                                 response.getWriter().write(
                                         "{\"success\":false,\"message\":\"Invalid or expired authentication token\"}");
-                                return;
                             }
                             // No token — allow anonymous access to proceed
                         })
@@ -149,6 +148,7 @@ public class SecurityConfig {
                         "/api/nkd/ontology/all",
                         "/api/nkd/ontology/download",
                         "/api/nkd/concept/detail",
+                        "/api/eli/resolve",
                         "/v3/api-docs/**",
                         "/swagger-ui/**",
                         "/swagger-ui.html"
@@ -207,7 +207,6 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/search").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/versions").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/eli/law/fragments").authenticated()
-                        .requestMatchers(HttpMethod.GET, "/api/eli/resolve").authenticated()
                         .anyRequest().denyAll()
                 )
                 // Disable CSRF for stateless JWT API

--- a/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
@@ -28,7 +28,6 @@ import static com.dia.constants.FormatConstants.Converter.LOG_REQUEST_ID;
 @RequestMapping("/api/eli")
 @RequiredArgsConstructor
 @Slf4j
-@PreAuthorize("isAuthenticated()")
 public class EsbirkaController {
 
     private final EsbirkaService esbirkaService;
@@ -40,6 +39,7 @@ public class EsbirkaController {
                     "Při prázdném dotazu se vrací nejnovější akty (rok desc, číslo asc)."
     )
     @GetMapping("/law/search")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponseDto<List<LawDto>>> searchLaws(
             @RequestParam(required = false) String q,
             @RequestParam(required = false) Integer limit) {
@@ -62,6 +62,7 @@ public class EsbirkaController {
                     "pole \"latest\" označuje aktuálně poslední znění."
     )
     @GetMapping("/law/versions")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponseDto<List<LawVersionDto>>> getVersions(
             @RequestParam String lawIri) {
         String requestId = UUID.randomUUID().toString();
@@ -83,6 +84,7 @@ public class EsbirkaController {
                     "stromová struktura sestavena na serveru)."
     )
     @GetMapping("/law/fragments")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponseDto<List<FragmentDto>>> getFragments(
             @RequestParam String versionIri) {
         String requestId = UUID.randomUUID().toString();
@@ -106,7 +108,6 @@ public class EsbirkaController {
                     "Public endpoint — used by concept detail rendering for unauthenticated viewers."
     )
     @GetMapping("/resolve")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<ApiResponseDto<ResolvedLegalSourceDto>> resolveLegalSource(
             @RequestParam String iri) {
         String requestId = UUID.randomUUID().toString();

--- a/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
@@ -102,9 +102,11 @@ public class EsbirkaController {
             summary = "Resolve e-Sbírka ELI URL to a display object",
             description = "Parses the URL synchronously, and for fragment-level URLs " +
                     "fetches the official citation + version metadata via SPARQL (cached 24h). " +
-                    "Forgiving: invalid URLs return HTTP 200 with enrichmentStatus=INVALID_IRI."
+                    "Forgiving: invalid URLs return HTTP 200 with enrichmentStatus=INVALID_IRI. " +
+                    "Public endpoint — used by concept detail rendering for unauthenticated viewers."
     )
     @GetMapping("/resolve")
+    @PreAuthorize("permitAll()")
     public ResponseEntity<ApiResponseDto<ResolvedLegalSourceDto>> resolveLegalSource(
             @RequestParam String iri) {
         String requestId = UUID.randomUUID().toString();
@@ -113,7 +115,7 @@ public class EsbirkaController {
             log.info("e-Sbírka resolve, iri: {}", iri);
             ResolvedLegalSourceDto dto = esbirkaService.resolveLegalSource(iri);
             return ResponseEntity.ok(ApiResponseDto.success(dto,
-                    "Resolve dokončen."));
+                    "Resolve finished"));
         } finally {
             MDC.remove(LOG_REQUEST_ID);
         }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
@@ -5,6 +5,7 @@ import com.dia.ismdtoolbackend.controller.dto.ApiResponseDto;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
 import com.dia.ismdtoolbackend.service.EsbirkaService;
 import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
 import io.swagger.v3.oas.annotations.Operation;
@@ -92,6 +93,27 @@ public class EsbirkaController {
             List<FragmentDto> results = esbirkaService.getFragments(versionIri);
             return ResponseEntity.ok(ApiResponseDto.success(results,
                     "Strom fragmentů úspěšně načten."));
+        } finally {
+            MDC.remove(LOG_REQUEST_ID);
+        }
+    }
+
+    @Operation(
+            summary = "Resolve e-Sbírka ELI URL to a display object",
+            description = "Parses the URL synchronously, and for fragment-level URLs " +
+                    "fetches the official citation + version metadata via SPARQL (cached 24h). " +
+                    "Forgiving: invalid URLs return HTTP 200 with enrichmentStatus=INVALID_IRI."
+    )
+    @GetMapping("/resolve")
+    public ResponseEntity<ApiResponseDto<ResolvedLegalSourceDto>> resolveLegalSource(
+            @RequestParam String iri) {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(LOG_REQUEST_ID, requestId);
+        try {
+            log.info("e-Sbírka resolve, iri: {}", iri);
+            ResolvedLegalSourceDto dto = esbirkaService.resolveLegalSource(iri);
+            return ResponseEntity.ok(ApiResponseDto.success(dto,
+                    "Resolve dokončen."));
         } finally {
             MDC.remove(LOG_REQUEST_ID);
         }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolvedLegalSourceDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolvedLegalSourceDto.java
@@ -1,0 +1,48 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResolvedLegalSourceDto {
+
+    private String originalUrl;
+    private String eliPath;
+    private String domain;
+    private ParsedEli.Level level;
+    private String lawIri;
+    private String versionIri;
+    private String fragmentIri;
+    private String lawNumber;
+    private Integer lawYear;
+    private String sbirkaCode;
+    private LocalDate versionDate;
+    private List<ParsedEli.FragmentSegment> fragmentSegments;
+    private String displayLabel;
+
+    private String fragmentCitation;
+    private LocalDate versionValidUntil;
+    private Boolean isLatestVersion;
+
+    private EnrichmentStatus enrichmentStatus;
+
+    public enum EnrichmentStatus {
+        OK,
+        PENDING,
+        UNAVAILABLE,
+        NOT_FOUND,
+        SKIPPED_NON_FRAGMENT,
+        INVALID_IRI
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/OntologyDetailModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/OntologyDetailModel.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.models;
 
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
 import com.dia.ismdtoolbackend.models.concept.ConceptPropertiesModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptRelationshipsModel;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -93,6 +94,12 @@ public class OntologyDetailModel {
 
         @JsonProperty("související-ustanovení-právního-předpisu")
         private List<String> relatedLegalSources;
+
+        @JsonProperty("definující-ustanovení-právního-předpisu-resolved")
+        private List<ResolvedLegalSourceDto> definingLegalSourcesResolved;
+
+        @JsonProperty("související-ustanovení-právního-předpisu-resolved")
+        private List<ResolvedLegalSourceDto> relatedLegalSourcesResolved;
 
         @JsonProperty("definující-nelegislativní-zdroj")
         private List<Map<String, Object>> definingNonLegalSources;

--- a/src/main/java/com/dia/ismdtoolbackend/models/eli/FragmentResolutionModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/eli/FragmentResolutionModel.java
@@ -1,0 +1,10 @@
+package com.dia.ismdtoolbackend.models.eli;
+
+import java.time.LocalDate;
+
+public record FragmentResolutionModel(
+        String citation,
+        LocalDate versionValidUntil,
+        boolean isLatest
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQuery.java
+++ b/src/main/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQuery.java
@@ -109,5 +109,36 @@ public class EsbirkaSPARQLQuery {
         return pss.toString();
     }
 
+    /**
+     * Resolve a single fragment IRI to its display citation + parent version's
+     * end-of-validity date + is-latest flag. Caller passes pre-derived parent
+     * versionIri and lawIri (from {@link com.dia.ismdtoolbackend.utility.eli.EsbirkaEliParser})
+     * so we avoid a {@code má-předka+} property-path traversal.
+     *
+     * <p>All three IRIs MUST be canonical-host IRIs and pre-validated via
+     * {@link com.dia.ismdtoolbackend.utility.security.SparqlIriValidator#isEsbirkaEliIri(String)}.
+     */
+    public static String buildResolveFragmentQuery(String fragmentIri, String versionIri, String lawIri) {
+        // Note: we cannot bind inputZneni via PSS because we also need to compare it
+        // structurally inside the SELECT projection (BIND). Instead, the version IRI
+        // is inlined as a VALUES row, leaving ?zneni as a real variable usable in
+        // (?zneni = ?posledniZneni) AS ?isLatest.
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.setCommandText("""
+                SELECT ?citace ?ucinnostDo ((?zneni = ?posledniZneni) AS ?isLatest)
+                WHERE {
+                  VALUES ?zneni { ?inputZneni }
+                  ?inputFragment <%1$scitace-označení-fragmentu-znění-právního-aktu> ?citace .
+                  ?inputAkt <%1$smá-poslední-znění> ?posledniZneni .
+                  OPTIONAL { ?zneni <%1$súčinnost-znění-do> ?ucinnostDo }
+                }
+                LIMIT 1
+                """.formatted(NS));
+        pss.setIri("inputFragment", fragmentIri);
+        pss.setIri("inputZneni", versionIri);
+        pss.setIri("inputAkt", lawIri);
+        return pss.toString();
+    }
+
     private EsbirkaSPARQLQuery() {}
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/EsbirkaService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/EsbirkaService.java
@@ -3,6 +3,7 @@ package com.dia.ismdtoolbackend.service;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
 
 import java.util.List;
 
@@ -13,4 +14,6 @@ public interface EsbirkaService {
     List<LawVersionDto> getVersions(String lawIri);
 
     List<FragmentDto> getFragments(String versionIri);
+
+    ResolvedLegalSourceDto resolveLegalSource(String url);
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCache.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCache.java
@@ -2,7 +2,10 @@ package com.dia.ismdtoolbackend.service.impl;
 
 import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
 import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
+import com.dia.ismdtoolbackend.utility.sparql.SparqlCircuitBreaker;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +21,10 @@ import java.util.Optional;
  * to a single cache entry. {@code versionIri}/{@code lawIri} are not part of
  * the key — they're derivable from {@code fragmentIri} and serve only as SPARQL
  * inputs.
+ *
+ * <p>A {@link SparqlCircuitBreaker} guards the underlying SPARQL call so a
+ * sustained e-Sbírka outage fast-fails after a few failures rather than letting
+ * every cache miss wait on the 10s SPARQL timeout.
  */
 @Component
 @RequiredArgsConstructor
@@ -25,8 +32,22 @@ public class EsbirkaFragmentResolutionCache {
 
     private final EsbirkaSparqlClient client;
 
+    @Value("${esbirka.resolve.circuit-breaker.failure-threshold:5}")
+    private int failureThreshold;
+
+    @Value("${esbirka.resolve.circuit-breaker.cooldown-ms:30000}")
+    private long cooldownMillis;
+
+    private SparqlCircuitBreaker breaker;
+
+    @PostConstruct
+    void initBreaker() {
+        this.breaker = new SparqlCircuitBreaker(
+                EsbirkaSparqlClient.ESBIRKA_LABEL, failureThreshold, cooldownMillis);
+    }
+
     @Cacheable(cacheNames = "esbirkaFragmentResolution", key = "#fragmentIri")
     public Optional<FragmentResolutionModel> fetch(String fragmentIri, String versionIri, String lawIri) {
-        return client.resolveFragment(fragmentIri, versionIri, lawIri);
+        return breaker.call(() -> client.resolveFragment(fragmentIri, versionIri, lawIri));
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCache.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCache.java
@@ -1,0 +1,32 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Caching wrapper around {@link EsbirkaSparqlClient#resolveFragment(String, String, String)}.
+ * Extracted to a dedicated component so Spring's caching proxy intercepts the
+ * call — {@code @Cacheable} on a method called from the same bean (e.g. inside
+ * {@code EsbirkaServiceImpl}) would be bypassed.
+ *
+ * <p>Cache key is the canonical fragment IRI so legacy-host duplicates collapse
+ * to a single cache entry. {@code versionIri}/{@code lawIri} are not part of
+ * the key — they're derivable from {@code fragmentIri} and serve only as SPARQL
+ * inputs.
+ */
+@Component
+@RequiredArgsConstructor
+public class EsbirkaFragmentResolutionCache {
+
+    private final EsbirkaSparqlClient client;
+
+    @Cacheable(cacheNames = "esbirkaFragmentResolution", key = "#fragmentIri")
+    public Optional<FragmentResolutionModel> fetch(String fragmentIri, String versionIri, String lawIri) {
+        return client.resolveFragment(fragmentIri, versionIri, lawIri);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -12,6 +12,7 @@ import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
 import com.dia.ismdtoolbackend.models.eli.LawModel;
 import com.dia.ismdtoolbackend.models.eli.LawVersionModel;
 import com.dia.ismdtoolbackend.service.EsbirkaService;
+import com.dia.ismdtoolbackend.utility.eli.EsbirkaCzechCitationFormatter;
 import com.dia.ismdtoolbackend.utility.eli.EsbirkaEliParser;
 import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
 import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
@@ -20,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,8 +35,6 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     static final int MAX_FRAGMENT_DEPTH = 10;
     static final int FRAGMENT_ROW_WARN_THRESHOLD = 5_000;
     private static final String NORMA_SUFFIX = "/dokument/norma";
-
-    private static final DateTimeFormatter CZECH_DATE = DateTimeFormatter.ofPattern("d. M. yyyy");
 
     private final EsbirkaSparqlClient client;
     private final EsbirkaFragmentResolutionCache resolutionCache;
@@ -187,7 +185,7 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         }
         if (!parsed.isFragment()) {
             return baseDtoBuilder(parsed)
-                    .displayLabel(buildDisplayLabel(parsed, null))
+                    .displayLabel(EsbirkaCzechCitationFormatter.buildDisplayLabel(parsed, null))
                     .enrichmentStatus(EnrichmentStatus.SKIPPED_NON_FRAGMENT)
                     .build();
         }
@@ -200,7 +198,7 @@ public class EsbirkaServiceImpl implements EsbirkaService {
                     parsed.fragmentIri(), parsed.versionIri(), parsed.lawIri());
             if (opt.isEmpty()) {
                 return baseDtoBuilder(parsed)
-                        .displayLabel(buildDisplayLabel(parsed, null))
+                        .displayLabel(EsbirkaCzechCitationFormatter.buildDisplayLabel(parsed, null))
                         .enrichmentStatus(EnrichmentStatus.NOT_FOUND)
                         .build();
             }
@@ -209,13 +207,13 @@ public class EsbirkaServiceImpl implements EsbirkaService {
                     .fragmentCitation(m.citation())
                     .versionValidUntil(m.versionValidUntil())
                     .isLatestVersion(m.isLatest())
-                    .displayLabel(buildDisplayLabel(parsed, m.citation()))
+                    .displayLabel(EsbirkaCzechCitationFormatter.buildDisplayLabel(parsed, m.citation()))
                     .enrichmentStatus(EnrichmentStatus.OK)
                     .build();
         } catch (SparqlEndpointUnavailableException e) {
-            log.debug("e-Sbírka unavailable while resolving {}: {}", parsed.fragmentIri(), e.getMessage());
+            log.warn("e-Sbírka unavailable while resolving {}: {}", parsed.fragmentIri(), e.getMessage());
             return baseDtoBuilder(parsed)
-                    .displayLabel(buildDisplayLabel(parsed, null))
+                    .displayLabel(EsbirkaCzechCitationFormatter.buildDisplayLabel(parsed, null))
                     .enrichmentStatus(EnrichmentStatus.UNAVAILABLE)
                     .build();
         }
@@ -237,63 +235,4 @@ public class EsbirkaServiceImpl implements EsbirkaService {
                 .fragmentSegments(p.fragmentSegments());
     }
 
-    /**
-     * Build a display label from the parsed components, optionally using
-     * an authoritative SPARQL-fetched citation for the fragment portion.
-     */
-    static String buildDisplayLabel(ParsedEli p, String sparqlCitation) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Zákon č. ").append(p.lawNumber()).append("/").append(p.lawYear()).append(" Sb.");
-        if (p.isFragment()) {
-            String fragmentPart = sparqlCitation != null && !sparqlCitation.isBlank()
-                    ? sparqlCitation
-                    : buildFragmentCitationFromSegments(p.fragmentSegments());
-            if (!fragmentPart.isBlank()) {
-                sb.append(", ").append(fragmentPart);
-            }
-        }
-        if (p.versionDate() != null) {
-            sb.append(" (znění od ").append(p.versionDate().format(CZECH_DATE)).append(")");
-        }
-        return sb.toString();
-    }
-
-    /**
-     * Fallback fragment citation built purely from path segments. Used when
-     * SPARQL is unavailable, the fragment isn't in the dataset, or we skip
-     * SPARQL on principle. If a {@code par_} segment is present, structural
-     * ancestors (cast/hlava/dil/oddil) are omitted — that matches e-Sbírka's
-     * own citation format.
-     */
-    static String buildFragmentCitationFromSegments(List<ParsedEli.FragmentSegment> segments) {
-        if (segments == null || segments.isEmpty()) return "";
-        boolean hasPar = segments.stream().anyMatch(s -> "par".equals(s.kind()));
-        StringBuilder sb = new StringBuilder();
-        for (ParsedEli.FragmentSegment s : segments) {
-            if (hasPar && isStructuralAncestor(s.kind())) continue;
-            if (!sb.isEmpty()) sb.append(' ');
-            sb.append(formatSegment(s));
-        }
-        return sb.toString();
-    }
-
-    private static boolean isStructuralAncestor(String kind) {
-        return "cast".equals(kind) || "hlava".equals(kind) || "dil".equals(kind) || "oddil".equals(kind);
-    }
-
-    private static String formatSegment(ParsedEli.FragmentSegment s) {
-        return switch (s.kind()) {
-            case "cast" -> "Část " + s.number();
-            case "hlava" -> "Hlava " + s.number();
-            case "dil" -> "Díl " + s.number();
-            case "oddil" -> "Oddíl " + s.number();
-            case "par" -> "§ " + s.number();
-            case "odst" -> "odst. " + s.number();
-            case "pism" -> "písm. " + s.number() + ")";
-            case "bod" -> "bod " + s.number();
-            case "ppc" -> "ppc " + s.number();
-            case "frag" -> "frag " + s.number();
-            default -> s.kind() + " " + s.number();
-        };
-    }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -4,20 +4,28 @@ import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
 import com.dia.ismdtoolbackend.models.eli.FragmentModel;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
 import com.dia.ismdtoolbackend.models.eli.LawModel;
 import com.dia.ismdtoolbackend.models.eli.LawVersionModel;
 import com.dia.ismdtoolbackend.service.EsbirkaService;
+import com.dia.ismdtoolbackend.utility.eli.EsbirkaEliParser;
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
 import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +36,10 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     static final int FRAGMENT_ROW_WARN_THRESHOLD = 5_000;
     private static final String NORMA_SUFFIX = "/dokument/norma";
 
+    private static final DateTimeFormatter CZECH_DATE = DateTimeFormatter.ofPattern("d. M. yyyy");
+
     private final EsbirkaSparqlClient client;
+    private final EsbirkaFragmentResolutionCache resolutionCache;
 
     @Override
     @Cacheable(cacheNames = "esbirkaLawSearch", key = "T(java.util.Objects).hash(#q, #limit)")
@@ -69,7 +80,7 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     }
 
     /**
-     * Tree assembly (G7). Top-level fragments have parent = {@code <versionIri>/dokument/norma}.
+     * Tree assembly. Top-level fragments have parent = {@code <versionIri>/dokument/norma}.
      * Multi-root is supported (any number of children of the norma node).
      * Orphans (rows whose parent IRI is not in the result set and is not the norma root)
      * are dropped with a warn-log. Depth is capped at {@link #MAX_FRAGMENT_DEPTH} as a
@@ -163,5 +174,126 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         dto.setCitation(m.getCitation());
         dto.setOrder(m.getOrder());
         return dto;
+    }
+
+    @Override
+    public ResolvedLegalSourceDto resolveLegalSource(String url) {
+        ParsedEli parsed = EsbirkaEliParser.parse(url);
+        if (!parsed.isValid()) {
+            return ResolvedLegalSourceDto.builder()
+                    .originalUrl(url)
+                    .enrichmentStatus(EnrichmentStatus.INVALID_IRI)
+                    .build();
+        }
+        if (!parsed.isFragment()) {
+            return baseDtoBuilder(parsed)
+                    .displayLabel(buildDisplayLabel(parsed, null))
+                    .enrichmentStatus(EnrichmentStatus.SKIPPED_NON_FRAGMENT)
+                    .build();
+        }
+        return enrichFragment(parsed);
+    }
+
+    private ResolvedLegalSourceDto enrichFragment(ParsedEli parsed) {
+        try {
+            Optional<FragmentResolutionModel> opt = resolutionCache.fetch(
+                    parsed.fragmentIri(), parsed.versionIri(), parsed.lawIri());
+            if (opt.isEmpty()) {
+                return baseDtoBuilder(parsed)
+                        .displayLabel(buildDisplayLabel(parsed, null))
+                        .enrichmentStatus(EnrichmentStatus.NOT_FOUND)
+                        .build();
+            }
+            FragmentResolutionModel m = opt.get();
+            return baseDtoBuilder(parsed)
+                    .fragmentCitation(m.citation())
+                    .versionValidUntil(m.versionValidUntil())
+                    .isLatestVersion(m.isLatest())
+                    .displayLabel(buildDisplayLabel(parsed, m.citation()))
+                    .enrichmentStatus(EnrichmentStatus.OK)
+                    .build();
+        } catch (SparqlEndpointUnavailableException e) {
+            log.debug("e-Sbírka unavailable while resolving {}: {}", parsed.fragmentIri(), e.getMessage());
+            return baseDtoBuilder(parsed)
+                    .displayLabel(buildDisplayLabel(parsed, null))
+                    .enrichmentStatus(EnrichmentStatus.UNAVAILABLE)
+                    .build();
+        }
+    }
+
+    private static ResolvedLegalSourceDto.ResolvedLegalSourceDtoBuilder baseDtoBuilder(ParsedEli p) {
+        return ResolvedLegalSourceDto.builder()
+                .originalUrl(p.originalUrl())
+                .domain(p.domain())
+                .eliPath(p.eliPath())
+                .level(p.level())
+                .lawIri(p.lawIri())
+                .versionIri(p.versionIri())
+                .fragmentIri(p.fragmentIri())
+                .lawNumber(p.lawNumber())
+                .lawYear(p.lawYear())
+                .sbirkaCode(p.sbirkaCode())
+                .versionDate(p.versionDate())
+                .fragmentSegments(p.fragmentSegments());
+    }
+
+    /**
+     * Build a display label from the parsed components, optionally using
+     * an authoritative SPARQL-fetched citation for the fragment portion.
+     */
+    static String buildDisplayLabel(ParsedEli p, String sparqlCitation) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Zákon č. ").append(p.lawNumber()).append("/").append(p.lawYear()).append(" Sb.");
+        if (p.isFragment()) {
+            String fragmentPart = sparqlCitation != null && !sparqlCitation.isBlank()
+                    ? sparqlCitation
+                    : buildFragmentCitationFromSegments(p.fragmentSegments());
+            if (!fragmentPart.isBlank()) {
+                sb.append(", ").append(fragmentPart);
+            }
+        }
+        if (p.versionDate() != null) {
+            sb.append(" (znění od ").append(p.versionDate().format(CZECH_DATE)).append(")");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Fallback fragment citation built purely from path segments. Used when
+     * SPARQL is unavailable, the fragment isn't in the dataset, or we skip
+     * SPARQL on principle. If a {@code par_} segment is present, structural
+     * ancestors (cast/hlava/dil/oddil) are omitted — that matches e-Sbírka's
+     * own citation format.
+     */
+    static String buildFragmentCitationFromSegments(List<ParsedEli.FragmentSegment> segments) {
+        if (segments == null || segments.isEmpty()) return "";
+        boolean hasPar = segments.stream().anyMatch(s -> "par".equals(s.kind()));
+        StringBuilder sb = new StringBuilder();
+        for (ParsedEli.FragmentSegment s : segments) {
+            if (hasPar && isStructuralAncestor(s.kind())) continue;
+            if (!sb.isEmpty()) sb.append(' ');
+            sb.append(formatSegment(s));
+        }
+        return sb.toString();
+    }
+
+    private static boolean isStructuralAncestor(String kind) {
+        return "cast".equals(kind) || "hlava".equals(kind) || "dil".equals(kind) || "oddil".equals(kind);
+    }
+
+    private static String formatSegment(ParsedEli.FragmentSegment s) {
+        return switch (s.kind()) {
+            case "cast" -> "Část " + s.number();
+            case "hlava" -> "Hlava " + s.number();
+            case "dil" -> "Díl " + s.number();
+            case "oddil" -> "Oddíl " + s.number();
+            case "par" -> "§ " + s.number();
+            case "odst" -> "odst. " + s.number();
+            case "pism" -> "písm. " + s.number() + ")";
+            case "bod" -> "bod " + s.number();
+            case "ppc" -> "ppc " + s.number();
+            case "frag" -> "frag " + s.number();
+            default -> s.kind() + " " + s.number();
+        };
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
@@ -1,10 +1,14 @@
 package com.dia.ismdtoolbackend.utility.detail;
 
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptPropertiesModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptRelationshipsModel;
 import com.dia.ismdtoolbackend.repository.ConceptMetadataRepository;
+import com.dia.ismdtoolbackend.utility.eli.EsbirkaEliParser;
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
 import com.dia.ismdtoolbackend.utility.exporter.json.ConceptData;
 import com.dia.ismdtoolbackend.utility.exporter.json.ConceptProcessor;
 import com.dia.ismdtoolbackend.utility.exporter.json.ModelAnalyzer;
@@ -303,6 +307,10 @@ public class OntologyDetailExtractor {
                 .broaderProperties((List<String>) conceptMap.get(NADRAZENA_VLASTNOST))
                 .definingLegalSources((List<String>) conceptMap.get(DEFINUJICI_USTANOVENI_PRAVNIHO_PREDPISU))
                 .relatedLegalSources((List<String>) conceptMap.get(SOUVISEJICI_USTANOVENI_PRAVNIHO_PREDPISU))
+                .definingLegalSourcesResolved(buildResolvedSources(
+                        (List<String>) conceptMap.get(DEFINUJICI_USTANOVENI_PRAVNIHO_PREDPISU)))
+                .relatedLegalSourcesResolved(buildResolvedSources(
+                        (List<String>) conceptMap.get(SOUVISEJICI_USTANOVENI_PRAVNIHO_PREDPISU)))
                 .definingNonLegalSources((List<Map<String, Object>>) conceptMap.get(DEFINUJICI_NELEGISLATIVNI_ZDROJ))
                 .relatedNonLegalSources((List<Map<String, Object>>) conceptMap.get(SOUVISEJICI_NELEGISLATIVNI_ZDROJ))
                 .sharingMethods((List<String>) conceptMap.get(ZPUSOBY_SDILENI_ALT))
@@ -364,5 +372,48 @@ public class OntologyDetailExtractor {
         }
 
         return descriptionMap;
+    }
+
+    /**
+     * Build parse-only resolved-source DTOs for the concept-detail response.
+     * Returns {@code null} when the input is null/empty so {@code @JsonInclude(NON_NULL)}
+     * omits the field. Never calls SPARQL — fragment URLs are flagged
+     * {@code PENDING} for the FE to enrich via {@code /api/eli/resolve}.
+     */
+    static List<ResolvedLegalSourceDto> buildResolvedSources(List<String> urls) {
+        if (urls == null || urls.isEmpty()) return null;
+        List<ResolvedLegalSourceDto> out = new ArrayList<>(urls.size());
+        for (String url : urls) {
+            out.add(parseUrlToPendingDto(url));
+        }
+        return out;
+    }
+
+    private static ResolvedLegalSourceDto parseUrlToPendingDto(String url) {
+        ParsedEli parsed = EsbirkaEliParser.parse(url);
+        if (!parsed.isValid()) {
+            return ResolvedLegalSourceDto.builder()
+                    .originalUrl(url)
+                    .enrichmentStatus(EnrichmentStatus.INVALID_IRI)
+                    .build();
+        }
+        EnrichmentStatus status = parsed.isFragment()
+                ? EnrichmentStatus.PENDING
+                : EnrichmentStatus.SKIPPED_NON_FRAGMENT;
+        return ResolvedLegalSourceDto.builder()
+                .originalUrl(url)
+                .domain(parsed.domain())
+                .eliPath(parsed.eliPath())
+                .level(parsed.level())
+                .lawIri(parsed.lawIri())
+                .versionIri(parsed.versionIri())
+                .fragmentIri(parsed.fragmentIri())
+                .lawNumber(parsed.lawNumber())
+                .lawYear(parsed.lawYear())
+                .sbirkaCode(parsed.sbirkaCode())
+                .versionDate(parsed.versionDate())
+                .fragmentSegments(parsed.fragmentSegments())
+                .enrichmentStatus(status)
+                .build();
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
@@ -7,6 +7,7 @@ import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptPropertiesModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptRelationshipsModel;
 import com.dia.ismdtoolbackend.repository.ConceptMetadataRepository;
+import com.dia.ismdtoolbackend.utility.eli.EsbirkaCzechCitationFormatter;
 import com.dia.ismdtoolbackend.utility.eli.EsbirkaEliParser;
 import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
 import com.dia.ismdtoolbackend.utility.exporter.json.ConceptData;
@@ -413,6 +414,7 @@ public class OntologyDetailExtractor {
                 .sbirkaCode(parsed.sbirkaCode())
                 .versionDate(parsed.versionDate())
                 .fragmentSegments(parsed.fragmentSegments())
+                .displayLabel(EsbirkaCzechCitationFormatter.buildDisplayLabel(parsed, null))
                 .enrichmentStatus(status)
                 .build();
     }

--- a/src/main/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaCzechCitationFormatter.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaCzechCitationFormatter.java
@@ -1,0 +1,98 @@
+package com.dia.ismdtoolbackend.utility.eli;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Builds Czech display labels for {@link ParsedEli} values.
+ *
+ * <p>Three layers:
+ * <ul>
+ *   <li>{@link #buildDisplayLabel(ParsedEli, String)} — full label, optionally
+ *       overriding the fragment portion with an authoritative SPARQL-fetched
+ *       citation (e.g. {@code "§ 119 odst. 2 písm. a)"}).</li>
+ *   <li>{@link #buildFragmentCitationFromSegments(List)} — fallback citation
+ *       built purely from IRI path segments. Drops structural ancestors
+ *       (Část/Hlava/Díl/Oddíl) when a {@code par_} segment is present, matching
+ *       e-Sbírka's own citation style.</li>
+ *   <li>{@link #formatCzechDate(java.time.LocalDate)} — {@code "d. M. yyyy"}
+ *       (no leading zeroes, Czech short-date convention).</li>
+ * </ul>
+ *
+ * <p>Static utility — never throws, never allocates Spring beans.
+ */
+public final class EsbirkaCzechCitationFormatter {
+
+    private static final DateTimeFormatter CZECH_DATE = DateTimeFormatter.ofPattern("d. M. yyyy");
+
+    private EsbirkaCzechCitationFormatter() {
+    }
+
+    /**
+     * Full Czech label: {@code "Zákon č. N/YYYY Sb.[, <fragment>] [(znění od D. M. YYYY)]"}.
+     * {@code sparqlCitation} overrides the fragment portion when present and non-blank.
+     */
+    public static String buildDisplayLabel(ParsedEli p, String sparqlCitation) {
+        if (p == null || !p.isValid()) return null;
+        StringBuilder sb = new StringBuilder();
+        sb.append("Zákon č. ").append(p.lawNumber()).append("/").append(p.lawYear()).append(" Sb.");
+        if (p.isFragment()) {
+            String fragmentPart = sparqlCitation != null && !sparqlCitation.isBlank()
+                    ? sparqlCitation
+                    : buildFragmentCitationFromSegments(p.fragmentSegments());
+            if (!fragmentPart.isBlank()) {
+                sb.append(", ").append(fragmentPart);
+            }
+        }
+        if (p.versionDate() != null) {
+            sb.append(" (znění od ").append(formatCzechDate(p.versionDate())).append(")");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Fallback fragment citation built purely from path segments. Used when
+     * SPARQL is unavailable, the fragment isn't in the dataset, or the
+     * extractor is rendering a PENDING DTO.
+     *
+     * <p>If a {@code par_} segment is present, structural ancestors are
+     * omitted — that matches e-Sbírka's own citation format (e.g. e-Sbírka
+     * cites {@code "§ 119 odst. 2 písm. a)"}, not
+     * {@code "Část 1 Hlava 4 § 119 odst. 2 písm. a)"}).
+     */
+    public static String buildFragmentCitationFromSegments(List<ParsedEli.FragmentSegment> segments) {
+        if (segments == null || segments.isEmpty()) return "";
+        boolean hasPar = segments.stream().anyMatch(s -> "par".equals(s.kind()));
+        StringBuilder sb = new StringBuilder();
+        for (ParsedEli.FragmentSegment s : segments) {
+            if (hasPar && isStructuralAncestor(s.kind())) continue;
+            if (sb.length() > 0) sb.append(' ');
+            sb.append(formatSegment(s));
+        }
+        return sb.toString();
+    }
+
+    public static String formatCzechDate(java.time.LocalDate date) {
+        return date == null ? null : date.format(CZECH_DATE);
+    }
+
+    private static boolean isStructuralAncestor(String kind) {
+        return "cast".equals(kind) || "hlava".equals(kind) || "dil".equals(kind) || "oddil".equals(kind);
+    }
+
+    private static String formatSegment(ParsedEli.FragmentSegment s) {
+        return switch (s.kind()) {
+            case "cast" -> "Část " + s.number();
+            case "hlava" -> "Hlava " + s.number();
+            case "dil" -> "Díl " + s.number();
+            case "oddil" -> "Oddíl " + s.number();
+            case "par" -> "§ " + s.number();
+            case "odst" -> "odst. " + s.number();
+            case "pism" -> "písm. " + s.number() + ")";
+            case "bod" -> "bod " + s.number();
+            case "ppc" -> "ppc " + s.number();
+            case "frag" -> "frag " + s.number();
+            default -> s.kind() + " " + s.number();
+        };
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaEliParser.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaEliParser.java
@@ -1,0 +1,124 @@
+package com.dia.ismdtoolbackend.utility.eli;
+
+import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class EsbirkaEliParser {
+
+    private static final String CANONICAL_DOMAIN = "https://opendata.eselpoint.gov.cz/esel-esb";
+    private static final String CANONICAL_HOST_PREFIX = "://opendata.eselpoint.gov.cz/esel-esb/";
+    private static final String LEGACY_HOST_PREFIX = "://opendata.eselpoint.cz/esel-esb/";
+    private static final String BARE_LEGACY_HOST_PREFIX = "://eselpoint.cz/";
+
+    private static final String ELI_MARKER = "/eli/";
+    private static final String DOKUMENT_NORMA = "dokument/norma";
+
+    private EsbirkaEliParser() {
+    }
+
+    public static ParsedEli parse(String url) {
+        if (url == null || url.isBlank()) {
+            return invalid(url);
+        }
+        String normalized = normalizeHost(url);
+        if (!SparqlIriValidator.isEsbirkaEliIri(normalized)) {
+            return invalid(url);
+        }
+        int eliIdx = normalized.indexOf(ELI_MARKER);
+        if (eliIdx < 0) {
+            return invalid(url);
+        }
+        String eliPath = normalized.substring(eliIdx);
+        String pathBody = eliPath.substring(ELI_MARKER.length());
+        String[] segs = pathBody.split("/");
+        if (segs.length < 4 || !"cz".equals(segs[0])) {
+            return invalid(url);
+        }
+        String sbirkaCode = segs[1];
+        Integer lawYear = parseIntOrNull(segs[2]);
+        String lawNumber = segs[3];
+        if (lawYear == null || lawNumber.isBlank()) {
+            return invalid(url);
+        }
+
+        String lawEliPath = ELI_MARKER + "cz/" + sbirkaCode + "/" + lawYear + "/" + lawNumber;
+        String lawIri = CANONICAL_DOMAIN + lawEliPath;
+
+        if (segs.length == 4) {
+            return new ParsedEli(url, CANONICAL_DOMAIN, lawEliPath,
+                    lawIri, null, null, lawNumber, lawYear, sbirkaCode,
+                    null, List.of(), ParsedEli.Level.LAW);
+        }
+
+        String dateSeg = segs[4];
+        LocalDate versionDate = parseDateOrNull(dateSeg);
+        String versionEliPath = lawEliPath + "/" + dateSeg;
+        String versionIri = CANONICAL_DOMAIN + versionEliPath;
+
+        if (segs.length == 5) {
+            return new ParsedEli(url, CANONICAL_DOMAIN, versionEliPath,
+                    lawIri, versionIri, null, lawNumber, lawYear, sbirkaCode,
+                    versionDate, List.of(), ParsedEli.Level.VERSION);
+        }
+
+        if (segs.length < 7 || !DOKUMENT_NORMA.equals(segs[5] + "/" + segs[6])) {
+            return invalid(url);
+        }
+
+        List<ParsedEli.FragmentSegment> fragmentSegments = new ArrayList<>();
+        for (int i = 7; i < segs.length; i++) {
+            fragmentSegments.add(splitSegment(segs[i]));
+        }
+        if (fragmentSegments.isEmpty()) {
+            return invalid(url);
+        }
+        String fragmentIri = CANONICAL_DOMAIN + eliPath;
+        return new ParsedEli(url, CANONICAL_DOMAIN, eliPath,
+                lawIri, versionIri, fragmentIri, lawNumber, lawYear, sbirkaCode,
+                versionDate, List.copyOf(fragmentSegments), ParsedEli.Level.FRAGMENT);
+    }
+
+    static String normalizeHost(String url) {
+        int legacy = url.indexOf(LEGACY_HOST_PREFIX);
+        if (legacy >= 0) {
+            return url.substring(0, legacy) + CANONICAL_HOST_PREFIX + url.substring(legacy + LEGACY_HOST_PREFIX.length());
+        }
+        int bareLegacy = url.indexOf(BARE_LEGACY_HOST_PREFIX);
+        if (bareLegacy >= 0 && url.indexOf(ELI_MARKER, bareLegacy) > 0) {
+            return url.substring(0, bareLegacy) + CANONICAL_HOST_PREFIX + url.substring(bareLegacy + BARE_LEGACY_HOST_PREFIX.length());
+        }
+        return url;
+    }
+
+    private static ParsedEli invalid(String url) {
+        return new ParsedEli(url, null, null, null, null, null, null, null, null, null, List.of(), null);
+    }
+
+    private static Integer parseIntOrNull(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static LocalDate parseDateOrNull(String s) {
+        try {
+            return LocalDate.parse(s);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static ParsedEli.FragmentSegment splitSegment(String seg) {
+        int us = seg.indexOf('_');
+        if (us <= 0 || us >= seg.length() - 1) {
+            return new ParsedEli.FragmentSegment(seg, "");
+        }
+        return new ParsedEli.FragmentSegment(seg.substring(0, us), seg.substring(us + 1));
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/eli/ParsedEli.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/eli/ParsedEli.java
@@ -1,0 +1,31 @@
+package com.dia.ismdtoolbackend.utility.eli;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ParsedEli(
+        String originalUrl,
+        String domain,
+        String eliPath,
+        String lawIri,
+        String versionIri,
+        String fragmentIri,
+        String lawNumber,
+        Integer lawYear,
+        String sbirkaCode,
+        LocalDate versionDate,
+        List<FragmentSegment> fragmentSegments,
+        Level level
+) {
+    public enum Level { LAW, VERSION, FRAGMENT }
+
+    public record FragmentSegment(String kind, String number) {}
+
+    public boolean isValid() {
+        return level != null;
+    }
+
+    public boolean isFragment() {
+        return level == Level.FRAGMENT;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/sparql/SparqlCircuitBreaker.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/sparql/SparqlCircuitBreaker.java
@@ -1,0 +1,99 @@
+package com.dia.ismdtoolbackend.utility.sparql;
+
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Lightweight per-endpoint circuit breaker for SPARQL calls.
+ *
+ * <p>Three states implicit in two fields ({@code consecutiveFailures}, {@code openedAt}):
+ * <ul>
+ *   <li><strong>Closed</strong> — calls flow through; failures increment a counter.</li>
+ *   <li><strong>Open</strong> — after {@link #failureThreshold} consecutive failures,
+ *       calls fail fast for {@link #cooldownMillis} so a thundering herd doesn't slam
+ *       an already-dead endpoint.</li>
+ *   <li><strong>Half-open</strong> (implicit) — once cooldown expires, one trial call
+ *       passes through. Success closes the breaker; failure re-opens it for another
+ *       cooldown window.</li>
+ * </ul>
+ *
+ * <p>Only {@link SparqlEndpointUnavailableException} counts as a failure — domain
+ * exceptions (e.g. invalid IRI) propagate untouched and don't trip the breaker.
+ *
+ * <p>Stateful, thread-safe, plain Java. Construct one per endpoint.
+ */
+@Slf4j
+public final class SparqlCircuitBreaker {
+
+    private final String endpointLabel;
+    private final int failureThreshold;
+    private final long cooldownMillis;
+
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final AtomicLong openedAt = new AtomicLong(0);
+
+    public SparqlCircuitBreaker(String endpointLabel, int failureThreshold, long cooldownMillis) {
+        this.endpointLabel = endpointLabel;
+        this.failureThreshold = failureThreshold;
+        this.cooldownMillis = cooldownMillis;
+    }
+
+    /**
+     * Execute {@code action}, with circuit-breaker fast-fail when the endpoint
+     * has been failing recently. Only {@link SparqlEndpointUnavailableException}
+     * counts toward the failure threshold.
+     */
+    public <T> T call(Supplier<T> action) {
+        long openSince = openedAt.get();
+        if (openSince > 0) {
+            long elapsed = System.currentTimeMillis() - openSince;
+            if (elapsed < cooldownMillis) {
+                throw new SparqlEndpointUnavailableException(endpointLabel,
+                        endpointLabel + " circuit breaker open (last failure " + elapsed + "ms ago)");
+            }
+            // cooldown expired — let one call through as a trial
+        }
+        try {
+            T result = action.get();
+            onSuccess();
+            return result;
+        } catch (SparqlEndpointUnavailableException e) {
+            onFailure();
+            throw e;
+        }
+    }
+
+    private void onSuccess() {
+        if (openedAt.getAndSet(0) > 0) {
+            log.info("{} circuit breaker closed after successful call.", endpointLabel);
+        }
+        consecutiveFailures.set(0);
+    }
+
+    private void onFailure() {
+        int failures = consecutiveFailures.incrementAndGet();
+        if (failures < failureThreshold) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long prev = openedAt.getAndSet(now);
+        if (prev == 0) {
+            log.warn("{} circuit breaker opened after {} consecutive failures (cooldown {}ms).",
+                    endpointLabel, failures, cooldownMillis);
+        } else {
+            log.warn("{} circuit breaker stays open (trial call failed; cooldown extended by {}ms).",
+                    endpointLabel, cooldownMillis);
+        }
+    }
+
+    // Visible for testing
+    boolean isOpen() {
+        long openSince = openedAt.get();
+        if (openSince == 0) return false;
+        return System.currentTimeMillis() - openSince < cooldownMillis;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,6 +57,8 @@ rpp.search.default-limit=20
 
 # e-Sbírka (ELI) SPARQL endpoint + search limits — issue #106
 esbirka.sparql.endpoint=
+# Per-call timeout shared by ALL e-Sbírka SPARQL operations including /api/eli/resolve (#158).
+# If resolve latency proves problematic, split into a dedicated short-timeout executor.
 esbirka.sparql.timeout=10000
 esbirka.search.max-limit=50
 esbirka.search.default-limit=20

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,11 @@ esbirka.sparql.endpoint=
 esbirka.sparql.timeout=10000
 esbirka.search.max-limit=50
 esbirka.search.default-limit=20
+# Circuit breaker for /api/eli/resolve SPARQL calls (#158).
+# After N consecutive failures the breaker opens and fast-fails for cooldown-ms,
+# preventing a thundering herd against a dead endpoint.
+esbirka.resolve.circuit-breaker.failure-threshold=5
+esbirka.resolve.circuit-breaker.cooldown-ms=30000
 
 # Response gzip — fragment trees can be ~2 MB JSON
 server.compression.enabled=true

--- a/src/test/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClientTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClientTest.java
@@ -2,6 +2,7 @@ package com.dia.ismdtoolbackend.client;
 
 import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
 import com.dia.ismdtoolbackend.models.eli.FragmentModel;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
 import com.dia.ismdtoolbackend.models.eli.LawModel;
 import com.dia.ismdtoolbackend.models.eli.LawVersionModel;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -15,6 +16,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
@@ -265,6 +267,88 @@ class EsbirkaSparqlClientTest {
         List<FragmentModel> out = client.fetchFragments(VERSION_IRI);
         assertEquals(1, out.size());
         assertEquals("§ 2", out.get(0).getCitation());
+    }
+
+    // --- resolveFragment ----------------------------------------------------
+
+    @Test
+    void resolveFragment_happyPath_returnsCitationAndMetadata() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        String json = """
+                {
+                  "head": { "vars": ["citace", "ucinnostDo", "isLatest"] },
+                  "results": { "bindings": [
+                    { "citace":     {"type":"literal","value":"§ 2 písm. d)"},
+                      "ucinnostDo": {"type":"typed-literal","datatype":"http://www.w3.org/2001/XMLSchema#date","value":"2024-12-31"},
+                      "isLatest":   {"type":"typed-literal","datatype":"http://www.w3.org/2001/XMLSchema#boolean","value":"true"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+
+        Optional<FragmentResolutionModel> out = client.resolveFragment(fragmentIri, VERSION_IRI, LAW_IRI);
+
+        assertTrue(out.isPresent());
+        assertEquals("§ 2 písm. d)", out.get().citation());
+        assertEquals(LocalDate.of(2024, 12, 31), out.get().versionValidUntil());
+        assertTrue(out.get().isLatest());
+    }
+
+    @Test
+    void resolveFragment_emptyResult_returnsEmptyOptional() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        stubSparql("""
+                {
+                  "head": { "vars": ["citace", "ucinnostDo", "isLatest"] },
+                  "results": { "bindings": [] }
+                }
+                """);
+
+        Optional<FragmentResolutionModel> out = client.resolveFragment(fragmentIri, VERSION_IRI, LAW_IRI);
+
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    void resolveFragment_noUcinnostDo_returnsNullValidUntil() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        String json = """
+                {
+                  "head": { "vars": ["citace", "ucinnostDo", "isLatest"] },
+                  "results": { "bindings": [
+                    { "citace":     {"type":"literal","value":"§ 2 písm. d)"},
+                      "isLatest":   {"type":"typed-literal","datatype":"http://www.w3.org/2001/XMLSchema#boolean","value":"false"} }
+                  ] }
+                }
+                """;
+        stubSparql(json);
+
+        Optional<FragmentResolutionModel> out = client.resolveFragment(fragmentIri, VERSION_IRI, LAW_IRI);
+
+        assertTrue(out.isPresent());
+        assertEquals("§ 2 písm. d)", out.get().citation());
+        assertNull(out.get().versionValidUntil());
+        assertFalse(out.get().isLatest());
+    }
+
+    @Test
+    void resolveFragment_endpointDown_throwsSparqlEndpointUnavailable() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(500)));
+
+        assertThrows(SparqlEndpointUnavailableException.class,
+                () -> client.resolveFragment(fragmentIri, VERSION_IRI, LAW_IRI));
+    }
+
+    @Test
+    void resolveFragment_malformedBody_throwsSparqlEndpointUnavailable() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        stubFor(any(anyUrl()).willReturn(aResponse()
+                .withHeader("Content-Type", "application/sparql-results+json")
+                .withBody("{ malformed")));
+
+        assertThrows(SparqlEndpointUnavailableException.class,
+                () -> client.resolveFragment(fragmentIri, VERSION_IRI, LAW_IRI));
     }
 
     // --- G12: failure modes -------------------------------------------------

--- a/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
@@ -285,8 +285,16 @@ class EsbirkaControllerTest {
     }
 
     @Test
-    void resolveUnauthenticatedReturns403() throws Exception {
+    void resolveUnauthenticatedReturns200() throws Exception {
+        // /resolve is a public endpoint (mirrors /concept/{slug}/detail being public).
+        ResolvedLegalSourceDto dto = ResolvedLegalSourceDto.builder()
+                .originalUrl("anything")
+                .enrichmentStatus(EnrichmentStatus.INVALID_IRI)
+                .build();
+        when(esbirkaService.resolveLegalSource("anything")).thenReturn(dto);
+
         mockMvc.perform(get("/api/eli/resolve").param("iri", "anything"))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.enrichmentStatus").value("INVALID_IRI"));
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
@@ -8,6 +8,9 @@ import com.dia.ismdtoolbackend.config.security.WithMockSecurityUser;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
 import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
 import com.dia.ismdtoolbackend.service.EsbirkaService;
 import org.junit.jupiter.api.BeforeEach;
@@ -227,5 +230,63 @@ class EsbirkaControllerTest {
 
         mockMvc.perform(get("/api/eli/law/fragments").param("versionIri", VERSION_IRI))
                 .andExpect(status().isServiceUnavailable());
+    }
+
+    // -------- /resolve --------
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void resolveValidFragmentUrlReturns200WithDto() throws Exception {
+        String fragmentUrl = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        ResolvedLegalSourceDto dto = ResolvedLegalSourceDto.builder()
+                .originalUrl(fragmentUrl)
+                .level(ParsedEli.Level.FRAGMENT)
+                .fragmentCitation("§ 2 písm. d)")
+                .displayLabel("Zákon č. 187/2006 Sb., § 2 písm. d)")
+                .enrichmentStatus(EnrichmentStatus.OK)
+                .build();
+        when(esbirkaService.resolveLegalSource(fragmentUrl)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/eli/resolve").param("iri", fragmentUrl))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.enrichmentStatus").value("OK"))
+                .andExpect(jsonPath("$.data.fragmentCitation").value("§ 2 písm. d)"));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void resolveInvalidUrlReturns200WithInvalidIriStatus() throws Exception {
+        ResolvedLegalSourceDto dto = ResolvedLegalSourceDto.builder()
+                .originalUrl("garbage")
+                .enrichmentStatus(EnrichmentStatus.INVALID_IRI)
+                .build();
+        when(esbirkaService.resolveLegalSource("garbage")).thenReturn(dto);
+
+        mockMvc.perform(get("/api/eli/resolve").param("iri", "garbage"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.enrichmentStatus").value("INVALID_IRI"));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void resolveESbirkaDownReturns200WithUnavailableStatus() throws Exception {
+        String fragmentUrl = VERSION_IRI + "/dokument/norma/par_2/pism_d";
+        ResolvedLegalSourceDto dto = ResolvedLegalSourceDto.builder()
+                .originalUrl(fragmentUrl)
+                .level(ParsedEli.Level.FRAGMENT)
+                .enrichmentStatus(EnrichmentStatus.UNAVAILABLE)
+                .build();
+        when(esbirkaService.resolveLegalSource(fragmentUrl)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/eli/resolve").param("iri", fragmentUrl))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.enrichmentStatus").value("UNAVAILABLE"));
+    }
+
+    @Test
+    void resolveUnauthenticatedReturns403() throws Exception {
+        mockMvc.perform(get("/api/eli/resolve").param("iri", "anything"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQueryTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQueryTest.java
@@ -83,4 +83,20 @@ class EsbirkaSPARQLQueryTest {
         assertTrue(q.contains("<" + VERSION_IRI + ">"),
                 "versionIri must be inlined as <iri> via ParameterizedSparqlString.setIri");
     }
+
+    @Test
+    void buildResolveFragmentQuery_bindsAllThreeIris() {
+        String fragmentIri = VERSION_IRI + "/dokument/norma/cast_1/par_2/pism_d";
+        String q = EsbirkaSPARQLQuery.buildResolveFragmentQuery(fragmentIri, VERSION_IRI, LAW_IRI);
+
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        assertTrue(q.contains("citace-označení-fragmentu-znění-právního-aktu"));
+        assertTrue(q.contains("má-poslední-znění"));
+        assertTrue(q.contains("účinnost-znění-do"));
+        assertTrue(q.contains("(?zneni = ?posledniZneni) AS ?isLatest"));
+        assertTrue(q.contains("LIMIT 1"));
+        assertTrue(q.contains("<" + fragmentIri + ">"), "fragmentIri must be inlined");
+        assertTrue(q.contains("<" + VERSION_IRI + ">"), "versionIri must be inlined");
+        assertTrue(q.contains("<" + LAW_IRI + ">"), "lawIri must be inlined");
+    }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCacheTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaFragmentResolutionCacheTest.java
@@ -1,0 +1,84 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
+import com.dia.ismdtoolbackend.config.CacheConfig;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {
+        CacheConfig.class,
+        EsbirkaFragmentResolutionCache.class
+})
+@Import(EsbirkaFragmentResolutionCacheTest.NoOpAppConfig.class)
+class EsbirkaFragmentResolutionCacheTest {
+
+    private static final String FRAGMENT_IRI =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361/2024-04-01/dokument/norma/par_2/pism_d";
+    private static final String VERSION_IRI =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361/2024-04-01";
+    private static final String LAW_IRI =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361";
+
+    @MockBean
+    private EsbirkaSparqlClient client;
+
+    @Autowired
+    private EsbirkaFragmentResolutionCache cache;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Test
+    void fetch_delegatesToClient() {
+        FragmentResolutionModel model = new FragmentResolutionModel("§ 2 písm. d)", LocalDate.of(2024, 12, 31), true);
+        when(client.resolveFragment(FRAGMENT_IRI, VERSION_IRI, LAW_IRI))
+                .thenReturn(Optional.of(model));
+
+        Optional<FragmentResolutionModel> out = cache.fetch(FRAGMENT_IRI, VERSION_IRI, LAW_IRI);
+
+        assertEquals(Optional.of(model), out);
+        verify(client, times(1)).resolveFragment(FRAGMENT_IRI, VERSION_IRI, LAW_IRI);
+    }
+
+    @Test
+    void fetch_isCached_secondCallSkipsClient() {
+        cacheManager.getCache("esbirkaFragmentResolution").clear();
+        FragmentResolutionModel model = new FragmentResolutionModel("§ 2 písm. d)", null, true);
+        when(client.resolveFragment(eq(FRAGMENT_IRI), eq(VERSION_IRI), eq(LAW_IRI)))
+                .thenReturn(Optional.of(model));
+
+        Optional<FragmentResolutionModel> first = cache.fetch(FRAGMENT_IRI, VERSION_IRI, LAW_IRI);
+        Optional<FragmentResolutionModel> second = cache.fetch(FRAGMENT_IRI, VERSION_IRI, LAW_IRI);
+
+        assertEquals(first, second);
+        verify(client, times(1)).resolveFragment(eq(FRAGMENT_IRI), eq(VERSION_IRI), eq(LAW_IRI));
+    }
+
+    @Test
+    void cacheRegistered_withExpectedName() {
+        assertNotNull(cacheManager.getCache("esbirkaFragmentResolution"),
+                "esbirkaFragmentResolution cache must be registered");
+        assertNotNull(cacheManager.getCache("esbirkaLawSearch"));
+        assertNotNull(cacheManager.getCache("esbirkaLawVersions"));
+    }
+
+    @org.springframework.boot.SpringBootConfiguration
+    @org.springframework.context.annotation.ComponentScan(useDefaultFilters = false)
+    static class NoOpAppConfig {
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplResolveTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplResolveTest.java
@@ -143,21 +143,4 @@ class EsbirkaServiceImplResolveTest {
                 "fragmentIri must use canonical host");
     }
 
-    @Test
-    void buildFragmentCitationFromSegments_parPresent_dropsAncestors() {
-        String citation = EsbirkaServiceImpl.buildFragmentCitationFromSegments(java.util.List.of(
-                new ParsedEli.FragmentSegment("cast", "1"),
-                new ParsedEli.FragmentSegment("hlava", "1"),
-                new ParsedEli.FragmentSegment("par", "2"),
-                new ParsedEli.FragmentSegment("pism", "d")));
-        assertEquals("§ 2 písm. d)", citation);
-    }
-
-    @Test
-    void buildFragmentCitationFromSegments_noPar_keepsAllSegments() {
-        String citation = EsbirkaServiceImpl.buildFragmentCitationFromSegments(java.util.List.of(
-                new ParsedEli.FragmentSegment("cast", "1"),
-                new ParsedEli.FragmentSegment("hlava", "1")));
-        assertEquals("Část 1 Hlava 1", citation);
-    }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplResolveTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplResolveTest.java
@@ -1,0 +1,163 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
+import com.dia.ismdtoolbackend.models.eli.FragmentResolutionModel;
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EsbirkaServiceImplResolveTest {
+
+    private static final String LAW_URL =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361";
+    private static final String VERSION_URL = LAW_URL + "/2024-04-01";
+    private static final String FRAGMENT_URL = VERSION_URL + "/dokument/norma/cast_1/hlava_1/par_2/pism_d";
+    private static final String LEGACY_FRAGMENT_URL =
+            "https://opendata.eselpoint.cz/esel-esb/eli/cz/sb/2000/361/2024-04-01/dokument/norma/par_2/pism_d";
+
+    private EsbirkaSparqlClient client;
+    private EsbirkaFragmentResolutionCache cache;
+    private EsbirkaServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(EsbirkaSparqlClient.class);
+        cache = mock(EsbirkaFragmentResolutionCache.class);
+        service = new EsbirkaServiceImpl(client, cache);
+    }
+
+    @Test
+    void resolveLegalSource_lawUrl_returnsSkippedNonFragment() {
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(LAW_URL);
+
+        assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, dto.getEnrichmentStatus());
+        assertEquals(ParsedEli.Level.LAW, dto.getLevel());
+        assertEquals("361", dto.getLawNumber());
+        assertEquals(2000, dto.getLawYear());
+        assertTrue(dto.getDisplayLabel().startsWith("Zákon č. 361/2000 Sb."));
+        verify(cache, never()).fetch(any(), any(), any());
+    }
+
+    @Test
+    void resolveLegalSource_versionUrl_returnsSkippedNonFragment() {
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(VERSION_URL);
+
+        assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, dto.getEnrichmentStatus());
+        assertEquals(ParsedEli.Level.VERSION, dto.getLevel());
+        assertEquals(LocalDate.of(2024, 4, 1), dto.getVersionDate());
+        assertTrue(dto.getDisplayLabel().contains("(znění od 1. 4. 2024)"));
+        verify(cache, never()).fetch(any(), any(), any());
+    }
+
+    @Test
+    void resolveLegalSource_fragmentUrl_happyPath_returnsOk() {
+        when(cache.fetch(any(), any(), any()))
+                .thenReturn(Optional.of(new FragmentResolutionModel(
+                        "§ 2 písm. d)", LocalDate.of(2024, 12, 31), true)));
+
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(FRAGMENT_URL);
+
+        assertEquals(EnrichmentStatus.OK, dto.getEnrichmentStatus());
+        assertEquals(ParsedEli.Level.FRAGMENT, dto.getLevel());
+        assertEquals("§ 2 písm. d)", dto.getFragmentCitation());
+        assertEquals(LocalDate.of(2024, 12, 31), dto.getVersionValidUntil());
+        assertTrue(dto.getIsLatestVersion());
+        assertTrue(dto.getDisplayLabel().contains("§ 2 písm. d)"),
+                "displayLabel should use SPARQL citation when available: " + dto.getDisplayLabel());
+    }
+
+    @Test
+    void resolveLegalSource_fragmentUrl_emptyResult_returnsNotFound() {
+        when(cache.fetch(any(), any(), any())).thenReturn(Optional.empty());
+
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(FRAGMENT_URL);
+
+        assertEquals(EnrichmentStatus.NOT_FOUND, dto.getEnrichmentStatus());
+        assertNull(dto.getFragmentCitation());
+        assertNull(dto.getVersionValidUntil());
+        assertNotNull(dto.getDisplayLabel(), "displayLabel must fall back to parse-only");
+        assertTrue(dto.getDisplayLabel().contains("§ 2"), "fallback citation should include § 2");
+    }
+
+    @Test
+    void resolveLegalSource_fragmentUrl_endpointDown_returnsUnavailable() {
+        when(cache.fetch(any(), any(), any()))
+                .thenThrow(new SparqlEndpointUnavailableException("e-Sbírka", "down"));
+
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(FRAGMENT_URL);
+
+        assertEquals(EnrichmentStatus.UNAVAILABLE, dto.getEnrichmentStatus());
+        assertNull(dto.getFragmentCitation());
+        assertNotNull(dto.getDisplayLabel());
+    }
+
+    @Test
+    void resolveLegalSource_invalidUrl_null_returnsInvalidIri() {
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(null);
+        assertEquals(EnrichmentStatus.INVALID_IRI, dto.getEnrichmentStatus());
+        assertNull(dto.getLevel());
+        assertNull(dto.getDisplayLabel());
+        verify(cache, never()).fetch(any(), any(), any());
+    }
+
+    @Test
+    void resolveLegalSource_invalidUrl_garbage_returnsInvalidIri() {
+        ResolvedLegalSourceDto dto = service.resolveLegalSource("not-a-url");
+        assertEquals(EnrichmentStatus.INVALID_IRI, dto.getEnrichmentStatus());
+    }
+
+    @Test
+    void resolveLegalSource_invalidUrl_foreignHost_returnsInvalidIri() {
+        ResolvedLegalSourceDto dto = service.resolveLegalSource("https://example.com/eli/cz/sb/2000/361");
+        assertEquals(EnrichmentStatus.INVALID_IRI, dto.getEnrichmentStatus());
+    }
+
+    @Test
+    void resolveLegalSource_legacyHost_originalUrlPreservedCanonicalIrisInDto() {
+        when(cache.fetch(any(), any(), any()))
+                .thenReturn(Optional.of(new FragmentResolutionModel("§ 2 písm. d)", null, true)));
+
+        ResolvedLegalSourceDto dto = service.resolveLegalSource(LEGACY_FRAGMENT_URL);
+
+        assertEquals(LEGACY_FRAGMENT_URL, dto.getOriginalUrl(),
+                "originalUrl preserved verbatim");
+        assertTrue(dto.getLawIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"),
+                "lawIri must use canonical host");
+        assertTrue(dto.getFragmentIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"),
+                "fragmentIri must use canonical host");
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_parPresent_dropsAncestors() {
+        String citation = EsbirkaServiceImpl.buildFragmentCitationFromSegments(java.util.List.of(
+                new ParsedEli.FragmentSegment("cast", "1"),
+                new ParsedEli.FragmentSegment("hlava", "1"),
+                new ParsedEli.FragmentSegment("par", "2"),
+                new ParsedEli.FragmentSegment("pism", "d")));
+        assertEquals("§ 2 písm. d)", citation);
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_noPar_keepsAllSegments() {
+        String citation = EsbirkaServiceImpl.buildFragmentCitationFromSegments(java.util.List.of(
+                new ParsedEli.FragmentSegment("cast", "1"),
+                new ParsedEli.FragmentSegment("hlava", "1")));
+        assertEquals("Část 1 Hlava 1", citation);
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorResolvedSourcesTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorResolvedSourcesTest.java
@@ -35,8 +35,17 @@ class OntologyDetailExtractorResolvedSourcesTest {
         assertEquals(1, out.size());
         assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, out.get(0).getEnrichmentStatus());
         assertEquals(ParsedEli.Level.LAW, out.get(0).getLevel());
-        assertNull(out.get(0).getDisplayLabel(),
-                "extractor stays parse-only — displayLabel is the service's job");
+        assertEquals("Zákon č. 361/2000 Sb.", out.get(0).getDisplayLabel(),
+                "extractor populates parse-only displayLabel via EsbirkaCzechCitationFormatter");
+    }
+
+    @Test
+    void buildResolvedSources_fragmentUrl_pendingHasFallbackDisplayLabel() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(List.of(FRAGMENT));
+        assertEquals(EnrichmentStatus.PENDING, out.get(0).getEnrichmentStatus());
+        assertEquals("Zákon č. 361/2000 Sb., § 2 písm. d) (znění od 1. 4. 2024)",
+                out.get(0).getDisplayLabel(),
+                "fragment fallback uses segment-derived citation");
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorResolvedSourcesTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorResolvedSourcesTest.java
@@ -1,0 +1,82 @@
+package com.dia.ismdtoolbackend.utility.detail;
+
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
+import com.dia.ismdtoolbackend.utility.eli.ParsedEli;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OntologyDetailExtractorResolvedSourcesTest {
+
+    private static final String LAW = "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361";
+    private static final String VERSION = LAW + "/2024-04-01";
+    private static final String FRAGMENT = VERSION + "/dokument/norma/par_2/pism_d";
+    private static final String LEGACY_FRAGMENT =
+            "https://opendata.eselpoint.cz/esel-esb/eli/cz/sb/2000/361/2024-04-01/dokument/norma/par_5";
+
+    @Test
+    void buildResolvedSources_nullInput_returnsNull() {
+        assertNull(OntologyDetailExtractor.buildResolvedSources(null));
+    }
+
+    @Test
+    void buildResolvedSources_emptyInput_returnsNull() {
+        assertNull(OntologyDetailExtractor.buildResolvedSources(List.of()));
+    }
+
+    @Test
+    void buildResolvedSources_lawUrl_skippedNonFragment() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(List.of(LAW));
+        assertEquals(1, out.size());
+        assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, out.get(0).getEnrichmentStatus());
+        assertEquals(ParsedEli.Level.LAW, out.get(0).getLevel());
+        assertNull(out.get(0).getDisplayLabel(),
+                "extractor stays parse-only — displayLabel is the service's job");
+    }
+
+    @Test
+    void buildResolvedSources_fragmentUrl_pending() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(List.of(FRAGMENT));
+        assertEquals(1, out.size());
+        assertEquals(EnrichmentStatus.PENDING, out.get(0).getEnrichmentStatus());
+        assertEquals(ParsedEli.Level.FRAGMENT, out.get(0).getLevel());
+        assertNull(out.get(0).getFragmentCitation(), "extractor never calls SPARQL");
+    }
+
+    @Test
+    void buildResolvedSources_invalidUrl_invalidIri() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(List.of("garbage"));
+        assertEquals(1, out.size());
+        assertEquals(EnrichmentStatus.INVALID_IRI, out.get(0).getEnrichmentStatus());
+        assertEquals("garbage", out.get(0).getOriginalUrl());
+    }
+
+    @Test
+    void buildResolvedSources_mixedList_preservesOrderAndStatuses() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(
+                List.of(LAW, FRAGMENT, "junk", VERSION));
+
+        assertEquals(4, out.size());
+        assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, out.get(0).getEnrichmentStatus());
+        assertEquals(EnrichmentStatus.PENDING, out.get(1).getEnrichmentStatus());
+        assertEquals(EnrichmentStatus.INVALID_IRI, out.get(2).getEnrichmentStatus());
+        assertEquals(EnrichmentStatus.SKIPPED_NON_FRAGMENT, out.get(3).getEnrichmentStatus());
+    }
+
+    @Test
+    void buildResolvedSources_legacyHost_originalPreservedCanonicalIris() {
+        List<ResolvedLegalSourceDto> out = OntologyDetailExtractor.buildResolvedSources(List.of(LEGACY_FRAGMENT));
+
+        assertEquals(1, out.size());
+        ResolvedLegalSourceDto dto = out.get(0);
+        assertEquals(EnrichmentStatus.PENDING, dto.getEnrichmentStatus());
+        assertEquals(LEGACY_FRAGMENT, dto.getOriginalUrl());
+        assertTrue(dto.getLawIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"));
+        assertTrue(dto.getFragmentIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaCzechCitationFormatterTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaCzechCitationFormatterTest.java
@@ -1,0 +1,134 @@
+package com.dia.ismdtoolbackend.utility.eli;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class EsbirkaCzechCitationFormatterTest {
+
+    @Test
+    void buildFragmentCitationFromSegments_parPresentDropsAncestors() {
+        String citation = EsbirkaCzechCitationFormatter.buildFragmentCitationFromSegments(List.of(
+                new ParsedEli.FragmentSegment("cast", "1"),
+                new ParsedEli.FragmentSegment("hlava", "1"),
+                new ParsedEli.FragmentSegment("par", "2"),
+                new ParsedEli.FragmentSegment("pism", "d")));
+        assertEquals("§ 2 písm. d)", citation);
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_noParKeepsAllSegments() {
+        String citation = EsbirkaCzechCitationFormatter.buildFragmentCitationFromSegments(List.of(
+                new ParsedEli.FragmentSegment("cast", "1"),
+                new ParsedEli.FragmentSegment("hlava", "1")));
+        assertEquals("Část 1 Hlava 1", citation);
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_emptyReturnsEmpty() {
+        assertEquals("", EsbirkaCzechCitationFormatter.buildFragmentCitationFromSegments(List.of()));
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_nullReturnsEmpty() {
+        assertEquals("", EsbirkaCzechCitationFormatter.buildFragmentCitationFromSegments(null));
+    }
+
+    @Test
+    void buildFragmentCitationFromSegments_unknownKindFallsThrough() {
+        String citation = EsbirkaCzechCitationFormatter.buildFragmentCitationFromSegments(List.of(
+                new ParsedEli.FragmentSegment("mystery", "42")));
+        assertEquals("mystery 42", citation);
+    }
+
+    @Test
+    void buildDisplayLabel_invalidParsedReturnsNull() {
+        ParsedEli invalid = new ParsedEli(null, null, null, null, null, null, null, null, null, null, List.of(), null);
+        assertNull(EsbirkaCzechCitationFormatter.buildDisplayLabel(invalid, null));
+    }
+
+    @Test
+    void buildDisplayLabel_lawOnly() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "/eli/cz/sb/2000/361",
+                "lawIri", null, null,
+                "361", 2000, "sb", null, List.of(), ParsedEli.Level.LAW);
+        assertEquals("Zákon č. 361/2000 Sb.", EsbirkaCzechCitationFormatter.buildDisplayLabel(p, null));
+    }
+
+    @Test
+    void buildDisplayLabel_versionAppendsZneniOd() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "/eli/cz/sb/2000/361/2024-04-01",
+                "lawIri", "verIri", null,
+                "361", 2000, "sb", LocalDate.of(2024, 4, 1), List.of(), ParsedEli.Level.VERSION);
+        assertEquals("Zákon č. 361/2000 Sb. (znění od 1. 4. 2024)",
+                EsbirkaCzechCitationFormatter.buildDisplayLabel(p, null));
+    }
+
+    @Test
+    void buildDisplayLabel_versionWithNullDateOmitsZneni() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "/eli/cz/sb/2000/361/not-a-date",
+                "lawIri", "verIri", null,
+                "361", 2000, "sb", null, List.of(), ParsedEli.Level.VERSION);
+        assertEquals("Zákon č. 361/2000 Sb.", EsbirkaCzechCitationFormatter.buildDisplayLabel(p, null));
+    }
+
+    @Test
+    void buildDisplayLabel_fragmentUsesSparqlCitationWhenPresent() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "/eli/cz/sb/2000/361/2024-04-01/dokument/norma/par_2/pism_d",
+                "lawIri", "verIri", "fragIri",
+                "361", 2000, "sb", LocalDate.of(2024, 4, 1),
+                List.of(new ParsedEli.FragmentSegment("par", "2"),
+                        new ParsedEli.FragmentSegment("pism", "d")),
+                ParsedEli.Level.FRAGMENT);
+        String label = EsbirkaCzechCitationFormatter.buildDisplayLabel(p, "§ 2 písm. d)");
+        assertEquals("Zákon č. 361/2000 Sb., § 2 písm. d) (znění od 1. 4. 2024)", label);
+    }
+
+    @Test
+    void buildDisplayLabel_fragmentFallsBackToSegmentFormatterWhenSparqlNull() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "path",
+                "lawIri", "verIri", "fragIri",
+                "361", 2000, "sb", LocalDate.of(2024, 4, 1),
+                List.of(new ParsedEli.FragmentSegment("par", "2"),
+                        new ParsedEli.FragmentSegment("odst", "1")),
+                ParsedEli.Level.FRAGMENT);
+        String label = EsbirkaCzechCitationFormatter.buildDisplayLabel(p, null);
+        assertEquals("Zákon č. 361/2000 Sb., § 2 odst. 1 (znění od 1. 4. 2024)", label);
+    }
+
+    @Test
+    void buildDisplayLabel_fragmentBlankSparqlFallsBackToSegments() {
+        ParsedEli p = new ParsedEli(
+                "url", "domain", "path",
+                "lawIri", "verIri", "fragIri",
+                "361", 2000, "sb", null,
+                List.of(new ParsedEli.FragmentSegment("par", "2")),
+                ParsedEli.Level.FRAGMENT);
+        assertEquals("Zákon č. 361/2000 Sb., § 2",
+                EsbirkaCzechCitationFormatter.buildDisplayLabel(p, "   "));
+    }
+
+    @Test
+    void formatCzechDate_nullReturnsNull() {
+        assertNull(EsbirkaCzechCitationFormatter.formatCzechDate(null));
+    }
+
+    @Test
+    void formatCzechDate_singleDigitNoLeadingZeroes() {
+        assertEquals("1. 4. 2024", EsbirkaCzechCitationFormatter.formatCzechDate(LocalDate.of(2024, 4, 1)));
+    }
+
+    @Test
+    void formatCzechDate_doubleDigit() {
+        assertEquals("31. 12. 2024", EsbirkaCzechCitationFormatter.formatCzechDate(LocalDate.of(2024, 12, 31)));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaEliParserTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/eli/EsbirkaEliParserTest.java
@@ -1,0 +1,170 @@
+package com.dia.ismdtoolbackend.utility.eli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EsbirkaEliParserTest {
+
+    private static final String CANONICAL_LAW = "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361";
+    private static final String CANONICAL_VERSION = CANONICAL_LAW + "/2024-04-01";
+    private static final String CANONICAL_FRAGMENT = CANONICAL_VERSION
+            + "/dokument/norma/cast_1/hlava_1/par_2/pism_d";
+
+    @Test
+    void parse_lawOnlyIri_returnsLawLevel() {
+        ParsedEli p = EsbirkaEliParser.parse(CANONICAL_LAW);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.LAW, p.level());
+        assertEquals("361", p.lawNumber());
+        assertEquals(2000, p.lawYear());
+        assertEquals("sb", p.sbirkaCode());
+        assertEquals(CANONICAL_LAW, p.lawIri());
+        assertNull(p.versionIri());
+        assertNull(p.fragmentIri());
+        assertNull(p.versionDate());
+        assertTrue(p.fragmentSegments().isEmpty());
+        assertEquals("/eli/cz/sb/2000/361", p.eliPath());
+        assertEquals("https://opendata.eselpoint.gov.cz/esel-esb", p.domain());
+    }
+
+    @Test
+    void parse_versionIri_returnsVersionLevel() {
+        ParsedEli p = EsbirkaEliParser.parse(CANONICAL_VERSION);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.VERSION, p.level());
+        assertEquals(LocalDate.of(2024, 4, 1), p.versionDate());
+        assertEquals(CANONICAL_VERSION, p.versionIri());
+        assertEquals(CANONICAL_LAW, p.lawIri());
+        assertNull(p.fragmentIri());
+        assertTrue(p.fragmentSegments().isEmpty());
+    }
+
+    @Test
+    void parse_fragmentIri_returnsFragmentLevel() {
+        ParsedEli p = EsbirkaEliParser.parse(CANONICAL_FRAGMENT);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.FRAGMENT, p.level());
+        assertTrue(p.isFragment());
+        assertEquals(CANONICAL_FRAGMENT, p.fragmentIri());
+        assertEquals(CANONICAL_VERSION, p.versionIri());
+        assertEquals(CANONICAL_LAW, p.lawIri());
+
+        assertEquals(4, p.fragmentSegments().size());
+        assertEquals(new ParsedEli.FragmentSegment("cast", "1"), p.fragmentSegments().get(0));
+        assertEquals(new ParsedEli.FragmentSegment("hlava", "1"), p.fragmentSegments().get(1));
+        assertEquals(new ParsedEli.FragmentSegment("par", "2"), p.fragmentSegments().get(2));
+        assertEquals(new ParsedEli.FragmentSegment("pism", "d"), p.fragmentSegments().get(3));
+    }
+
+    @Test
+    void parse_legacyHost_normalizes() {
+        String legacyFragment = "https://opendata.eselpoint.cz/esel-esb/eli/cz/sb/2000/361"
+                + "/2024-04-01/dokument/norma/par_2/pism_d";
+
+        ParsedEli p = EsbirkaEliParser.parse(legacyFragment);
+
+        assertTrue(p.isValid());
+        assertEquals(legacyFragment, p.originalUrl());
+        assertEquals("https://opendata.eselpoint.gov.cz/esel-esb", p.domain());
+        assertTrue(p.lawIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"));
+        assertTrue(p.versionIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"));
+        assertTrue(p.fragmentIri().startsWith("https://opendata.eselpoint.gov.cz/esel-esb/"));
+    }
+
+    @Test
+    void parse_legacyLawOnly_normalizes() {
+        String legacyLaw = "https://opendata.eselpoint.cz/esel-esb/eli/cz/sb/2000/361";
+
+        ParsedEli p = EsbirkaEliParser.parse(legacyLaw);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.LAW, p.level());
+        assertEquals(legacyLaw, p.originalUrl());
+        assertEquals(CANONICAL_LAW, p.lawIri());
+    }
+
+    @Test
+    void parse_null_returnsInvalid() {
+        ParsedEli p = EsbirkaEliParser.parse(null);
+        assertFalse(p.isValid());
+        assertNull(p.level());
+        assertNull(p.originalUrl());
+    }
+
+    @Test
+    void parse_blank_returnsInvalid() {
+        ParsedEli p = EsbirkaEliParser.parse("   ");
+        assertFalse(p.isValid());
+    }
+
+    @Test
+    void parse_foreignHost_returnsInvalid() {
+        ParsedEli p = EsbirkaEliParser.parse("https://example.com/eli/cz/sb/2000/361");
+        assertFalse(p.isValid());
+        assertNull(p.level());
+    }
+
+    @Test
+    void parse_nonEliPath_returnsInvalid() {
+        ParsedEli p = EsbirkaEliParser.parse("https://opendata.eselpoint.gov.cz/esel-esb/foo/bar");
+        assertFalse(p.isValid());
+    }
+
+    @Test
+    void parse_malformedDate_keepsLevelVersionDateNull() {
+        String url = "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2000/361/not-a-date";
+        ParsedEli p = EsbirkaEliParser.parse(url);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.VERSION, p.level());
+        assertNull(p.versionDate());
+        assertNotNull(p.versionIri());
+    }
+
+    @Test
+    void parse_fragmentMissingDokumentNorma_returnsInvalid() {
+        String bogusFragment = CANONICAL_VERSION + "/something/else/par_2";
+        ParsedEli p = EsbirkaEliParser.parse(bogusFragment);
+        assertFalse(p.isValid());
+    }
+
+    @Test
+    void parse_yearNotInteger_returnsInvalid() {
+        String url = "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/twentythousand/361";
+        ParsedEli p = EsbirkaEliParser.parse(url);
+        assertFalse(p.isValid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"par", "odst", "pism", "bod", "ppc", "dil", "hlava", "oddil", "cast", "frag"})
+    void parse_allTenKinds_extractsKindCorrectly(String kind) {
+        String url = CANONICAL_VERSION + "/dokument/norma/" + kind + "_1";
+
+        ParsedEli p = EsbirkaEliParser.parse(url);
+
+        assertTrue(p.isValid());
+        assertEquals(ParsedEli.Level.FRAGMENT, p.level());
+        assertEquals(1, p.fragmentSegments().size());
+        assertEquals(kind, p.fragmentSegments().get(0).kind());
+        assertEquals("1", p.fragmentSegments().get(0).number());
+    }
+
+    @Test
+    void parse_preservesOriginalUrlVerbatim() {
+        String original = "https://opendata.eselpoint.cz/esel-esb/eli/cz/sb/2000/361";
+        ParsedEli p = EsbirkaEliParser.parse(original);
+        assertEquals(original, p.originalUrl());
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/sparql/SparqlCircuitBreakerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/sparql/SparqlCircuitBreakerTest.java
@@ -1,0 +1,116 @@
+package com.dia.ismdtoolbackend.utility.sparql;
+
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SparqlCircuitBreakerTest {
+
+    private SparqlCircuitBreaker breaker;
+
+    @BeforeEach
+    void setUp() {
+        breaker = new SparqlCircuitBreaker("test", 3, 50);
+    }
+
+    @Test
+    void closedBreakerLetsCallsThrough() {
+        AtomicInteger calls = new AtomicInteger();
+        for (int i = 0; i < 10; i++) {
+            String out = breaker.call(() -> {
+                calls.incrementAndGet();
+                return "ok";
+            });
+            assertEquals("ok", out);
+        }
+        assertEquals(10, calls.get());
+        assertFalse(breaker.isOpen());
+    }
+
+    @Test
+    void breakerOpensAfterThresholdFailures() {
+        AtomicInteger calls = new AtomicInteger();
+        for (int i = 0; i < 3; i++) {
+            assertThrows(SparqlEndpointUnavailableException.class, () -> breaker.call(() -> {
+                calls.incrementAndGet();
+                throw new SparqlEndpointUnavailableException("test", "boom");
+            }));
+        }
+        assertTrue(breaker.isOpen(), "breaker should be open after threshold consecutive failures");
+
+        // Subsequent call should fast-fail without invoking the action
+        int callsBefore = calls.get();
+        SparqlEndpointUnavailableException ex = assertThrows(SparqlEndpointUnavailableException.class,
+                () -> breaker.call(() -> {
+                    calls.incrementAndGet();
+                    return "should not run";
+                }));
+        assertTrue(ex.getMessage().contains("circuit breaker open"));
+        assertEquals(callsBefore, calls.get(), "open breaker must not invoke action");
+    }
+
+    @Test
+    void successResetsConsecutiveFailureCounter() {
+        // 2 failures
+        for (int i = 0; i < 2; i++) {
+            assertThrows(SparqlEndpointUnavailableException.class,
+                    () -> breaker.call(() -> { throw new SparqlEndpointUnavailableException("test", "boom"); }));
+        }
+        // success — resets
+        breaker.call(() -> "ok");
+        assertFalse(breaker.isOpen());
+
+        // 2 more failures — should NOT open since counter reset
+        for (int i = 0; i < 2; i++) {
+            assertThrows(SparqlEndpointUnavailableException.class,
+                    () -> breaker.call(() -> { throw new SparqlEndpointUnavailableException("test", "boom"); }));
+        }
+        assertFalse(breaker.isOpen(), "2 failures after reset should NOT open the breaker (threshold is 3)");
+    }
+
+    @Test
+    void breakerHalfOpensAfterCooldownAndClosesOnSuccess() throws InterruptedException {
+        for (int i = 0; i < 3; i++) {
+            assertThrows(SparqlEndpointUnavailableException.class,
+                    () -> breaker.call(() -> { throw new SparqlEndpointUnavailableException("test", "boom"); }));
+        }
+        assertTrue(breaker.isOpen());
+
+        Thread.sleep(60); // cooldown is 50ms
+
+        // Trial call succeeds — breaker closes
+        String out = breaker.call(() -> "ok");
+        assertEquals("ok", out);
+        assertFalse(breaker.isOpen());
+    }
+
+    @Test
+    void breakerHalfOpensAfterCooldownAndReopensOnFailure() throws InterruptedException {
+        for (int i = 0; i < 3; i++) {
+            assertThrows(SparqlEndpointUnavailableException.class,
+                    () -> breaker.call(() -> { throw new SparqlEndpointUnavailableException("test", "boom"); }));
+        }
+        Thread.sleep(60);
+
+        // Trial call fails — breaker re-opens
+        assertThrows(SparqlEndpointUnavailableException.class,
+                () -> breaker.call(() -> { throw new SparqlEndpointUnavailableException("test", "still down"); }));
+        assertTrue(breaker.isOpen());
+    }
+
+    @Test
+    void nonSparqlExceptionsDoNotTripTheBreaker() {
+        for (int i = 0; i < 10; i++) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> breaker.call(() -> { throw new IllegalArgumentException("user input"); }));
+        }
+        assertFalse(breaker.isOpen(), "non-SPARQL exceptions are user/domain errors and must not count");
+    }
+}


### PR DESCRIPTION
Summary

Concept detail (GET /api/concept/{slug}/detail) — additive, backward-compatible. Two new fields on conceptDetail:

  - definující-ustanovení-právního-předpisu-resolved
  - související-ustanovení-právního-předpisu-resolved

  Same indices as the existing string arrays. Each entry is a ResolvedLegalSourceDto with parsed fields (law/version/fragment IRI, year/number, sbírka code, fragment segments, display label) and an enrichmentStatus:

  Concept detail does zero SPARQL — latency unchanged, decoupled from e-Sbírka health.
  
  GET /api/eli/resolve?iri=... — new public endpoint. Synchronously fetches the official Czech fragment citation (§ 119 odst. 2 písm. a)), version validity end-date, and isLatest flag via SPARQL. Returns 200 even on failure (enrichmentStatus = UNAVAILABLE | NOT_FOUND | INVALID_IRI) so the FE renders gracefully.

  Architecture
  
  - Two-call design. Concept detail returns parse-only data instantly; FE fires /resolve per PENDING URL after render. No coupling between concept-detail latency and e-Sbírka availability.
  - Caffeine cache (esbirkaFragmentResolution, 24h TTL, 5000 entries). Cache key is the canonical fragment IRI — legacy eselpoint.cz and canonical opendata.eselpoint.gov.cz URLs collapse to one cache entry.
  - Circuit breaker (SparqlCircuitBreaker) on the SPARQL call: 5 consecutive failures opens the breaker for 30s. Prevents thundering herd against a dead endpoint while keeping cache hits free.

  Key implementation details
  
  - EsbirkaEliParser (new) decomposes ELI URLs into structured fields and normalizes legacy hosts.
  - EsbirkaCzechCitationFormatter (new) builds display labels like "Zákon č. 361/2000 Sb., § 2 písm. d) (znění od 1. 4. 2024)". Drops structural ancestors (Část/Hlava/Díl/Oddíl) when par_ is present, mirroring e-Sbírka's own citation style.
  - EsbirkaFragmentResolutionCache is a dedicated @Component so Spring's caching proxy fires (a @Cacheable method called from the same bean would be bypassed).
  - SPARQL goes through the existing unified HttpSparqlExecutor → SparqlExceptionMapper → SparqlEndpointUnavailableException cascade.
  - CacheConfig refactored from shared setCaffeine to per-cache registerCustomCache so the new 24h TTL coexists with the existing 60-min catalogue caches.
