### PR TITLE
non legal source dto for detail workflow

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/NonLegalSourceDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/NonLegalSourceDto.java
@@ -1,0 +1,31 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NonLegalSourceDto {
+
+    private String iri;
+
+    @JsonProperty("typ")
+    private String typ;
+
+    @JsonProperty("název")
+    private Map<String, String> nazev;
+
+    @JsonProperty("popis")
+    private Map<String, String> popis;
+
+    private String url;
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/OntologyDetailModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/OntologyDetailModel.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.models;
 
+import com.dia.ismdtoolbackend.controller.dto.NonLegalSourceDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
 import com.dia.ismdtoolbackend.models.concept.ConceptPropertiesModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptRelationshipsModel;
@@ -104,10 +105,10 @@ public class OntologyDetailModel {
         private List<ResolvedLegalSourceDto> relatedLegalSourcesResolved;
 
         @JsonProperty("definující-nelegislativní-zdroj")
-        private List<Map<String, Object>> definingNonLegalSources;
+        private List<NonLegalSourceDto> definingNonLegalSources;
 
         @JsonProperty("související-nelegislativní-zdroj")
-        private List<Map<String, Object>> relatedNonLegalSources;
+        private List<NonLegalSourceDto> relatedNonLegalSources;
 
         @JsonProperty("způsob-sdílení-údaje")
         private List<String> sharingMethods;

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/PublishedConceptDeviationModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/PublishedConceptDeviationModel.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.models.concept;
 
+import com.dia.ismdtoolbackend.controller.dto.NonLegalSourceDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -59,10 +60,10 @@ public class PublishedConceptDeviationModel {
     private PropertyDeviation<List<String>> relatedLegalSources;
 
     @JsonProperty("definující-nelegislativní-zdroj")
-    private PropertyDeviation<List<Map<String, Object>>> definingNonLegalSources;
+    private PropertyDeviation<List<NonLegalSourceDto>> definingNonLegalSources;
 
     @JsonProperty("související-nelegislativní-zdroj")
-    private PropertyDeviation<List<Map<String, Object>>> relatedNonLegalSources;
+    private PropertyDeviation<List<NonLegalSourceDto>> relatedNonLegalSources;
 
     @JsonProperty("způsob-sdílení-údajů")
     private PropertyDeviation<List<String>> sharingMethods;

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptDeviationComparator.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptDeviationComparator.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.service.impl;
 
+import com.dia.ismdtoolbackend.controller.dto.NonLegalSourceDto;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.concept.PublishedConceptDeviationModel;
 import lombok.extern.slf4j.Slf4j;
@@ -281,7 +282,7 @@ public class ConceptDeviationComparator {
             PublishedConceptDeviationModel.PublishedConceptDeviationModelBuilder builder) {
 
         if (areDifferent(local.getDefiningNonLegalSources(), published.getDefiningNonLegalSources())) {
-            builder.definingNonLegalSources(PublishedConceptDeviationModel.PropertyDeviation.<List<Map<String, Object>>>builder()
+            builder.definingNonLegalSources(PublishedConceptDeviationModel.PropertyDeviation.<List<NonLegalSourceDto>>builder()
                     .localValue(local.getDefiningNonLegalSources())
                     .publishedValue(published.getDefiningNonLegalSources())
                     .isDifferent(true)
@@ -297,7 +298,7 @@ public class ConceptDeviationComparator {
             PublishedConceptDeviationModel.PublishedConceptDeviationModelBuilder builder) {
 
         if (areDifferent(local.getRelatedNonLegalSources(), published.getRelatedNonLegalSources())) {
-            builder.relatedNonLegalSources(PublishedConceptDeviationModel.PropertyDeviation.<List<Map<String, Object>>>builder()
+            builder.relatedNonLegalSources(PublishedConceptDeviationModel.PropertyDeviation.<List<NonLegalSourceDto>>builder()
                     .localValue(local.getRelatedNonLegalSources())
                     .publishedValue(published.getRelatedNonLegalSources())
                     .isDifferent(true)

--- a/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.utility.detail;
 
+import com.dia.ismdtoolbackend.controller.dto.NonLegalSourceDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto.EnrichmentStatus;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
@@ -312,8 +313,10 @@ public class OntologyDetailExtractor {
                         (List<String>) conceptMap.get(DEFINUJICI_USTANOVENI_PRAVNIHO_PREDPISU)))
                 .relatedLegalSourcesResolved(buildResolvedSources(
                         (List<String>) conceptMap.get(SOUVISEJICI_USTANOVENI_PRAVNIHO_PREDPISU)))
-                .definingNonLegalSources((List<Map<String, Object>>) conceptMap.get(DEFINUJICI_NELEGISLATIVNI_ZDROJ))
-                .relatedNonLegalSources((List<Map<String, Object>>) conceptMap.get(SOUVISEJICI_NELEGISLATIVNI_ZDROJ))
+                .definingNonLegalSources(buildNonLegalSources(
+                        (List<Map<String, Object>>) conceptMap.get(DEFINUJICI_NELEGISLATIVNI_ZDROJ)))
+                .relatedNonLegalSources(buildNonLegalSources(
+                        (List<Map<String, Object>>) conceptMap.get(SOUVISEJICI_NELEGISLATIVNI_ZDROJ)))
                 .sharingMethods((List<String>) conceptMap.get(ZPUSOBY_SDILENI_ALT))
                 .acquisitionMethod(extractStringFromValue(conceptMap.get(ZPUSOB_ZISKANI_ALT)))
                 .contentType(extractStringFromValue(conceptMap.get(TYP_OBSAHU_ALT)))
@@ -324,6 +327,44 @@ public class OntologyDetailExtractor {
                 .conceptProperties(properties)
                 .conceptRelationships(relationships)
                 .build();
+    }
+
+    static List<NonLegalSourceDto> buildNonLegalSources(List<Map<String, Object>> rawSources) {
+        if (rawSources == null || rawSources.isEmpty()) {
+            return null;
+        }
+        List<NonLegalSourceDto> out = new ArrayList<>(rawSources.size());
+        for (Map<String, Object> src : rawSources) {
+            if (src == null) {
+                continue;
+            }
+            out.add(NonLegalSourceDto.builder()
+                    .iri(asString(src.get("iri")))
+                    .typ(asString(src.get("typ")))
+                    .nazev(asMultilingualMap(src.get(NAZEV)))
+                    .popis(asMultilingualMap(src.get(POPIS)))
+                    .url(asString(src.get("url")))
+                    .build());
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    private static String asString(Object value) {
+        return value instanceof String s ? s : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> asMultilingualMap(Object value) {
+        if (!(value instanceof Map<?, ?> map) || map.isEmpty()) {
+            return null;
+        }
+        Map<String, String> out = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> e : map.entrySet()) {
+            if (e.getKey() instanceof String key && e.getValue() instanceof String val) {
+                out.put(key, val);
+            }
+        }
+        return out.isEmpty() ? null : out;
     }
 
     private String extractStringFromValue(Object value) {

--- a/src/test/java/com/dia/ismdtoolbackend/service/ConceptDeviationComparatorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/ConceptDeviationComparatorTest.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.service;
 
+import com.dia.ismdtoolbackend.controller.dto.NonLegalSourceDto;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.concept.PublishedConceptDeviationModel;
 import com.dia.ismdtoolbackend.service.impl.ConceptDeviationComparator;
@@ -329,7 +330,10 @@ class ConceptDeviationComparatorTest {
 
         @Test
         void identicalNonLegalSources_shouldReturnNoDeviation() {
-            Map<String, Object> source = Map.of("url", "https://example.com", "name", "Source");
+            NonLegalSourceDto source = NonLegalSourceDto.builder()
+                    .url("https://example.com")
+                    .nazev(Map.of("cs", "Source"))
+                    .build();
             OntologyDetailModel.ConceptDetailModel local = minimalConcept()
                     .definingNonLegalSources(List.of(source))
                     .build();
@@ -345,10 +349,10 @@ class ConceptDeviationComparatorTest {
         @Test
         void differentNonLegalSources_shouldDetectDeviation() {
             OntologyDetailModel.ConceptDetailModel local = minimalConcept()
-                    .definingNonLegalSources(List.of(Map.of("url", "https://a.com")))
+                    .definingNonLegalSources(List.of(NonLegalSourceDto.builder().url("https://a.com").build()))
                     .build();
             OntologyDetailModel.ConceptDetailModel published = minimalConcept()
-                    .definingNonLegalSources(List.of(Map.of("url", "https://b.com")))
+                    .definingNonLegalSources(List.of(NonLegalSourceDto.builder().url("https://b.com").build()))
                     .build();
 
             PublishedConceptDeviationModel result = comparator.compareConceptDetails(local, published);


### PR DESCRIPTION
GET concept detail now returns properly typed dto for non legal sources, previously generic Map<Map<String, Object>>