### PR TITLE
ci(security): fix codeql build and authenticate maven dep submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,37 @@
+name: Maven Dependency Submission
+
+# Submits the resolved Maven dependency graph to GitHub so Dependabot
+# alerts and dependency review reflect the real transitive tree.
+# Replaces the repo's "Automatic dependency submission" setting, which
+# cannot authenticate against our private GitHub Packages repo.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: read
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Submit dependency snapshot
+        uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
- deps: add explicit maven-dependency-submission workflow that authenticates against GitHub Packages via PACKAGES_READ_TOKEN, replacing the automatic submission that 401s on our private repo