### PR TITLE
resolve conept iris metadata pipeline

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/client/NkdSparqlClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/NkdSparqlClient.java
@@ -1,9 +1,13 @@
 package com.dia.ismdtoolbackend.client;
 
 import com.dia.ismdtoolbackend.config.NkdConfig;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
+import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.query.NKDSPARQLConstructQuery;
+import com.dia.ismdtoolbackend.repository.JenaTDB2Repository;
 import com.dia.ismdtoolbackend.utility.detail.OntologyDetailExtractor;
+import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
 import com.dia.ismdtoolbackend.utility.sparql.HttpSparqlExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.query.QuerySolution;
@@ -119,6 +123,53 @@ public class NkdSparqlClient {
         }
         log.debug("Fetched {} triples from NKD for ontology: {}", resultModel.get().size(), ontologyIri);
         return resultModel;
+    }
+
+    /**
+     * Batched concept-reference resolver against NKD. For each input IRI present
+     * on the remote endpoint, returns its {@code skos:inScheme} (ontology IRI)
+     * and the scheme's multilingual {@code dcterms:description}. IRIs absent from
+     * NKD are absent from the returned map.
+     *
+     * <p>One CONSTRUCT for the whole batch = one HTTP round-trip. Replaces the
+     * naive per-IRI fan-out which would issue N {@link #buildConstructQuery}
+     * calls (each pulling 100–300 triples of full concept graph) and serialize
+     * on the 4-permit thread pool.
+     *
+     * <p>Lenient mode: an NKD outage degrades to an empty map rather than
+     * failing the whole resolve request.
+     */
+    public Map<String, ResolvedConceptDto> fetchConceptResolutions(List<String> conceptIris) {
+        if (conceptIris == null || conceptIris.isEmpty()) {
+            return Map.of();
+        }
+        if (!executor.isConfigured()) {
+            log.warn("NKD endpoint not configured, skipping concept resolution batch");
+            return Map.of();
+        }
+        List<String> safeConceptIris = conceptIris.stream()
+                .filter(SparqlIriValidator::isSafeHttpIri)
+                .toList();
+        if (safeConceptIris.size() != conceptIris.size()) {
+            log.warn("Dropped {} invalid concept IRI(s) from NKD fetchConceptResolutions",
+                    conceptIris.size() - safeConceptIris.size());
+        }
+        if (safeConceptIris.isEmpty()) {
+            return Map.of();
+        }
+
+        String query = NKDSPARQLConstructQuery.buildResolutionConstructQuery(safeConceptIris);
+        Optional<Model> result = executor.constructLenient(
+                "NKD concept resolution batch (" + safeConceptIris.size() + " IRIs)", query);
+        if (result.isEmpty()) {
+            log.debug("NKD returned no resolutions for {} requested IRI(s)", safeConceptIris.size());
+            return Map.of();
+        }
+        Map<String, ResolvedConceptDto> resolutions =
+                JenaTDB2Repository.projectResolutions(result.get(), SearchSource.NKD);
+        log.debug("Resolved {} of {} requested concept IRI(s) against NKD",
+                resolutions.size(), safeConceptIris.size());
+        return resolutions;
     }
 
     public List<String> getPublishedResourcesList(List<String> resourceIris) {

--- a/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
@@ -34,6 +34,9 @@ public class CacheConfig {
     static final long ESBIRKA_RESOLUTION_TTL_HOURS = 24;
     static final long ESBIRKA_RESOLUTION_MAX_ENTRIES = 5_000;
 
+    static final long CONCEPT_METADATA_TTL_HOURS = 24;
+    static final long CONCEPT_METADATA_MAX_ENTRIES = 10_000;
+
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager mgr = new CaffeineCacheManager();
@@ -51,6 +54,15 @@ public class CacheConfig {
         mgr.registerCustomCache("esbirkaFragmentResolution", Caffeine.newBuilder()
                 .expireAfterWrite(ESBIRKA_RESOLUTION_TTL_HOURS, TimeUnit.HOURS)
                 .maximumSize(ESBIRKA_RESOLUTION_MAX_ENTRIES)
+                .build());
+
+        // Backs the concept-reference resolver (POST /api/ontology/concepts/resolve).
+        // Per-IRI entries so partially-overlapping detail views share cache hits. 24h
+        // TTL is the safety net for NKD-side changes we can't observe; ISMD mutations
+        // are invalidated synchronously via @CacheEvict on OntologyServiceImpl.
+        mgr.registerCustomCache("conceptMetadataResolution", Caffeine.newBuilder()
+                .expireAfterWrite(CONCEPT_METADATA_TTL_HOURS, TimeUnit.HOURS)
+                .maximumSize(CONCEPT_METADATA_MAX_ENTRIES)
                 .build());
 
         return mgr;

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -141,6 +141,7 @@ public class SecurityConfig {
                         "/api/ontology/*/download",
                         "/api/ontology/*/detail",
                         "/api/ontology/concepts",
+                        "/api/ontology/concepts/resolve",
                         "/api/ontology/list",
                         "/api/concept/list",
                         "/api/concept/*/detail",

--- a/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
@@ -9,6 +9,9 @@ import com.dia.ismdtoolbackend.controller.dto.CatalogRecordRequestDto;
 import com.dia.ismdtoolbackend.controller.dto.CatalogRequestDto;
 import com.dia.ismdtoolbackend.controller.dto.GetOntologyDto;
 import com.dia.ismdtoolbackend.controller.dto.MinimalConceptDto;
+import com.dia.ismdtoolbackend.controller.dto.ResolveConceptsRequest;
+import com.dia.ismdtoolbackend.controller.dto.ResolveConceptsResponse;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
 import com.dia.ismdtoolbackend.models.OntologyCreateModel;
@@ -20,6 +23,7 @@ import com.dia.ismdtoolbackend.service.OntologyDownloadService;
 import com.dia.ismdtoolbackend.service.OntologyService;
 import com.dia.ismdtoolbackend.service.OntologyUploadService;
 import com.dia.ismdtoolbackend.service.ValidationService;
+import com.dia.ismdtoolbackend.service.impl.ConceptMetadataResolver;
 import com.dia.validation.ValidationReport;
 import com.dia.validation.ValidationReportDto;
 import com.dia.validation.ValidationResult;
@@ -42,6 +46,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -60,6 +65,7 @@ public class OntologyController {
     private final ValidationClient validationClient;
     private final ValidationConfig validationConfig;
     private final NkdDetailService nkdDetailService;
+    private final ConceptMetadataResolver conceptMetadataResolver;
 
     @Operation(
             summary = "Nahrání slovníku ze souboru",
@@ -236,6 +242,26 @@ public class OntologyController {
         };
 
         return ResponseEntity.ok().body(ApiResponseDto.success(concepts, "Seznam pojmů byl úspěšně načten."));
+    }
+
+    @Operation(
+            summary = "Získání metadat referencovaných pojmů",
+            description = "Pro pole IRI pojmů vrací mapu IRI → {ontologyIri, ontologyDescription, source}. " +
+                    "FE volá tento endpoint po obdržení detailu pojmu/slovníku, aby obohatil prosté IRI " +
+                    "(nadřazená třída/vztah/vlastnost, ekvivalentní pojem, vlastnosti, vztahy) o informace " +
+                    "potřebné k navigaci napříč zdroji ISMD/NKD. Nerozlišené IRI jsou v odpovědi vynechány. " +
+                    "Veřejný endpoint."
+    )
+    @PostMapping("/concepts/resolve")
+    public ResponseEntity<ApiResponseDto<ResolveConceptsResponse>> resolveConceptReferences(
+            @Valid @RequestBody ResolveConceptsRequest request) {
+        log.info("Concept reference resolution requested, count: {}", request.iris().size());
+
+        Map<String, ResolvedConceptDto> resolved = conceptMetadataResolver.resolveAll(request.iris());
+
+        return ResponseEntity.ok().body(ApiResponseDto.success(
+                new ResolveConceptsResponse(resolved),
+                "Metadata referencovaných pojmů byla úspěšně načtena."));
     }
 
     @Operation(

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolveConceptsRequest.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolveConceptsRequest.java
@@ -1,0 +1,16 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * Request body for {@code POST /api/ontology/concepts/resolve}: the FE sends every
+ * concept IRI referenced by a concept-detail response so the backend can return
+ * scheme + ontology description + source in a single round-trip.
+ */
+public record ResolveConceptsRequest(
+        @NotEmpty List<@NotBlank String> iris
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolveConceptsResponse.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolveConceptsResponse.java
@@ -1,0 +1,13 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import java.util.Map;
+
+/**
+ * Response body for {@code POST /api/ontology/concepts/resolve}: a map keyed by
+ * input IRI. IRIs that couldn't be resolved against either ISMD or NKD are
+ * absent (no error, no null entry).
+ */
+public record ResolveConceptsResponse(
+        Map<String, ResolvedConceptDto> resolved
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolvedConceptDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/ResolvedConceptDto.java
@@ -1,0 +1,22 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import com.dia.ismdtoolbackend.enums.SearchSource;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+import java.util.Map;
+
+/**
+ * Resolved metadata for a single concept IRI. Returned as a map value keyed by
+ * the input IRI; unresolved IRIs are simply absent from the response map (the
+ * FE falls back to rendering the plain IRI).
+ */
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResolvedConceptDto(
+        String iri,
+        String ontologyIri,
+        Map<String, String> ontologyDescription,
+        SearchSource source
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/query/NKDSPARQLConstructQuery.java
+++ b/src/main/java/com/dia/ismdtoolbackend/query/NKDSPARQLConstructQuery.java
@@ -2,7 +2,36 @@ package com.dia.ismdtoolbackend.query;
 
 import org.apache.jena.query.ParameterizedSparqlString;
 
+import java.util.List;
+
 public class NKDSPARQLConstructQuery {
+
+    /**
+     * Narrow batched CONSTRUCT for the concept-reference resolver:
+     * pulls only {@code skos:inScheme} and the scheme's {@code dcterms:description}
+     * for a batch of concept IRIs. One HTTP round-trip resolves the whole batch,
+     * which is ~50× cheaper than calling {@link #buildConstructQuery(String)} per
+     * IRI (that variant pulls the full concept graph + blank-node expansion).
+     */
+    public static String buildResolutionConstructQuery(List<String> conceptIris) {
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.append("PREFIX skos: <http://www.w3.org/2004/02/skos/core#> ");
+        pss.append("PREFIX dcterms: <http://purl.org/dc/terms/> ");
+        pss.append("CONSTRUCT { ");
+        pss.append("  ?concept skos:inScheme ?scheme . ");
+        pss.append("  ?scheme dcterms:description ?desc . ");
+        pss.append("} WHERE { VALUES ?concept { ");
+        for (String iri : conceptIris) {
+            pss.appendIri(iri);
+            pss.append(" ");
+        }
+        pss.append("} ?concept skos:inScheme ?scheme . ");
+        pss.append("FILTER(STRSTARTS(STR(?concept), STR(?scheme))) ");
+        pss.append("OPTIONAL { ?scheme dcterms:description ?desc . } ");
+        pss.append("}");
+        return pss.toString();
+    }
+
     public static String buildConstructQuery(String conceptIri) {
         ParameterizedSparqlString pss = new ParameterizedSparqlString();
         pss.setCommandText("""

--- a/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
+++ b/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
@@ -1,14 +1,21 @@
 package com.dia.ismdtoolbackend.repository;
 
 import com.dia.ismdtoolbackend.config.DomainApplicationProfile;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
+import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
 import com.dia.ismdtoolbackend.utility.sparql.FusekiSparqlExecutor;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.query.ParameterizedSparqlString;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QuerySolution;
@@ -651,6 +658,130 @@ public class JenaTDB2Repository {
                         return result;
                     }
                 });
+    }
+
+    /**
+     * Batched ISMD concept-reference resolver. For each input IRI present in the
+     * local store, returns its {@code skos:inScheme} (ontology IRI) and the
+     * scheme's multilingual {@code dcterms:description}. IRIs not in any local
+     * graph are simply absent from the returned map — the caller falls back to
+     * NKD (or to the plain IRI on the FE).
+     *
+     * <p>One CONSTRUCT for the whole batch = one Fuseki semaphore permit. With
+     * only 10 permits total, per-IRI parallelism would serialize and quickly
+     * saturate the pool; batching keeps the worst-case path cheap.
+     *
+     * <p>Prefix-filtered: only matches the scheme whose IRI is a string prefix
+     * of the concept IRI. Local graphs sometimes contain stray
+     * {@code skos:inScheme} triples that point a foreign concept at the wrong
+     * scheme — without this filter the union-graph query returns those
+     * non-deterministically.
+     */
+    public Map<String, ResolvedConceptDto> fetchConceptResolutions(List<String> conceptIris) {
+        if (conceptIris == null || conceptIris.isEmpty()) {
+            return Map.of();
+        }
+
+        List<String> safeConceptIris = conceptIris.stream()
+                .filter(SparqlIriValidator::isSafeHttpIri)
+                .toList();
+        if (safeConceptIris.size() != conceptIris.size()) {
+            log.warn("Dropped {} invalid concept IRI(s) from fetchConceptResolutions",
+                    conceptIris.size() - safeConceptIris.size());
+        }
+        if (safeConceptIris.isEmpty()) {
+            return Map.of();
+        }
+
+        return executor.execute(
+                "fetching concept resolutions for " + safeConceptIris.size() + " IRIs",
+                "Failed to fetch concept resolutions from Fuseki",
+                conn -> {
+                    ParameterizedSparqlString pss = new ParameterizedSparqlString();
+                    pss.append("PREFIX skos: <http://www.w3.org/2004/02/skos/core#> ");
+                    pss.append("PREFIX dcterms: <http://purl.org/dc/terms/> ");
+                    pss.append("CONSTRUCT { ");
+                    pss.append("  ?concept skos:inScheme ?scheme . ");
+                    pss.append("  ?scheme dcterms:description ?desc . ");
+                    pss.append("} WHERE { VALUES ?concept { ");
+                    for (String iri : safeConceptIris) {
+                        pss.appendIri(iri);
+                        pss.append(" ");
+                    }
+                    pss.append("} GRAPH ?g { ");
+                    pss.append("  ?concept skos:inScheme ?scheme . ");
+                    pss.append("  FILTER(STRSTARTS(STR(?concept), STR(?scheme))) ");
+                    pss.append("  OPTIONAL { ?scheme dcterms:description ?desc . } ");
+                    pss.append("} }");
+                    try (QueryExecution qExec = conn.query(pss.asQuery())) {
+                        Model result = qExec.execConstruct();
+                        Map<String, ResolvedConceptDto> resolutions =
+                                projectResolutions(result, SearchSource.ISMD);
+                        log.debug("Resolved {} of {} requested concept IRI(s) against ISMD",
+                                resolutions.size(), safeConceptIris.size());
+                        return resolutions;
+                    }
+                });
+    }
+
+    /**
+     * Iterates the result Model once and projects rows into a map keyed by concept
+     * IRI. Same shape used by both ISMD ({@link #fetchConceptResolutions}) and the
+     * NKD client — co-located here as a static helper so the two callers stay in
+     * sync on parsing rules.
+     */
+    public static Map<String, ResolvedConceptDto> projectResolutions(Model model, SearchSource source) {
+        if (model == null || model.isEmpty()) {
+            return Map.of();
+        }
+        Property inScheme = model.createProperty("http://www.w3.org/2004/02/skos/core#inScheme");
+        Property description = model.createProperty("http://purl.org/dc/terms/description");
+
+        Map<String, ResolvedConceptDto> out = new HashMap<>();
+        StmtIterator inSchemeStmts = model.listStatements(null, inScheme, (RDFNode) null);
+        try {
+            while (inSchemeStmts.hasNext()) {
+                Statement stmt = inSchemeStmts.next();
+                if (!stmt.getSubject().isURIResource() || !stmt.getObject().isURIResource()) {
+                    continue;
+                }
+                String conceptIri = stmt.getSubject().getURI();
+                if (out.containsKey(conceptIri)) {
+                    continue;
+                }
+                Resource scheme = stmt.getObject().asResource();
+                Map<String, String> descriptions = collectMultilingual(scheme, description);
+                out.put(conceptIri, ResolvedConceptDto.builder()
+                        .iri(conceptIri)
+                        .ontologyIri(scheme.getURI())
+                        .ontologyDescription(descriptions.isEmpty() ? null : descriptions)
+                        .source(source)
+                        .build());
+            }
+        } finally {
+            inSchemeStmts.close();
+        }
+        return out;
+    }
+
+    private static Map<String, String> collectMultilingual(Resource subject, Property property) {
+        Map<String, String> values = new LinkedHashMap<>();
+        StmtIterator stmts = subject.listProperties(property);
+        try {
+            while (stmts.hasNext()) {
+                RDFNode node = stmts.next().getObject();
+                if (!node.isLiteral()) continue;
+                Literal lit = node.asLiteral();
+                String text = lit.getString();
+                if (text == null || text.isEmpty()) continue;
+                String lang = lit.getLanguage();
+                String key = (lang == null || lang.isEmpty()) ? "" : lang;
+                values.putIfAbsent(key, text);
+            }
+        } finally {
+            stmts.close();
+        }
+        return values;
     }
 
     /**

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptMetadataResolver.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptMetadataResolver.java
@@ -1,0 +1,100 @@
+package com.dia.ismdtoolbackend.service.impl;
+
+import com.dia.ismdtoolbackend.client.NkdSparqlClient;
+import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
+import com.dia.ismdtoolbackend.repository.JenaTDB2Repository;
+import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Resolves a batch of concept IRIs to {ontologyIri, ontologyDescription, source}.
+ * The FE calls this once per concept-detail view, after the detail response
+ * arrives, to enrich plain IRIs in {@code broaderClasses}, {@code exactMatches},
+ * etc. into rich navigation metadata.
+ *
+ * <p>Resolution strategy is cache-first, then batched:
+ * <ol>
+ *   <li>Validate and dedupe inputs (silently dropping unsafe IRIs — the request
+ *       is best-effort, one malformed IRI shouldn't 400 the whole batch).</li>
+ *   <li>Split into hits (served from Caffeine) and misses.</li>
+ *   <li>Misses are resolved against ISMD in <strong>one</strong> CONSTRUCT.</li>
+ *   <li>IRIs ISMD doesn't know about fall through to NKD in <strong>one</strong>
+ *       CONSTRUCT.</li>
+ * </ol>
+ *
+ * <p>This shape replaces a naive per-IRI parallel design that would serialize on
+ * the 10-permit Fuseki semaphore and the 4-permit NKD pool — cutting cold worst
+ * case from multi-second to a single ISMD batch + a single NKD HTTP round-trip.
+ *
+ * <p>{@code @Cacheable} isn't used here because per-IRI cache semantics would
+ * fight the batched-query design; instead we drive the {@code Cache} directly.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConceptMetadataResolver {
+
+    public static final String CACHE_NAME = "conceptMetadataResolution";
+
+    private final JenaTDB2Repository jenaTDB2Repository;
+    private final NkdSparqlClient nkdSparqlClient;
+    private final CacheManager cacheManager;
+
+    public Map<String, ResolvedConceptDto> resolveAll(List<String> iris) {
+        if (iris == null || iris.isEmpty()) {
+            return Map.of();
+        }
+        List<String> clean = iris.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .filter(SparqlIriValidator::isSafeHttpIri)
+                .toList();
+        if (clean.isEmpty()) {
+            return Map.of();
+        }
+
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        Map<String, ResolvedConceptDto> out = new HashMap<>();
+        List<String> misses = new ArrayList<>();
+        for (String iri : clean) {
+            ResolvedConceptDto hit = (cache == null) ? null : cache.get(iri, ResolvedConceptDto.class);
+            if (hit != null) {
+                out.put(iri, hit);
+            } else {
+                misses.add(iri);
+            }
+        }
+        if (misses.isEmpty()) {
+            return out;
+        }
+
+        Map<String, ResolvedConceptDto> ismdHits = jenaTDB2Repository.fetchConceptResolutions(misses);
+        ismdHits.forEach((iri, dto) -> {
+            if (cache != null) cache.put(iri, dto);
+            out.put(iri, dto);
+        });
+
+        List<String> remaining = misses.stream()
+                .filter(iri -> !ismdHits.containsKey(iri))
+                .toList();
+        if (!remaining.isEmpty()) {
+            Map<String, ResolvedConceptDto> nkdHits = nkdSparqlClient.fetchConceptResolutions(remaining);
+            nkdHits.forEach((iri, dto) -> {
+                if (cache != null) cache.put(iri, dto);
+                out.put(iri, dto);
+            });
+        }
+
+        return out;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
@@ -36,6 +36,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,6 +71,7 @@ public class OntologyServiceImpl implements OntologyService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
     public void deleteOntology(Long ontologyId) {
         Optional<OntologyMetadataEntity> ontologyMetadataOpt = ontologyMetadataRepository.findById(ontologyId);
         if (ontologyMetadataOpt.isEmpty()) {
@@ -94,6 +96,7 @@ public class OntologyServiceImpl implements OntologyService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
     public OntologyMetadataModel createOntology(OntologyCreateModel ontologyCreateModel, String userId) {
         validateOntologyCreateModel(ontologyCreateModel);
 
@@ -305,6 +308,7 @@ public class OntologyServiceImpl implements OntologyService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
     public OntologyMetadataModel editOntology(Long id, OntologyEditModel ontologyEditModel) {
         if (ontologyEditModel == null) {
             throw new OntologyException("Data pro úpravu slovníku jsou prázdná");

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
@@ -25,6 +25,7 @@ import com.dia.validation.ValidationReport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.util.unit.DataSize;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
@@ -104,6 +105,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
     public OntologyMetadataModel uploadFromFile(MultipartFile file, String providedName, String userId) throws IOException, OntologyUploadException {
         if (file.isEmpty()) {
             throw new EmptyFileException("Uploaded file is empty");

--- a/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
@@ -19,6 +19,7 @@ import com.dia.ismdtoolbackend.service.OntologyDownloadService;
 import com.dia.ismdtoolbackend.service.OntologyService;
 import com.dia.ismdtoolbackend.service.OntologyUploadService;
 import com.dia.ismdtoolbackend.service.ValidationService;
+import com.dia.ismdtoolbackend.service.impl.ConceptMetadataResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.jena.riot.Lang;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +84,9 @@ class OntologyControllerTest {
 
     @MockitoBean
     private NkdDetailService nkdDetailService;
+
+    @MockitoBean
+    private ConceptMetadataResolver conceptMetadataResolver;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 


### PR DESCRIPTION
 Summary

  Adds POST /api/ontology/concepts/resolve so the FE can enrich plain concept IRIs returned by concept/ontology detail (broaderClasses, broaderRelations, broaderProperties,
  exactMatches, domain, range, conceptProperties[].ref, conceptRelationships[].ref) with { ontologyIri, ontologyDescription, source }.

  Design

  - Batched, not parallel. One ISMD CONSTRUCT + one NKD CONSTRUCT per request, regardless of input size. Avoids serialising on the 10-permit Fuseki semaphore and the 4-permit NKD pool — keeps cold latency in the ~100–500 ms range instead of multi-second.
  - ISMD-first. Same IRI in both wins as ISMD; NKD only fires for IRIs ISMD doesn't satisfy.
  - Per-IRI Caffeine cache (conceptMetadataResolution, 24h, 10k entries) driven via CacheManager directly so cache-first split coexists with batched queries.
  @CacheEvict(allEntries=true) on OntologyServiceImpl.{create,edit,delete} + OntologyUploadServiceImpl.uploadFromFile for ISMD-side invalidation.
  - Prefix-filtered skos:inScheme (STRSTARTS(STR(?concept), STR(?scheme))) in both queries — without it, stray inScheme triples in unrelated graphs non-deterministically hijack foreign IRIs.
  - Unresolvable / malformed IRIs are silently absent from the response (no 400) — FE renders the plain IRI.

  What changed

  - New endpoint in OntologyController, allowlisted in SecurityConfig.
  - New ConceptMetadataResolver service.
  - New batched SPARQL methods: JenaTDB2Repository.fetchConceptResolutions (ISMD) and NkdSparqlClient.fetchConceptResolutions (NKD); shared parsing via
  JenaTDB2Repository.projectResolutions.
  - New narrow CONSTRUCT in NKDSPARQLConstructQuery.buildResolutionConstructQuery (replaces the heavy full-graph variant for this use case).
  - New cache in CacheConfig; new DTOs ResolveConceptsRequest, ResolveConceptsResponse, ResolvedConceptDto.
  - OntologyControllerTest mocks the new resolver bean.