### PR TITLE
fix(compose): mount fuseki config over baked config.ttl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
     volumes:
       - fuseki_tdb2:/opt/fuseki/run/databases/tdb2/ismd-tool-dataset
       - fuseki_lucene:/opt/fuseki/run/databases/lucene/ismd-tool-dataset
-      - ./fuseki-config.ttl:/opt/fuseki/run/configuration/ismd-tool-dataset.ttl
+      - ./fuseki-config.ttl:/opt/fuseki/run/configuration/config.ttl
     networks:
       - ismd-network
 


### PR DESCRIPTION
Mounting to ismd-tool-dataset.ttl left the image's baked config.ttl in place, so Fuseki auto-discovered both files and tried to open the Lucene index twice — the second openIndexWriter failed and the container exited with code 1.