### PR TITLE
minimalistic get ontology concept detail for fe navigation

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -140,6 +140,7 @@ public class SecurityConfig {
                         "/actuator/info",
                         "/api/ontology/*/download",
                         "/api/ontology/*/detail",
+                        "/api/ontology/concepts",
                         "/api/ontology/list",
                         "/api/concept/list",
                         "/api/concept/*/detail",

--- a/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
@@ -8,10 +8,13 @@ import com.dia.ismdtoolbackend.controller.dto.ApiResponseDto;
 import com.dia.ismdtoolbackend.controller.dto.CatalogRecordRequestDto;
 import com.dia.ismdtoolbackend.controller.dto.CatalogRequestDto;
 import com.dia.ismdtoolbackend.controller.dto.GetOntologyDto;
+import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
 import com.dia.ismdtoolbackend.models.OntologyCreateModel;
+import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.OntologyEditModel;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
+import com.dia.ismdtoolbackend.service.NkdDetailService;
 import com.dia.ismdtoolbackend.service.OntologyDownloadService;
 import com.dia.ismdtoolbackend.service.OntologyService;
 import com.dia.ismdtoolbackend.service.OntologyUploadService;
@@ -21,6 +24,7 @@ import com.dia.validation.ValidationReportDto;
 import com.dia.validation.ValidationResult;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +58,7 @@ public class OntologyController {
     private final ValidationService validationService;
     private final ValidationClient validationClient;
     private final ValidationConfig validationConfig;
+    private final NkdDetailService nkdDetailService;
 
     @Operation(
             summary = "Nahrání slovníku ze souboru",
@@ -193,6 +198,33 @@ public class OntologyController {
         GetOntologyDto ontologyDto = ontologyService.getOntologyDetailModel(slug);
 
         return ResponseEntity.ok().body(ApiResponseDto.success(ontologyDto, "Detail slovníku byl úspěšně načten."));
+    }
+
+    @Operation(
+            summary = "Seznam pojmů slovníku podle IRI",
+            description = "Vrací seznam pojmů slovníku podle jeho IRI. Parametr source určuje zdroj: ISMD (lokální úložiště) nebo NKD (Národní katalog dat). Veřejný endpoint."
+    )
+    @GetMapping("/concepts")
+    public ResponseEntity<ApiResponseDto<List<OntologyDetailModel.ConceptDetailModel>>> getConceptsByIri(
+            @Parameter(description = "IRI slovníku", required = true)
+            @RequestParam String iri,
+            @Parameter(description = "Zdroj: ISMD nebo NKD", required = true)
+            @RequestParam SearchSource source
+    ) {
+        log.info("Ontology concepts requested, iri: {}, source: {}", iri, source);
+
+        List<OntologyDetailModel.ConceptDetailModel> concepts = switch (source) {
+            case ISMD -> ontologyService.getConceptsByIri(iri);
+            case NKD -> {
+                OntologyDetailModel detail = nkdDetailService.getOntologyDetail(iri).getOntologyDetail();
+                List<OntologyDetailModel.ConceptDetailModel> nkdConcepts = detail.getConcepts();
+                yield nkdConcepts != null ? nkdConcepts : List.of();
+            }
+            default -> throw new IllegalArgumentException(
+                    "Nepodporovaný zdroj: " + source + ". Povolené hodnoty: ISMD, NKD.");
+        };
+
+        return ResponseEntity.ok().body(ApiResponseDto.success(concepts, "Seznam pojmů byl úspěšně načten."));
     }
 
     @Operation(

--- a/src/main/java/com/dia/ismdtoolbackend/service/OntologyService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/OntologyService.java
@@ -2,6 +2,7 @@ package com.dia.ismdtoolbackend.service;
 
 import com.dia.ismdtoolbackend.controller.dto.GetOntologyDto;
 import com.dia.ismdtoolbackend.models.OntologyCreateModel;
+import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.OntologyEditModel;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 
@@ -12,6 +13,7 @@ public interface OntologyService {
     void deleteOntology(Long ontologyId);
     OntologyMetadataModel createOntology(OntologyCreateModel ontologyCreateModel, String userId);
     GetOntologyDto getOntologyDetailModel(String ontologySlug);
+    List<OntologyDetailModel.ConceptDetailModel> getConceptsByIri(String ontologyIri);
     OntologyMetadataModel editOntology(Long id, OntologyEditModel ontologyEditModel);
     List<OntologyMetadataModel> getAll(String userId, Boolean isPublished);
     List<OntologyMetadataModel> getBySlugs(List<String> slugs);

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
@@ -192,6 +192,30 @@ public class OntologyServiceImpl implements OntologyService {
         return result;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<OntologyDetailModel.ConceptDetailModel> getConceptsByIri(String ontologyIri) {
+        if (ontologyIri == null || ontologyIri.isBlank()) {
+            throw new OntologyException("IRI slovníku musí být zadáno.");
+        }
+
+        Optional<OntologyMetadataEntity> ontologyMetadataOpt = ontologyMetadataRepository.findByGraphName(ontologyIri);
+        if (ontologyMetadataOpt.isEmpty()) {
+            log.info("ISMD ontology not found for IRI: {}", ontologyIri);
+            throw new OntologyException("Slovník s IRI " + ontologyIri + " nebyl nalezen.");
+        }
+
+        Model rawModel = jenaTDB2Repository.fetchGraph(ontologyIri);
+        if (rawModel.isEmpty()) {
+            throw new OntologyException("Slovník je prázdný, nebo nebyl nalezen.");
+        }
+
+        Model processedModel = detailExtractor.applyOFNTransformations(rawModel);
+        OntologyDetailModel detailModel = detailExtractor.extractOntologyDetail(processedModel);
+        List<OntologyDetailModel.ConceptDetailModel> concepts = detailModel.getConcepts();
+        return concepts != null ? concepts : List.of();
+    }
+
     private void validateOntologyCreateModel(OntologyCreateModel model) {
         if (model == null) {
             throw new OntologyException("Data pro vytvoření slovníku jsou prázdná");

--- a/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
@@ -5,11 +5,15 @@ import com.dia.ismdtoolbackend.config.ValidationConfig;
 import com.dia.ismdtoolbackend.config.security.TestOntologySecurityService;
 import com.dia.ismdtoolbackend.config.security.TestSecurityConfig;
 import com.dia.ismdtoolbackend.config.security.WithMockSecurityUser;
+import com.dia.ismdtoolbackend.controller.dto.GetNkdOntologyDto;
 import com.dia.ismdtoolbackend.controller.dto.GetOntologyDto;
+import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.EmptyFileException;
+import com.dia.ismdtoolbackend.exception.NkdResourceNotFoundException;
 import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
 import com.dia.ismdtoolbackend.exception.UnsupportedRdfFormatException;
 import com.dia.ismdtoolbackend.models.*;
+import com.dia.ismdtoolbackend.service.NkdDetailService;
 import com.dia.ismdtoolbackend.service.OntologyDownloadService;
 import com.dia.ismdtoolbackend.service.OntologyService;
 import com.dia.ismdtoolbackend.service.OntologyUploadService;
@@ -75,6 +79,9 @@ class OntologyControllerTest {
 
     @MockitoBean
     private ValidationConfig validationConfig;
+
+    @MockitoBean
+    private NkdDetailService nkdDetailService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -955,5 +962,150 @@ class OntologyControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    // ========== Get Concepts By IRI Tests ==========
+
+    @Test
+    void testGetConceptsByIri_IsmdSuccess() throws Exception {
+        String iri = "http://example.org/test-ontology";
+
+        OntologyDetailModel.ConceptDetailModel concept = OntologyDetailModel.ConceptDetailModel.builder()
+                .iri(iri + "/pojem/foo")
+                .name(java.util.Map.of("cs", "Foo"))
+                .build();
+
+        when(ontologyService.getConceptsByIri(iri))
+                .thenReturn(java.util.List.of(concept));
+
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", iri)
+                        .param("source", "ISMD"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].iri").value(iri + "/pojem/foo"))
+                .andExpect(jsonPath("$.message").value("Seznam pojmů byl úspěšně načten."));
+
+        verify(nkdDetailService, never()).getOntologyDetail(anyString());
+    }
+
+    @Test
+    void testGetConceptsByIri_NkdSuccess() throws Exception {
+        String iri = "https://data.gov.cz/zdroj/slovnik/test";
+
+        OntologyDetailModel.ConceptDetailModel concept = OntologyDetailModel.ConceptDetailModel.builder()
+                .iri(iri + "/pojem/bar")
+                .name(java.util.Map.of("cs", "Bar"))
+                .build();
+        OntologyDetailModel detail = OntologyDetailModel.builder()
+                .iri(iri)
+                .concepts(java.util.List.of(concept))
+                .build();
+
+        when(nkdDetailService.getOntologyDetail(iri))
+                .thenReturn(new GetNkdOntologyDto(detail));
+
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", iri)
+                        .param("source", "NKD"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].iri").value(iri + "/pojem/bar"))
+                .andExpect(jsonPath("$.message").value("Seznam pojmů byl úspěšně načten."));
+
+        verify(ontologyService, never()).getConceptsByIri(anyString());
+    }
+
+    @Test
+    void testGetConceptsByIri_NkdEmptyConceptsCoercedToEmptyArray() throws Exception {
+        String iri = "https://data.gov.cz/zdroj/slovnik/test";
+
+        OntologyDetailModel detail = OntologyDetailModel.builder()
+                .iri(iri)
+                .concepts(null)
+                .build();
+
+        when(nkdDetailService.getOntologyDetail(iri))
+                .thenReturn(new GetNkdOntologyDto(detail));
+
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", iri)
+                        .param("source", "NKD"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void testGetConceptsByIri_IsmdNotFound() throws Exception {
+        String iri = "http://example.org/missing";
+
+        when(ontologyService.getConceptsByIri(iri))
+                .thenThrow(new org.apache.jena.ontology.OntologyException(
+                        "Slovník s IRI " + iri + " nebyl nalezen."));
+
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", iri)
+                        .param("source", "ISMD"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.message").value("Slovník s IRI " + iri + " nebyl nalezen."));
+    }
+
+    @Test
+    void testGetConceptsByIri_NkdNotFound() throws Exception {
+        String iri = "https://data.gov.cz/zdroj/slovnik/missing";
+
+        when(nkdDetailService.getOntologyDetail(iri))
+                .thenThrow(new NkdResourceNotFoundException(
+                        "Slovník s IRI " + iri + " nebyl v NKD nalezen."));
+
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", iri)
+                        .param("source", "NKD"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.message").value("Slovník s IRI " + iri + " nebyl v NKD nalezen."));
+    }
+
+    @Test
+    void testGetConceptsByIri_UnsupportedSourceRejected() throws Exception {
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", "http://example.org/x")
+                        .param("source", "UNPUBLISHED"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(ontologyService, never()).getConceptsByIri(anyString());
+        verify(nkdDetailService, never()).getOntologyDetail(anyString());
+    }
+
+    @Test
+    void testGetConceptsByIri_UnknownSourceRejected() throws Exception {
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", "http://example.org/x")
+                        .param("source", "BOGUS"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    void testGetConceptsByIri_MissingSourceParamRejected() throws Exception {
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("iri", "http://example.org/x"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testGetConceptsByIri_MissingIriParamRejected() throws Exception {
+        mockMvc.perform(get("/api/ontology/concepts")
+                        .param("source", "ISMD"))
+                .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
new GET ontology concepts that accepts: iri, source
used to retrieve ontology concepts List<OntologyDetailModel.ConceptDetailModel> for FE navigation on detail page