### PR TITLE
Feat/ontology upload provided name removal

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/client/NkdSparqlClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/NkdSparqlClient.java
@@ -65,7 +65,7 @@ public class NkdSparqlClient {
         Model rawModel = resultModel.get();
         log.debug("Fetched {} triples from NKD for concept: {}", rawModel.size(), conceptIri);
         String inSchemeIri = extractInSchemeIri(rawModel, conceptIri);
-        Model processedModel = detailExtractor.applyOFNTransformations(rawModel);
+        Model processedModel = detailExtractor.applyOFNTransformationsForNkd(rawModel);
         OntologyDetailModel.ConceptDetailModel conceptDetail =
                 detailExtractor.extractConceptDetail(processedModel, conceptIri,
                         OntologyDetailExtractor.iriResolver());
@@ -100,7 +100,7 @@ public class NkdSparqlClient {
 
     public Optional<OntologyDetailModel> fetchPublishedOntology(String ontologyIri) {
         return fetchPublishedOntologyRaw(ontologyIri).map(resultModel -> {
-            Model processedModel = detailExtractor.applyOFNTransformations(resultModel);
+            Model processedModel = detailExtractor.applyOFNTransformationsForNkd(resultModel);
             OntologyDetailModel ontologyDetail = detailExtractor.extractOntologyDetail(processedModel,
                     OntologyDetailExtractor.iriResolver());
             log.debug("Successfully extracted published ontology detail from NKD: {}", ontologyIri);

--- a/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.dia.ismdtoolbackend.config;
 
 import com.dia.exceptions.ValidationException;
 import com.dia.ismdtoolbackend.controller.dto.ApiResponseDto;
+import com.dia.ismdtoolbackend.controller.dto.MissingInSchemeDecisionDto;
 import com.dia.ismdtoolbackend.exception.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -59,6 +60,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponseDto<Void>> handleOntologyValidationException(OntologyValidationException e) {
         log.warn("Ontology validation failed: {}", e.getMessage());
         return new ResponseEntity<>(ApiResponseDto.error(e.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InSchemeDecisionRequiredException.class)
+    public ResponseEntity<ApiResponseDto<MissingInSchemeDecisionDto>> handleInSchemeDecisionRequired(InSchemeDecisionRequiredException e) {
+        log.info("Upload paused for inScheme decision: {} concept(s) missing skos:inScheme",
+                e.getConceptsMissingInScheme().size());
+        MissingInSchemeDecisionDto data = new MissingInSchemeDecisionDto(
+                e.getGraphName(), e.getConceptsMissingInScheme());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseDto.error(data, e.getMessage(), InSchemeDecisionRequiredException.ERROR_CODE));
     }
 
     @ExceptionHandler(OntologyStorageException.class)

--- a/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
@@ -12,6 +12,7 @@ import com.dia.ismdtoolbackend.controller.dto.MinimalConceptDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolveConceptsRequest;
 import com.dia.ismdtoolbackend.controller.dto.ResolveConceptsResponse;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
 import com.dia.ismdtoolbackend.models.OntologyCreateModel;
@@ -74,15 +75,19 @@ public class OntologyController {
     @PostMapping(path="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponseDto<OntologyMetadataModel>> uploadFromFile(
             @RequestParam(value = "file", required = false) MultipartFile file,
+            @RequestParam(value = "normalizeMode", required = false) NormalizeMode normalizeMode,
+            @RequestParam(value = "conceptsToNormalize", required = false) List<String> conceptsToNormalize,
             @AuthenticationPrincipal SecurityUser securityUser) throws IOException {
 
         log.info(
-                "Ontology upload requested, fileName: {}, userId: {}",
+                "Ontology upload requested, fileName: {}, normalizeMode: {}, userId: {}",
                 file.getOriginalFilename(),
+                normalizeMode,
                 securityUser.getUserId()
         );
 
-        OntologyMetadataModel savedOntology = ontologyUploadService.uploadFromFile(file, securityUser.getUserId());
+        OntologyMetadataModel savedOntology = ontologyUploadService.uploadFromFile(
+                file, securityUser.getUserId(), normalizeMode, conceptsToNormalize);
         log.info("Ontology upload successful: {}", savedOntology.getGraphName());
 
         return ResponseEntity.ok().body(ApiResponseDto.success(savedOntology, "Slovník úspěšně nahrán: " + savedOntology.getGraphName()));

--- a/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
@@ -74,17 +74,15 @@ public class OntologyController {
     @PostMapping(path="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponseDto<OntologyMetadataModel>> uploadFromFile(
             @RequestParam(value = "file", required = false) MultipartFile file,
-            @RequestParam(name = "providedName", required = false) String providedName,
             @AuthenticationPrincipal SecurityUser securityUser) throws IOException {
 
         log.info(
-                "Ontology upload requested, fileName: {}, providedName: {}, userId: {}",
+                "Ontology upload requested, fileName: {}, userId: {}",
                 file.getOriginalFilename(),
-                providedName,
                 securityUser.getUserId()
         );
 
-        OntologyMetadataModel savedOntology = ontologyUploadService.uploadFromFile(file, providedName, securityUser.getUserId());
+        OntologyMetadataModel savedOntology = ontologyUploadService.uploadFromFile(file, securityUser.getUserId());
         log.info("Ontology upload successful: {}", savedOntology.getGraphName());
 
         return ResponseEntity.ok().body(ApiResponseDto.success(savedOntology, "Slovník úspěšně nahrán: " + savedOntology.getGraphName()));

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/ApiResponseDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/ApiResponseDto.java
@@ -11,22 +11,40 @@ public class ApiResponseDto<T> {
     private T data;
     private String message;
     private boolean success;
-    
+    /**
+     * Stable, machine-readable error code for the FE to branch on (e.g.
+     * {@code MISSING_INSCHEME_DECISION_REQUIRED}). Null for success responses and for
+     * errors that don't need a distinct code.
+     */
+    private String errorCode;
+
+    public ApiResponseDto(T data, String message, boolean success) {
+        this.data = data;
+        this.message = message;
+        this.success = success;
+        this.errorCode = null;
+    }
+
     public ApiResponseDto(String message, boolean success) {
         this.message = message;
         this.success = success;
         this.data = null;
+        this.errorCode = null;
     }
-    
+
     public static <T> ApiResponseDto<T> success(T data, String message) {
         return new ApiResponseDto<>(data, message, true);
     }
-    
+
     public static <T> ApiResponseDto<T> success(String message) {
         return new ApiResponseDto<>(message, true);
     }
-    
+
     public static <T> ApiResponseDto<T> error(String message) {
         return new ApiResponseDto<>(message, false);
+    }
+
+    public static <T> ApiResponseDto<T> error(T data, String message, String errorCode) {
+        return new ApiResponseDto<>(data, message, false, errorCode);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/MissingConceptDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/MissingConceptDto.java
@@ -1,0 +1,17 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+/**
+ * One owned concept that lacks {@code skos:inScheme} on upload. Shown to the user so
+ * they can verify the {@code proposedInScheme} (always the vocabulary IRI / graphName)
+ * before choosing to normalize or exclude it.
+ *
+ * @param conceptIri      the concept's IRI (under graphName's namespace)
+ * @param conceptName     the name extracted from the IRI, for display
+ * @param proposedInScheme the {@code skos:inScheme} value that NORMALIZE would add (= graphName)
+ */
+public record MissingConceptDto(
+        String conceptIri,
+        String conceptName,
+        String proposedInScheme
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/MissingInSchemeDecisionDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/MissingInSchemeDecisionDto.java
@@ -1,0 +1,17 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import java.util.List;
+
+/**
+ * Body of the {@code MISSING_INSCHEME_DECISION_REQUIRED} (HTTP 400) response. Lists
+ * the owned concepts that lack {@code skos:inScheme}; the user re-uploads the same file
+ * with a {@code normalizeMode} (+ optional {@code conceptsToNormalize}) decision.
+ *
+ * @param graphName               the authoritative vocabulary IRI derived from the RDF
+ * @param conceptsMissingInScheme owned concepts missing skos:inScheme, with proposed values
+ */
+public record MissingInSchemeDecisionDto(
+        String graphName,
+        List<MissingConceptDto> conceptsMissingInScheme
+) {
+}

--- a/src/main/java/com/dia/ismdtoolbackend/enums/NormalizeMode.java
+++ b/src/main/java/com/dia/ismdtoolbackend/enums/NormalizeMode.java
@@ -1,0 +1,16 @@
+package com.dia.ismdtoolbackend.enums;
+
+/**
+ * How the upload should treat owned concepts that are missing {@code skos:inScheme}.
+ * Sent by the FE on re-upload after a {@code MISSING_INSCHEME_DECISION_REQUIRED}
+ * response. When absent, an upload with missing-inScheme concepts is rejected with
+ * that response (the user must make a decision).
+ */
+public enum NormalizeMode {
+    /** Add {@code inScheme → graphName} for every missing owned concept. */
+    NORMALIZE_ALL,
+    /** Leave every missing concept without inScheme (no ownership row; triples kept). */
+    EXCLUDE_ALL,
+    /** Normalize only the concepts listed in {@code conceptsToNormalize}; exclude the rest. */
+    PER_CONCEPT
+}

--- a/src/main/java/com/dia/ismdtoolbackend/exception/InSchemeDecisionRequiredException.java
+++ b/src/main/java/com/dia/ismdtoolbackend/exception/InSchemeDecisionRequiredException.java
@@ -1,0 +1,34 @@
+package com.dia.ismdtoolbackend.exception;
+
+import com.dia.ismdtoolbackend.controller.dto.MissingConceptDto;
+
+import java.util.List;
+
+/**
+ * Thrown on upload when owned concepts lack {@code skos:inScheme} and no
+ * {@code normalizeMode} decision was supplied. Carries the data needed to render the
+ * {@code MISSING_INSCHEME_DECISION_REQUIRED} (HTTP 400) response so the FE can prompt
+ * the user. Nothing has been persisted when this is thrown.
+ */
+public class InSchemeDecisionRequiredException extends RuntimeException {
+
+    /** Stable error code the FE branches on (not the localized message). */
+    public static final String ERROR_CODE = "MISSING_INSCHEME_DECISION_REQUIRED";
+
+    private final transient String graphName;
+    private final transient List<MissingConceptDto> conceptsMissingInScheme;
+
+    public InSchemeDecisionRequiredException(String graphName, List<MissingConceptDto> conceptsMissingInScheme) {
+        super("Některé pojmy nemají skos:inScheme. Vyberte způsob zpracování (normalizovat nebo vyloučit).");
+        this.graphName = graphName;
+        this.conceptsMissingInScheme = conceptsMissingInScheme;
+    }
+
+    public String getGraphName() {
+        return graphName;
+    }
+
+    public List<MissingConceptDto> getConceptsMissingInScheme() {
+        return conceptsMissingInScheme;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/service/OntologyUploadService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/OntologyUploadService.java
@@ -9,5 +9,5 @@ import java.io.IOException;
 
 public interface OntologyUploadService {
     Lang determineRDFFormat(MultipartFile file);
-    OntologyMetadataModel uploadFromFile(MultipartFile file, String providedName, String userId) throws IOException, OntologyUploadException;
+    OntologyMetadataModel uploadFromFile(MultipartFile file, String userId) throws IOException, OntologyUploadException;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/OntologyUploadService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/OntologyUploadService.java
@@ -1,13 +1,27 @@
 package com.dia.ismdtoolbackend.service;
 
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.exception.OntologyUploadException;
 import org.apache.jena.riot.Lang;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface OntologyUploadService {
     Lang determineRDFFormat(MultipartFile file);
-    OntologyMetadataModel uploadFromFile(MultipartFile file, String userId) throws IOException, OntologyUploadException;
+
+    /**
+     * Uploads a vocabulary. If owned concepts lack {@code skos:inScheme} and
+     * {@code normalizeMode} is null, throws
+     * {@link com.dia.ismdtoolbackend.exception.InSchemeDecisionRequiredException}
+     * (nothing persisted) so the user can choose how to handle them on re-upload.
+     *
+     * @param normalizeMode        how to treat missing-inScheme concepts (null = require a decision)
+     * @param conceptsToNormalize  for {@link NormalizeMode#PER_CONCEPT}, the IRIs to normalize
+     */
+    OntologyMetadataModel uploadFromFile(MultipartFile file, String userId,
+                                         NormalizeMode normalizeMode,
+                                         List<String> conceptsToNormalize) throws IOException, OntologyUploadException;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
@@ -106,7 +106,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
     @Override
     @Transactional
     @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
-    public OntologyMetadataModel uploadFromFile(MultipartFile file, String providedName, String userId) throws IOException, OntologyUploadException {
+    public OntologyMetadataModel uploadFromFile(MultipartFile file, String userId) throws IOException, OntologyUploadException {
         if (file.isEmpty()) {
             throw new EmptyFileException("Uploaded file is empty");
         }
@@ -125,7 +125,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
 
         OntModel finalModel = getOntologyModel(file, rdfLang);
         try {
-            String graphName = determineGraphName(file, providedName, finalModel);
+            String graphName = determineGraphName(finalModel);
             log.info("Uploading final model with {} statements to graph: {}", finalModel.size(), graphName);
 
             List<String> publishedConceptIris = deviationChecker.checkPublishedResourcesInNKD(finalModel);
@@ -137,7 +137,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
             checkSlugUniqueness(graphName);
 
             // 2. Normalize OFN types and labels at import time
-            int normalizedCount = OFNTypeNormalizer.normalize(finalModel);
+            int normalizedCount = OFNTypeNormalizer.normalize(finalModel, graphName);
             if (normalizedCount > 0) {
                 log.info("Normalized OFN types on {} resources", normalizedCount);
             }
@@ -210,33 +210,36 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         }
     }
 
-    private String determineGraphName(MultipartFile file, String providedName, OntModel model) {
-        if (providedName != null && !providedName.trim().isEmpty()) {
-            log.debug("Using provided graph name: {}", providedName);
-            return providedName;
-        }
-
+    private String determineGraphName(OntModel model) {
+        // The RDF data is authoritative for the vocabulary IRI / graph name. If no
+        // ontology IRI can be derived, FAIL — never fabricate a filename-based name,
+        // which produces orphan concepts whose namespace diverges from the graph.
         String ontologyIRI = extractOntologyIRI(model);
-        if (ontologyIRI != null) {
-            log.debug("Using extracted ontology IRI as graph name: {}", ontologyIRI);
-            return ontologyIRI;
+        if (ontologyIRI == null) {
+            throw new OntologyUploadException(
+                    "Z RDF dat nelze odvodit IRI slovníku (chybí owl:Ontology nebo skos:ConceptScheme). "
+                            + "Slovník nelze nahrát bez identity odvozené z dat.");
         }
-
-        String fileName = file.getOriginalFilename();
-        String baseName = fileName != null ?
-                fileName.replaceAll("\\.[^.]+$", "") : "ontology";
-
-        String generatedName = String.format(DEFAULT_NS + "%s-%s", baseName, UUID.randomUUID());
-        log.debug("Generated graph name: {}", generatedName);
-        return generatedName;
+        log.debug("Using extracted ontology IRI as graph name: {}", ontologyIRI);
+        return ontologyIRI;
     }
 
     private String extractOntologyIRI(OntModel model) {
-        ResIterator ontologies = model.listResourcesWithProperty(RDF.type, OWL2.Ontology);
-        if (ontologies.hasNext()) {
-            Resource ont = ontologies.next();
-            if (ont.isURIResource()) {
-                return ont.getURI();
+        // owl:Ontology is the primary signal; SKOS-only vocabularies declare the
+        // vocabulary as a skos:ConceptScheme instead, so accept that too.
+        String iri = firstUriSubjectOfType(model, OWL2.Ontology);
+        if (iri == null) {
+            iri = firstUriSubjectOfType(model, SKOS.ConceptScheme);
+        }
+        return iri;
+    }
+
+    private String firstUriSubjectOfType(OntModel model, Resource type) {
+        ResIterator subjects = model.listResourcesWithProperty(RDF.type, type);
+        while (subjects.hasNext()) {
+            Resource subject = subjects.next();
+            if (subject.isURIResource()) {
+                return subject.getURI();
             }
         }
         return null;
@@ -334,7 +337,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         while (conceptIterator.hasNext()) {
             Resource conceptResource = conceptIterator.next();
 
-            if (shouldSkipConcept(conceptResource)) {
+            if (shouldSkipConcept(conceptResource, graphName)) {
                 continue;
             }
 
@@ -377,12 +380,23 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         }
     }
 
-    private boolean shouldSkipConcept(Resource conceptResource) {
+    private boolean shouldSkipConcept(Resource conceptResource, String graphName) {
         if (!conceptResource.isURIResource()) {
             return true;
         }
 
         String conceptIri = conceptResource.getURI();
+
+        // Alien-concept guard: a concept whose IRI is not under this vocabulary's
+        // namespace is not owned by this upload (e.g. an embedded legislative
+        // reference). Don't claim it with a Postgres ownership row — it stays a
+        // referenced concept, resolved later via its own vocabulary / NKD. Mirrors
+        // the resolution invariant STRSTARTS(conceptIri, graphName).
+        if (!OFNTypeNormalizer.isOwnedConcept(conceptIri, graphName)) {
+            log.debug("Skipping alien concept not owned by {}: {}", graphName, conceptIri);
+            return true;
+        }
+
         Optional<ConceptMetadataEntity> existing = conceptMetadataRepository.findByConceptIri(conceptIri);
         if (existing.isPresent()) {
             log.debug("Concept already exists: {}", conceptIri);

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
@@ -7,6 +7,9 @@ import com.dia.ismdtoolbackend.exception.EmptyFileException;
 import com.dia.ismdtoolbackend.exception.OntologyUploadException;
 import com.dia.ismdtoolbackend.exception.UnsupportedRdfFormatException;
 import com.dia.ismdtoolbackend.client.ValidationClient;
+import com.dia.ismdtoolbackend.controller.dto.MissingConceptDto;
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
+import com.dia.ismdtoolbackend.exception.InSchemeDecisionRequiredException;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.entity.ValidationReportEntity;
@@ -106,7 +109,9 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
     @Override
     @Transactional
     @CacheEvict(cacheNames = ConceptMetadataResolver.CACHE_NAME, allEntries = true)
-    public OntologyMetadataModel uploadFromFile(MultipartFile file, String userId) throws IOException, OntologyUploadException {
+    public OntologyMetadataModel uploadFromFile(MultipartFile file, String userId,
+                                                NormalizeMode normalizeMode,
+                                                List<String> conceptsToNormalize) throws IOException, OntologyUploadException {
         if (file.isEmpty()) {
             throw new EmptyFileException("Uploaded file is empty");
         }
@@ -136,20 +141,37 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
             // 1. Fail-fast validation — check slug uniqueness before any persistence
             checkSlugUniqueness(graphName);
 
-            // 2. Normalize OFN types and labels at import time
-            int normalizedCount = OFNTypeNormalizer.normalize(finalModel, graphName);
+            // 2. Missing-inScheme decision gate. Detect BEFORE normalize (normalize would
+            //    stamp inScheme and hide the gap). If any owned concept lacks inScheme and
+            //    the user hasn't decided, reject with the list — nothing persisted.
+            List<String> missingInScheme = OFNTypeNormalizer.detectOwnedConceptsMissingInScheme(finalModel, graphName);
+            if (!missingInScheme.isEmpty() && normalizeMode == null) {
+                List<MissingConceptDto> missingDtos = missingInScheme.stream()
+                        .map(iri -> new MissingConceptDto(
+                                iri, UtilityMethods.extractNameFromIRI(iri), graphName))
+                        .toList();
+                log.info("Upload requires inScheme decision: {} concept(s) missing skos:inScheme in {}",
+                        missingDtos.size(), graphName);
+                throw new InSchemeDecisionRequiredException(graphName, missingDtos);
+            }
+
+            // 3. Resolve which missing concepts to normalize from the user's decision.
+            Set<String> conceptsToStamp = resolveConceptsToNormalize(missingInScheme, normalizeMode, conceptsToNormalize);
+
+            // 4. Normalize OFN types/labels + add inScheme only for the chosen concepts.
+            int normalizedCount = OFNTypeNormalizer.normalize(finalModel, graphName, conceptsToStamp);
             if (normalizedCount > 0) {
                 log.info("Normalized OFN types on {} resources", normalizedCount);
             }
 
-            // 3. Save RDF data to TDB2 first — if this fails, no metadata exists, clean exit
+            // 5. Save RDF data to TDB2 first — if this fails, no metadata exists, clean exit
             try {
                 jenaTDB2Repository.putOntologyModel(graphName, finalModel);
             } catch (Exception e) {
                 throw new OntologyUploadException("Failed to save ontology to TDB2: " + e.getMessage(), e);
             }
 
-            // 4. Save metadata to PostgreSQL — protected by @Transactional
+            // 6. Save metadata to PostgreSQL — protected by @Transactional
             //    If anything below fails, Spring rolls back PostgreSQL; catch cleans up TDB2
             OntologyMetadataModel metadata;
             try {
@@ -222,6 +244,35 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         }
         log.debug("Using extracted ontology IRI as graph name: {}", ontologyIRI);
         return ontologyIRI;
+    }
+
+    /**
+     * Maps the user's {@link NormalizeMode} decision to the set of missing-inScheme
+     * concept IRIs that should be normalized (stamped with {@code inScheme → graphName}).
+     * The complement — missing concepts NOT returned here — are excluded: no inScheme,
+     * no ownership row, triples kept.
+     */
+    private Set<String> resolveConceptsToNormalize(List<String> missingInScheme,
+                                                   NormalizeMode normalizeMode,
+                                                   List<String> conceptsToNormalize) {
+        if (missingInScheme.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> missingSet = new HashSet<>(missingInScheme);
+        // normalizeMode is non-null here (the decision gate above returned otherwise).
+        return switch (normalizeMode) {
+            case NORMALIZE_ALL -> missingSet;
+            case EXCLUDE_ALL -> Set.of();
+            case PER_CONCEPT -> {
+                if (conceptsToNormalize == null) {
+                    yield Set.of();
+                }
+                // Only honor IRIs that are actually in the missing set; ignore unknowns.
+                Set<String> chosen = new HashSet<>(conceptsToNormalize);
+                chosen.retainAll(missingSet);
+                yield chosen;
+            }
+        };
     }
 
     private String extractOntologyIRI(OntModel model) {
@@ -394,6 +445,16 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         // the resolution invariant STRSTARTS(conceptIri, graphName).
         if (!OFNTypeNormalizer.isOwnedConcept(conceptIri, graphName)) {
             log.debug("Skipping alien concept not owned by {}: {}", graphName, conceptIri);
+            return true;
+        }
+
+        // Excluded-concept guard: an owned concept that still lacks skos:inScheme after
+        // normalization is one the user chose to EXCLUDE. It must not get an ownership
+        // row — it would be unresolvable (no inScheme) and falsely claimed. Its triples
+        // remain in the graph as inert context.
+        Property skosInScheme = conceptResource.getModel().createProperty(SKOS_NS + "inScheme");
+        if (!conceptResource.hasProperty(skosInScheme)) {
+            log.debug("Skipping excluded concept (no skos:inScheme) in {}: {}", graphName, conceptIri);
             return true;
         }
 

--- a/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
@@ -60,14 +60,33 @@ public class OntologyDetailExtractor {
         return iri -> iri;
     }
 
+    /**
+     * Local-detail OFN transform. Infers role tags + labels but does NOT derive
+     * {@code skos:inScheme}: local vocabularies are written via the authoritative
+     * upload path, which guarantees an explicit inScheme on every owned concept.
+     */
     public Model applyOFNTransformations(Model rawModel) {
-        log.debug("Applying OFN transformations");
+        return applyOFNTransformations(rawModel, false);
+    }
+
+    /**
+     * NKD-detail OFN transform. Same as the local transform PLUS {@code skos:inScheme}
+     * derivation, since NKD data is out of our control and often arrives without one.
+     */
+    public Model applyOFNTransformationsForNkd(Model rawModel) {
+        return applyOFNTransformations(rawModel, true);
+    }
+
+    private Model applyOFNTransformations(Model rawModel, boolean deriveInScheme) {
+        log.debug("Applying OFN transformations (deriveInScheme={})", deriveInScheme);
         // Normalize before filtering: NKD-published concepts often carry only
         // generic types (slovníky:pojem + owl:Class/ObjectProperty/DatatypeProperty),
         // all of which TurtleFilterUtil treats as "vocabulary noise" and would
         // strip. Inferring the role tags (skos:Concept, slovníky:třída/vztah/
         // vlastnost) here keeps real concepts past the filter.
-        int normalized = OFNTypeNormalizer.normalize(rawModel);
+        int normalized = deriveInScheme
+                ? OFNTypeNormalizer.normalizeForNkd(rawModel)
+                : OFNTypeNormalizer.normalizeForLocalDetail(rawModel);
         if (normalized > 0) {
             log.debug("Inferred OFN role tags on {} resources before filtering", normalized);
         }

--- a/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
@@ -8,7 +8,9 @@ import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.dia.constants.VocabularyConstants.*;
 
@@ -38,7 +40,7 @@ public final class OFNTypeNormalizer {
         count += normalizeOwlClassConcepts(model);
         count += normalizePropertyConcepts(model);
         count += convertLabelsToSkosPrefLabel(model);
-        count += ensureOwnedConceptsHaveInScheme(model, null);
+        count += ensureConceptsHaveDerivedInScheme(model);
         return count;
     }
 
@@ -57,25 +59,107 @@ public final class OFNTypeNormalizer {
         if (graphName == null || graphName.isBlank()) {
             throw new IllegalArgumentException("graphName must be non-null for the upload-path normalizer");
         }
+        // NORMALIZE_ALL convenience: stamp every owned concept that's missing inScheme.
+        return normalize(model, graphName, new HashSet<>(detectOwnedConceptsMissingInScheme(model, graphName)));
+    }
+
+    /**
+     * Upload-path normalization with an explicit allow-list of concepts to stamp.
+     * Runs the type/label normalization steps unconditionally, then adds
+     * {@code inScheme → graphName} ONLY for concepts whose IRI is in
+     * {@code conceptsToNormalize}. Concepts not in the list (the user's "exclude"
+     * choice) are left without inScheme and remain unresolvable by design.
+     *
+     * @param model                the parsed upload model
+     * @param graphName            the authoritative vocabulary IRI (must be non-null)
+     * @param conceptsToNormalize  IRIs of owned concepts the user chose to normalize
+     */
+    public static int normalize(Model model, String graphName, Set<String> conceptsToNormalize) {
+        if (graphName == null || graphName.isBlank()) {
+            throw new IllegalArgumentException("graphName must be non-null for the upload-path normalizer");
+        }
+        Set<String> allowList = conceptsToNormalize == null ? Set.of() : conceptsToNormalize;
         int count = 0;
         count += ensureConceptsHaveSkosType(model);
         count += normalizeOwlClassConcepts(model);
         count += normalizePropertyConcepts(model);
         count += convertLabelsToSkosPrefLabel(model);
-        count += ensureOwnedConceptsHaveInScheme(model, graphName);
+        count += addInSchemeForAllowedConcepts(model, graphName, allowList);
         return count;
     }
 
     /**
-     * Guarantees the resolution invariant for owned concepts: every
-     * {@code skos:Concept} carries a {@code skos:inScheme}. When {@code graphName}
-     * is provided, only concepts under that namespace are touched and they receive
-     * {@code inScheme → graphName} authoritatively; alien concepts are skipped.
-     * When {@code graphName} is null (read path), {@code inScheme} is derived by
-     * stripping {@code /pojem/} from the concept IRI, and concepts that can't yield
-     * a derived scheme are left as-is.
+     * Pure detection (no mutation): returns the IRIs of owned concepts (under
+     * {@code graphName}) that lack {@code skos:inScheme}. Drives the
+     * {@code MISSING_INSCHEME_DECISION_REQUIRED} prompt. Detect BEFORE
+     * {@link #normalize} — once normalize runs, the type-normalization steps may have
+     * stamped inScheme on some concepts and they'd no longer appear missing.
      */
-    private static int ensureOwnedConceptsHaveInScheme(Model model, String graphName) {
+    public static List<String> detectOwnedConceptsMissingInScheme(Model model, String graphName) {
+        if (graphName == null || graphName.isBlank()) {
+            throw new IllegalArgumentException("graphName must be non-null to detect missing inScheme");
+        }
+        Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
+        Resource pojemResource = model.createResource(POJEM_GENERIC);
+        List<String> missing = new ArrayList<>();
+
+        for (Resource concept : ownedConceptCandidates(model, pojemResource, graphName)) {
+            if (!concept.hasProperty(skosInScheme)) {
+                missing.add(concept.getURI());
+            }
+        }
+        return missing;
+    }
+
+    /**
+     * Owned concept candidates under {@code graphName}: URI resources typed as
+     * {@code skos:Concept} or {@code slovníky:pojem}, de-duplicated.
+     */
+    private static List<Resource> ownedConceptCandidates(Model model, Resource pojemResource, String graphName) {
+        List<Resource> candidates = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        collectOwnedTyped(model, SKOS.Concept, graphName, candidates, seen);
+        collectOwnedTyped(model, pojemResource, graphName, candidates, seen);
+        return candidates;
+    }
+
+    private static void collectOwnedTyped(Model model, Resource type, String graphName,
+                                          List<Resource> out, Set<String> seen) {
+        ResIterator iter = model.listResourcesWithProperty(RDF.type, type);
+        while (iter.hasNext()) {
+            Resource r = iter.next();
+            if (r.isURIResource() && isOwnedConcept(r.getURI(), graphName) && seen.add(r.getURI())) {
+                out.add(r);
+            }
+        }
+    }
+
+    /**
+     * Adds {@code inScheme → graphName} for owned concepts whose IRI is in the
+     * allow-list and that don't already have an inScheme. Owned concepts NOT in the
+     * allow-list are left untouched (excluded by user decision).
+     */
+    private static int addInSchemeForAllowedConcepts(Model model, String graphName, Set<String> allowList) {
+        Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
+        Resource pojemResource = model.createResource(POJEM_GENERIC);
+        int count = 0;
+
+        for (Resource concept : ownedConceptCandidates(model, pojemResource, graphName)) {
+            if (concept.hasProperty(skosInScheme) || !allowList.contains(concept.getURI())) {
+                continue;
+            }
+            concept.addProperty(skosInScheme, model.getResource(graphName));
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Read/NKD-path inScheme derivation (no authoritative graphName). Adds
+     * {@code inScheme} to every {@code skos:Concept} by stripping {@code /pojem/} from
+     * its IRI; concepts that can't yield a derived scheme are left as-is.
+     */
+    private static int ensureConceptsHaveDerivedInScheme(Model model) {
         Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
         int count = 0;
 
@@ -92,17 +176,9 @@ public final class OFNTypeNormalizer {
             if (concept.hasProperty(skosInScheme)) {
                 continue;
             }
-            String scheme;
-            if (graphName != null) {
-                if (!isOwnedConcept(concept.getURI(), graphName)) {
-                    continue;
-                }
-                scheme = graphName;
-            } else {
-                scheme = extractOntologyIRIFromConcept(concept.getURI());
-                if (scheme == null) {
-                    continue;
-                }
+            String scheme = extractOntologyIRIFromConcept(concept.getURI());
+            if (scheme == null) {
+                continue;
             }
             concept.addProperty(skosInScheme, model.getResource(scheme));
             count++;

--- a/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
@@ -29,17 +29,34 @@ public final class OFNTypeNormalizer {
     private OFNTypeNormalizer() {}
 
     /**
-     * Read/NKD-path normalization with no authoritative graph IRI. {@code inScheme}
-     * is derived per-concept by stripping {@code /pojem/} from the concept IRI
-     * ({@link #extractOntologyIRIFromConcept}). Used where there is no single
-     * owning vocabulary (e.g. {@code OntologyDetailExtractor}, which mixes graphs).
+     * Local-detail-path normalization. Infers the OFN role tags
+     * ({@code skos:Concept}, {@code slovníky:třída/vztah/vlastnost}) and converts
+     * labels so real concepts survive {@link TurtleFilterUtil}, but does NOT touch
+     * {@code skos:inScheme}: local vocabularies are written via the authoritative
+     * upload path, which guarantees every owned concept carries an explicit
+     * {@code inScheme}. Deriving it here would be redundant and risks the
+     * {@code /pojem/} string heuristic diverging from the real scheme.
      */
-    public static int normalize(Model model) {
+    public static int normalizeForLocalDetail(Model model) {
         int count = 0;
         count += ensureConceptsHaveSkosType(model);
         count += normalizeOwlClassConcepts(model);
         count += normalizePropertyConcepts(model);
         count += convertLabelsToSkosPrefLabel(model);
+        return count;
+    }
+
+    /**
+     * NKD-path normalization. Same role-tag/label inference as
+     * {@link #normalizeForLocalDetail} PLUS {@code skos:inScheme} derivation: NKD data
+     * is out of our control and often arrives without an explicit scheme, so we infer
+     * it per-concept by stripping {@code /pojem/} from the concept IRI
+     * ({@link #extractOntologyIRIFromConcept}) — a reasonable inference given OFN's IRI
+     * structure. There is no single authoritative graph IRI here (the detail model can
+     * mix vocabularies), hence the per-concept derivation rather than a fixed graphName.
+     */
+    public static int normalizeForNkd(Model model) {
+        int count = normalizeForLocalDetail(model);
         count += ensureConceptsHaveDerivedInScheme(model);
         return count;
     }
@@ -215,10 +232,15 @@ public final class OFNTypeNormalizer {
         return added;
     }
 
+    /**
+     * Infers OFN role tags ({@code skos:Concept}, {@code slovníky:pojem},
+     * {@code slovníky:třída}) on {@code owl:Class} concepts. Role tags only — does NOT
+     * touch {@code skos:inScheme} (that's the NKD-only derivation step, or the
+     * authoritative upload step).
+     */
     private static int normalizeOwlClassConcepts(Model model) {
         Resource slovnikyPojem = model.createResource(OFN_NAMESPACE + POJEM);
         Resource slovnikyTrida = model.createResource(OFN_NAMESPACE + TRIDA);
-        Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
         int count = 0;
 
         List<Resource> classesToNormalize = new ArrayList<>();
@@ -244,21 +266,20 @@ public final class OFNTypeNormalizer {
                 cls.addProperty(RDF.type, slovnikyTrida);
                 modified = true;
             }
-            String ontologyIRI = extractOntologyIRIFromConcept(cls.getURI());
-            if (ontologyIRI != null && !cls.hasProperty(skosInScheme)) {
-                cls.addProperty(skosInScheme, model.getResource(ontologyIRI));
-                modified = true;
-            }
             if (modified) count++;
         }
 
         return count;
     }
 
+    /**
+     * Infers OFN role tags ({@code slovníky:vztah} on object properties,
+     * {@code slovníky:vlastnost} on datatype properties) for {@code /pojem/} concepts.
+     * Role tags only — does NOT touch {@code skos:inScheme}.
+     */
     private static int normalizePropertyConcepts(Model model) {
         Resource slovnikyVztah = model.createResource(OFN_NAMESPACE + VZTAH);
         Resource slovnikyVlastnost = model.createResource(OFN_NAMESPACE + VLASTNOST);
-        Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
         int count = 0;
 
         List<Resource> objectProperties = new ArrayList<>();
@@ -267,18 +288,10 @@ public final class OFNTypeNormalizer {
             objectProperties.add(iter.next());
         }
         for (Resource prop : objectProperties) {
-            if (prop.isURIResource() && prop.getURI().contains("/pojem/")) {
-                boolean modified = false;
-                if (!prop.hasProperty(RDF.type, slovnikyVztah)) {
-                    prop.addProperty(RDF.type, slovnikyVztah);
-                    modified = true;
-                }
-                String ontologyIRI = extractOntologyIRIFromConcept(prop.getURI());
-                if (ontologyIRI != null && !prop.hasProperty(skosInScheme)) {
-                    prop.addProperty(skosInScheme, model.getResource(ontologyIRI));
-                    modified = true;
-                }
-                if (modified) count++;
+            if (prop.isURIResource() && prop.getURI().contains("/pojem/")
+                    && !prop.hasProperty(RDF.type, slovnikyVztah)) {
+                prop.addProperty(RDF.type, slovnikyVztah);
+                count++;
             }
         }
 
@@ -289,18 +302,10 @@ public final class OFNTypeNormalizer {
         }
         for (Resource prop : datatypeProperties) {
             if (prop.isURIResource() && prop.getURI().contains("/pojem/")
-                    && !prop.hasProperty(RDF.type, OWL2.ObjectProperty)) {
-                boolean modified = false;
-                if (!prop.hasProperty(RDF.type, slovnikyVlastnost)) {
-                    prop.addProperty(RDF.type, slovnikyVlastnost);
-                    modified = true;
-                }
-                String ontologyIRI = extractOntologyIRIFromConcept(prop.getURI());
-                if (ontologyIRI != null && !prop.hasProperty(skosInScheme)) {
-                    prop.addProperty(skosInScheme, model.getResource(ontologyIRI));
-                    modified = true;
-                }
-                if (modified) count++;
+                    && !prop.hasProperty(RDF.type, OWL2.ObjectProperty)
+                    && !prop.hasProperty(RDF.type, slovnikyVlastnost)) {
+                prop.addProperty(RDF.type, slovnikyVlastnost);
+                count++;
             }
         }
 

--- a/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizer.java
@@ -26,13 +26,99 @@ public final class OFNTypeNormalizer {
 
     private OFNTypeNormalizer() {}
 
+    /**
+     * Read/NKD-path normalization with no authoritative graph IRI. {@code inScheme}
+     * is derived per-concept by stripping {@code /pojem/} from the concept IRI
+     * ({@link #extractOntologyIRIFromConcept}). Used where there is no single
+     * owning vocabulary (e.g. {@code OntologyDetailExtractor}, which mixes graphs).
+     */
     public static int normalize(Model model) {
         int count = 0;
         count += ensureConceptsHaveSkosType(model);
         count += normalizeOwlClassConcepts(model);
         count += normalizePropertyConcepts(model);
         count += convertLabelsToSkosPrefLabel(model);
+        count += ensureOwnedConceptsHaveInScheme(model, null);
         return count;
+    }
+
+    /**
+     * Upload-path normalization. {@code graphName} is the authoritative vocabulary
+     * IRI derived from the RDF; every {@code skos:Concept} <b>under that namespace</b>
+     * that lacks an {@code skos:inScheme} gets {@code inScheme → graphName} (not the
+     * {@code /pojem/}-stripped value, which can diverge). Concepts whose IRI is NOT
+     * under {@code graphName} (alien / referenced concepts) are left untouched — they
+     * are not claimed as owned by this vocabulary.
+     *
+     * @param model     the parsed upload model
+     * @param graphName the authoritative vocabulary IRI (must be non-null)
+     */
+    public static int normalize(Model model, String graphName) {
+        if (graphName == null || graphName.isBlank()) {
+            throw new IllegalArgumentException("graphName must be non-null for the upload-path normalizer");
+        }
+        int count = 0;
+        count += ensureConceptsHaveSkosType(model);
+        count += normalizeOwlClassConcepts(model);
+        count += normalizePropertyConcepts(model);
+        count += convertLabelsToSkosPrefLabel(model);
+        count += ensureOwnedConceptsHaveInScheme(model, graphName);
+        return count;
+    }
+
+    /**
+     * Guarantees the resolution invariant for owned concepts: every
+     * {@code skos:Concept} carries a {@code skos:inScheme}. When {@code graphName}
+     * is provided, only concepts under that namespace are touched and they receive
+     * {@code inScheme → graphName} authoritatively; alien concepts are skipped.
+     * When {@code graphName} is null (read path), {@code inScheme} is derived by
+     * stripping {@code /pojem/} from the concept IRI, and concepts that can't yield
+     * a derived scheme are left as-is.
+     */
+    private static int ensureOwnedConceptsHaveInScheme(Model model, String graphName) {
+        Property skosInScheme = model.createProperty(SKOS_NS + "inScheme");
+        int count = 0;
+
+        List<Resource> concepts = new ArrayList<>();
+        ResIterator iter = model.listResourcesWithProperty(RDF.type, SKOS.Concept);
+        while (iter.hasNext()) {
+            Resource r = iter.next();
+            if (r.isURIResource()) {
+                concepts.add(r);
+            }
+        }
+
+        for (Resource concept : concepts) {
+            if (concept.hasProperty(skosInScheme)) {
+                continue;
+            }
+            String scheme;
+            if (graphName != null) {
+                if (!isOwnedConcept(concept.getURI(), graphName)) {
+                    continue;
+                }
+                scheme = graphName;
+            } else {
+                scheme = extractOntologyIRIFromConcept(concept.getURI());
+                if (scheme == null) {
+                    continue;
+                }
+            }
+            concept.addProperty(skosInScheme, model.getResource(scheme));
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * Ownership predicate mirroring the resolution invariant
+     * ({@code STRSTARTS(conceptIri, scheme)} in
+     * {@code JenaTDB2Repository#fetchConceptResolutions}). A concept is owned by
+     * {@code graphName} iff its IRI starts with the vocabulary IRI; owned concepts
+     * are {@code {graphName}/pojem/{name}}.
+     */
+    public static boolean isOwnedConcept(String conceptIri, String graphName) {
+        return conceptIri != null && graphName != null && conceptIri.startsWith(graphName);
     }
 
     private static int ensureConceptsHaveSkosType(Model model) {

--- a/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
@@ -100,7 +100,6 @@ class OntologyControllerTest {
     @WithMockSecurityUser(userId = "user123")
     void testUploadFromFile_Success() throws Exception {
         String userId = "user123";
-        String providedName = "test-ontology";
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "test.ttl",
@@ -109,19 +108,18 @@ class OntologyControllerTest {
         );
 
         OntologyMetadataModel expectedMetadata = new OntologyMetadataModel();
-        expectedMetadata.setGraphName(providedName);
+        expectedMetadata.setGraphName("file");
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(providedName), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
-                        .file(file)
-                        .param("providedName", providedName))
+                        .file(file))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.data.graphName").value(providedName))
+                .andExpect(jsonPath("$.data.graphName").value("file"))
                 .andExpect(jsonPath("$.data.user.userId").value(userId))
                 .andExpect(jsonPath("$.message").isString());
     }
@@ -142,7 +140,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), isNull(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -166,7 +164,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenThrow(new EmptyFileException("Soubor je prázdný."));
 
         TestOntologySecurityService.setAllowModify(true);
@@ -190,7 +188,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenThrow(new UnsupportedRdfFormatException("RDF jazyk není podporován."));
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -212,7 +210,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenThrow(new RuntimeException("Parse error"));
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -226,7 +224,6 @@ class OntologyControllerTest {
     @WithMockSecurityUser(userId = "user123")
     void testUploadFromFile_MissingFile() throws Exception {
         String userId = "user123";
-        String providedName = "jsonld-ontology";
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "test.jsonld",
@@ -235,12 +232,11 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(providedName), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenThrow(new EmptyFileException("Soubor je prázdný."));
 
         mockMvc.perform(multipart("/api/ontology/upload")
-                        .file(file)
-                        .param("providedName", providedName))
+                        .file(file))
                 .andExpect(status().isBadRequest());
     }
 
@@ -248,7 +244,6 @@ class OntologyControllerTest {
     @WithMockSecurityUser(userId = "user123")
     void testUploadFromFile_JsonLdFormat() throws Exception {
         String userId = "user123";
-        String providedName = "jsonld-ontology";
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "test.jsonld",
@@ -257,19 +252,18 @@ class OntologyControllerTest {
         );
 
         OntologyMetadataModel expectedMetadata = new OntologyMetadataModel();
-        expectedMetadata.setGraphName(providedName);
+        expectedMetadata.setGraphName("file");
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.JSONLD);
-        when(ontologyUploadService.uploadFromFile(any(), eq(providedName), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
-                        .file(file)
-                        .param("providedName", providedName))
+                        .file(file))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.data.graphName").value(providedName))
+                .andExpect(jsonPath("$.data.graphName").value("file"))
                 .andExpect(jsonPath("$.data.user.userId").value(userId));
     }
 
@@ -284,7 +278,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), isNull(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -316,7 +310,6 @@ class OntologyControllerTest {
     @WithMockSecurityUser(userId = "user123")
     void testUploadFromFile_AlreadyExistsScenario() throws Exception {
         String userId = "user123";
-        String providedName = "existing-ontology";
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "test.ttl",
@@ -326,22 +319,21 @@ class OntologyControllerTest {
 
         OntologyMetadataModel existingMetadata = new OntologyMetadataModel();
         existingMetadata.setId(1L);
-        existingMetadata.setGraphName(providedName);
+        existingMetadata.setGraphName("file");
         existingMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(providedName), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
                 .thenReturn(existingMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
-                        .file(file)
-                        .param("providedName", providedName))
+                        .file(file))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data.id").value(1))
-                .andExpect(jsonPath("$.data.graphName").value(providedName))
+                .andExpect(jsonPath("$.data.graphName").value("file"))
                 .andExpect(jsonPath("$.data.user.userId").value(userId))
-                .andExpect(jsonPath("$.message").value("Slovník úspěšně nahrán: " + providedName));
+                .andExpect(jsonPath("$.message").value("Slovník úspěšně nahrán: " + "file"));
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
@@ -8,8 +8,11 @@ import com.dia.ismdtoolbackend.config.security.WithMockSecurityUser;
 import com.dia.ismdtoolbackend.controller.dto.GetNkdOntologyDto;
 import com.dia.ismdtoolbackend.controller.dto.GetOntologyDto;
 import com.dia.ismdtoolbackend.controller.dto.MinimalConceptDto;
+import com.dia.ismdtoolbackend.controller.dto.MissingConceptDto;
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.EmptyFileException;
+import com.dia.ismdtoolbackend.exception.InSchemeDecisionRequiredException;
 import com.dia.ismdtoolbackend.exception.NkdResourceNotFoundException;
 import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
 import com.dia.ismdtoolbackend.exception.UnsupportedRdfFormatException;
@@ -21,6 +24,8 @@ import com.dia.ismdtoolbackend.service.OntologyUploadService;
 import com.dia.ismdtoolbackend.service.ValidationService;
 import com.dia.ismdtoolbackend.service.impl.ConceptMetadataResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
 import org.apache.jena.riot.Lang;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -112,7 +117,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -140,7 +145,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -164,7 +169,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenThrow(new EmptyFileException("Soubor je prázdný."));
 
         TestOntologySecurityService.setAllowModify(true);
@@ -188,7 +193,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenThrow(new UnsupportedRdfFormatException("RDF jazyk není podporován."));
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -210,7 +215,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenThrow(new RuntimeException("Parse error"));
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -232,7 +237,7 @@ class OntologyControllerTest {
         );
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenThrow(new EmptyFileException("Soubor je prázdný."));
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -256,7 +261,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.JSONLD);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -265,6 +270,66 @@ class OntologyControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data.graphName").value("file"))
                 .andExpect(jsonPath("$.data.user.userId").value(userId));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void testUploadFromFile_missingInScheme_returns400WithDecisionPayload() throws Exception {
+        String userId = "user123";
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.ttl", "text/turtle",
+                "@prefix owl: <http://www.w3.org/2002/07/owl#> . <http://example.org/test> a owl:Ontology .".getBytes()
+        );
+
+        String graphName = "https://slovník.gov.cz/a3791";
+        String conceptIri = graphName + "/pojem/vysoká-škola";
+        when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
+                .thenThrow(new InSchemeDecisionRequiredException(
+                        graphName,
+                        List.of(new MissingConceptDto(conceptIri, "vysoká škola", graphName))));
+
+        mockMvc.perform(multipart("/api/ontology/upload")
+                        .file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.errorCode").value("MISSING_INSCHEME_DECISION_REQUIRED"))
+                .andExpect(jsonPath("$.data.graphName").value(graphName))
+                .andExpect(jsonPath("$.data.conceptsMissingInScheme[0].conceptIri").value(conceptIri))
+                .andExpect(jsonPath("$.data.conceptsMissingInScheme[0].proposedInScheme").value(graphName));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void testUploadFromFile_withDecisionParams_passesThroughToService() throws Exception {
+        String userId = "user123";
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.ttl", "text/turtle",
+                "@prefix owl: <http://www.w3.org/2002/07/owl#> . <http://example.org/test> a owl:Ontology .".getBytes()
+        );
+
+        OntologyMetadataModel expected = new OntologyMetadataModel();
+        expected.setGraphName("file");
+        expected.setUser(new UserModel(userId));
+
+        when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
+                .thenReturn(expected);
+
+        mockMvc.perform(multipart("/api/ontology/upload")
+                        .file(file)
+                        .param("normalizeMode", "PER_CONCEPT")
+                        .param("conceptsToNormalize", "https://slovník.gov.cz/a3791/pojem/x")
+                        .param("conceptsToNormalize", "https://slovník.gov.cz/a3791/pojem/y"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.graphName").value("file"));
+
+        verify(ontologyUploadService).uploadFromFile(
+                any(),
+                eq(userId),
+                eq(NormalizeMode.PER_CONCEPT),
+                eq(List.of("https://slovník.gov.cz/a3791/pojem/x", "https://slovník.gov.cz/a3791/pojem/y")));
     }
 
     @Test
@@ -278,7 +343,7 @@ class OntologyControllerTest {
         expectedMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenReturn(expectedMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")
@@ -323,7 +388,7 @@ class OntologyControllerTest {
         existingMetadata.setUser(new UserModel(userId));
 
         when(ontologyUploadService.determineRDFFormat(any())).thenReturn(Lang.TURTLE);
-        when(ontologyUploadService.uploadFromFile(any(), eq(userId)))
+        when(ontologyUploadService.uploadFromFile(any(), eq(userId), any(), any()))
                 .thenReturn(existingMetadata);
 
         mockMvc.perform(multipart("/api/ontology/upload")

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
@@ -5,6 +5,7 @@ import com.dia.ismdtoolbackend.exception.OntologyUploadException;
 import com.dia.ismdtoolbackend.exception.UnsupportedRdfFormatException;
 import com.dia.ismdtoolbackend.client.NkdSparqlClient;
 import com.dia.ismdtoolbackend.client.ValidationClient;
+import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.models.UserModel;
@@ -20,6 +21,7 @@ import org.apache.jena.riot.Lang;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -163,46 +165,6 @@ class OntologyUploadServiceImplTest {
     }
 
     @Test
-    void testUploadFromFile_WithProvidedName() throws Exception {
-        String providedName = "custom-ontology";
-        String userId = "user123";
-        byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> . <http://example.org/test> a owl:Ontology .".getBytes();
-
-        when(multipartFile.getBytes()).thenReturn(fileContent);
-        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
-        when(multipartFile.isEmpty()).thenReturn(false);
-
-        OntologyMetadataModel expectedDto = new OntologyMetadataModel();
-        expectedDto.setGraphName(providedName);
-        expectedDto.setUser(new UserModel(userId));
-        expectedDto.setId(1L);
-
-        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setGraphName(providedName);
-        savedEntity.setUserId(userId);
-        savedEntity.setId(1L);
-
-        when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
-        when(ontologyMetadataMapper.toEntity(any(OntologyMetadataModel.class))).thenReturn(savedEntity);
-        when(ontologyMetadataRepository.save(any(OntologyMetadataEntity.class))).thenReturn(savedEntity);
-        when(ontologyMetadataMapper.toDto(any(OntologyMetadataEntity.class))).thenReturn(expectedDto);
-        when(ontologyMetadataRepository.findById(1L)).thenReturn(Optional.of(savedEntity));
-
-        when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
-
-        doNothing().when(jenaTDB2Repository).putOntologyModel(eq(providedName), any(OntModel.class));
-
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, providedName, userId);
-
-        assertNotNull(result);
-        assertEquals(providedName, result.getGraphName());
-        assertEquals(userId, result.getUser().getUserId());
-
-        verify(jenaTDB2Repository).putOntologyModel(eq(providedName), any(OntModel.class));
-        verify(ontologyMetadataRepository).save(any(OntologyMetadataEntity.class));
-    }
-
-    @Test
     void testUploadFromFile_WithOntologyIRI() throws Exception {
         String userId = "user123";
         String ontologyIRI = "http://example.org/test-ontology";
@@ -232,7 +194,7 @@ class OntologyUploadServiceImplTest {
 
         doNothing().when(jenaTDB2Repository).putOntologyModel(eq(ontologyIRI), any(OntModel.class));
 
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, null, userId);
+        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, userId);
 
         assertNotNull(result);
         assertEquals(ontologyIRI, result.getGraphName());
@@ -242,69 +204,103 @@ class OntologyUploadServiceImplTest {
     }
 
     @Test
-    void testUploadFromFile_GeneratedName() throws Exception {
+    void testUploadFromFile_NoDerivableOntologyIRI_throws() throws Exception {
+        // RDF with no owl:Ontology / skos:ConceptScheme subject — graph name cannot be
+        // derived from the data. Per the authority decision, we must FAIL rather than
+        // fabricate a filename+UUID name.
         String userId = "user123";
-        String filename = "test-ontology.ttl";
         byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
 
         when(multipartFile.getBytes()).thenReturn(fileContent);
-        when(multipartFile.getOriginalFilename()).thenReturn(filename);
+        when(multipartFile.getOriginalFilename()).thenReturn("test-ontology.ttl");
         when(multipartFile.isEmpty()).thenReturn(false);
-
-        OntologyMetadataModel expectedDto = new OntologyMetadataModel();
-        expectedDto.setId(1L);
-        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setId(1L);
-
-        when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
-        when(ontologyMetadataMapper.toEntity(any(OntologyMetadataModel.class))).thenReturn(savedEntity);
-        when(ontologyMetadataRepository.save(any(OntologyMetadataEntity.class))).thenReturn(savedEntity);
-        when(ontologyMetadataMapper.toDto(any(OntologyMetadataEntity.class))).thenReturn(expectedDto);
-        when(ontologyMetadataRepository.findById(1L)).thenReturn(Optional.of(savedEntity));
 
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
 
-        doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
+        assertThrows(OntologyUploadException.class, () ->
+                ontologyUploadService.uploadFromFile(multipartFile, userId));
 
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, null, userId);
-
-        assertNotNull(result);
-        verify(jenaTDB2Repository).putOntologyModel(argThat(graphName ->
-            graphName.contains("test-ontology") && graphName.startsWith("https://slovník.gov.cz/")
-        ), any(OntModel.class));
+        // Nothing persisted — fail-fast before any TDB2/metadata write.
+        // (verifyNoInteractions rather than never().putOntologyModel(..) — the latter
+        // makes Mockito toString() the OntModel, which is already closed by the finally.)
+        verifyNoInteractions(jenaTDB2Repository);
+        verify(ontologyMetadataRepository, never()).save(any());
     }
 
     @Test
-    void testUploadFromFile_EmptyProvidedName() throws Exception {
+    void testUploadFromFile_NoFilename_noDerivableIRI_throwsWithoutNPE() throws Exception {
+        // Null filename + no derivable ontology IRI: must fail cleanly (no NPE from the
+        // old filename-fallback path, which no longer exists).
         String userId = "user123";
-        String filename = "test.ttl";
         byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
 
         when(multipartFile.getBytes()).thenReturn(fileContent);
-        when(multipartFile.getOriginalFilename()).thenReturn(filename);
+        when(multipartFile.getOriginalFilename()).thenReturn(null);
+        when(multipartFile.isEmpty()).thenReturn(false);
+        when(multipartFile.getContentType()).thenReturn("text/turtle");
+
+        when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
+
+        assertThrows(OntologyUploadException.class, () ->
+                ontologyUploadService.uploadFromFile(multipartFile, userId));
+
+        verifyNoInteractions(jenaTDB2Repository);
+        verify(ontologyMetadataRepository, never()).save(any());
+    }
+
+    @Test
+    void testUploadFromFile_alienConcept_notSavedAsOwned() throws Exception {
+        // The vocabulary IRI (graphName) is derived from owl:Ontology. The file embeds
+        // TWO slovníky:pojem concepts: one OWNED (under graphName/pojem/...) and one
+        // ALIEN (a legislative reference outside graphName's namespace). Only the owned
+        // concept may get a Postgres ownership row; the alien must be skipped.
+        String userId = "user123";
+        String ontologyIRI = "https://slovník.gov.cz/a3791---registr";
+        String ownedConcept = ontologyIRI + "/pojem/vysoká-škola";
+        String alienConcept = "https://slovník.gov.cz/128-2000/pojem/obec";
+        String pojem = "https://slovník.gov.cz/generický/datový-slovník-ofn-slovníků/pojem/pojem";
+
+        String ttl = String.format(
+                "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
+                        + " <%s> a owl:Ontology ."
+                        + " <%s> a <%s> ."
+                        + " <%s> a <%s> .",
+                ontologyIRI, ownedConcept, pojem, alienConcept, pojem);
+
+        when(multipartFile.getBytes()).thenReturn(ttl.getBytes());
+        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
         when(multipartFile.isEmpty()).thenReturn(false);
 
+        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
+        savedEntity.setGraphName(ontologyIRI);
+        savedEntity.setUserId(userId);
+        savedEntity.setId(1L);
         OntologyMetadataModel expectedDto = new OntologyMetadataModel();
         expectedDto.setId(1L);
-        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setId(1L);
 
         when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
         when(ontologyMetadataMapper.toEntity(any(OntologyMetadataModel.class))).thenReturn(savedEntity);
         when(ontologyMetadataRepository.save(any(OntologyMetadataEntity.class))).thenReturn(savedEntity);
         when(ontologyMetadataMapper.toDto(any(OntologyMetadataEntity.class))).thenReturn(expectedDto);
         when(ontologyMetadataRepository.findById(1L)).thenReturn(Optional.of(savedEntity));
-
+        when(conceptMetadataRepository.findByConceptIri(anyString())).thenReturn(Optional.empty());
+        when(conceptMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
-
         doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
 
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, "  ", userId);
+        ontologyUploadService.uploadFromFile(multipartFile, userId);
 
-        assertNotNull(result);
-        verify(jenaTDB2Repository).putOntologyModel(argThat(graphName ->
-            graphName.contains("test") && graphName.startsWith("https://slovník.gov.cz/")
-        ), any(OntModel.class));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ConceptMetadataEntity>> captor = ArgumentCaptor.forClass(List.class);
+        verify(conceptMetadataRepository).saveAll(captor.capture());
+        List<String> savedIris = captor.getValue().stream()
+                .map(ConceptMetadataEntity::getConceptIri)
+                .toList();
+
+        assertTrue(savedIris.contains(ownedConcept),
+                "Owned concept under graphName must be saved as owned");
+        assertFalse(savedIris.contains(alienConcept),
+                "Alien concept outside graphName's namespace must NOT be claimed as owned");
     }
 
     @Test
@@ -317,43 +313,9 @@ class OntologyUploadServiceImplTest {
 
         // The implementation catches IOException and wraps it, but RuntimeException propagates directly
         assertThrows(RuntimeException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, "test", userId));
+            ontologyUploadService.uploadFromFile(multipartFile, userId));
 
         verify(ontologyMetadataRepository, never()).save(any());
-    }
-
-    @Test
-    void testUploadFromFile_NoFilename() throws Exception {
-        String userId = "user123";
-        byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
-
-        when(multipartFile.getBytes()).thenReturn(fileContent);
-        when(multipartFile.getOriginalFilename()).thenReturn(null);
-        when(multipartFile.isEmpty()).thenReturn(false);
-        // Need to mock content type since no filename
-        when(multipartFile.getContentType()).thenReturn("text/turtle");
-
-        OntologyMetadataModel expectedDto = new OntologyMetadataModel();
-        expectedDto.setId(1L);
-        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setId(1L);
-
-        when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
-        when(ontologyMetadataMapper.toEntity(any(OntologyMetadataModel.class))).thenReturn(savedEntity);
-        when(ontologyMetadataRepository.save(any(OntologyMetadataEntity.class))).thenReturn(savedEntity);
-        when(ontologyMetadataMapper.toDto(any(OntologyMetadataEntity.class))).thenReturn(expectedDto);
-        when(ontologyMetadataRepository.findById(1L)).thenReturn(Optional.of(savedEntity));
-
-        when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
-
-        doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
-
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, null, userId);
-
-        assertNotNull(result);
-        verify(jenaTDB2Repository).putOntologyModel(argThat(graphName ->
-            graphName.contains("ontology") && graphName.startsWith("https://slovník.gov.cz/")
-        ), any(OntModel.class));
     }
 
     @Test
@@ -363,7 +325,7 @@ class OntologyUploadServiceImplTest {
         when(multipartFile.isEmpty()).thenReturn(true);
 
         assertThrows(EmptyFileException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, "test", userId));
+            ontologyUploadService.uploadFromFile(multipartFile, userId));
 
         verify(ontologyMetadataRepository, never()).save(any());
     }
@@ -377,16 +339,16 @@ class OntologyUploadServiceImplTest {
         when(multipartFile.getContentType()).thenReturn("application/unknown");
 
         assertThrows(UnsupportedRdfFormatException.class, () ->
-                ontologyUploadService.uploadFromFile(multipartFile, "test", userId));
+                ontologyUploadService.uploadFromFile(multipartFile, userId));
 
         verify(ontologyMetadataRepository, never()).save(any());
     }
 
     @Test
     void testUploadFromFile_NKDCheckBeforeMetadataCreation() throws IOException {
-        String providedName = "test-ontology";
+        String graphName = "http://example.org/test-ontology";
         String userId = "user123";
-        byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
+        byte[] fileContent = String.format("@prefix owl: <http://www.w3.org/2002/07/owl#> . <%s> a owl:Ontology .", graphName).getBytes();
 
         when(multipartFile.getBytes()).thenReturn(fileContent);
         when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
@@ -396,7 +358,7 @@ class OntologyUploadServiceImplTest {
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(publishedConcepts);
 
         OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setGraphName(providedName);
+        savedEntity.setGraphName(graphName);
         savedEntity.setUserId(userId);
         savedEntity.setId(1L);
 
@@ -411,7 +373,7 @@ class OntologyUploadServiceImplTest {
 
         doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
 
-        ontologyUploadService.uploadFromFile(multipartFile, providedName, userId);
+        ontologyUploadService.uploadFromFile(multipartFile, userId);
 
         // Verify metadata save happens
         verify(ontologyMetadataRepository).save(any(OntologyMetadataEntity.class));
@@ -419,9 +381,9 @@ class OntologyUploadServiceImplTest {
 
     @Test
     void testUploadFromFile_RollbackOnTDB2Failure() throws IOException {
-        String providedName = "test-ontology";
+        String ontologyIRI = "http://example.org/test-ontology";
         String userId = "user123";
-        byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
+        byte[] fileContent = String.format("@prefix owl: <http://www.w3.org/2002/07/owl#> . <%s> a owl:Ontology .", ontologyIRI).getBytes();
 
         when(multipartFile.getBytes()).thenReturn(fileContent);
         when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
@@ -436,7 +398,7 @@ class OntologyUploadServiceImplTest {
 
         // Expect exception to be thrown
         assertThrows(OntologyUploadException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, providedName, userId)
+            ontologyUploadService.uploadFromFile(multipartFile, userId)
         );
 
         // TDB2 save fails before any metadata is created — no cleanup needed
@@ -447,15 +409,15 @@ class OntologyUploadServiceImplTest {
 
     @Test
     void testUploadFromFile_RollbackOnConceptMetadataExtractionFailure() throws IOException {
-        String providedName = "test-ontology";
+        String ontologyIRI = "http://example.org/test-ontology";
         String userId = "user123";
-        byte[] fileContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .".getBytes();
+        byte[] fileContent = String.format("@prefix owl: <http://www.w3.org/2002/07/owl#> . <%s> a owl:Ontology .", ontologyIRI).getBytes();
 
         when(multipartFile.getBytes()).thenReturn(fileContent);
         when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
 
         OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
-        savedEntity.setGraphName(providedName);
+        savedEntity.setGraphName(ontologyIRI);
         savedEntity.setUserId(userId);
         savedEntity.setId(1L);
 
@@ -476,12 +438,12 @@ class OntologyUploadServiceImplTest {
 
         // Expect exception to be thrown
         assertThrows(Exception.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, providedName, userId)
+            ontologyUploadService.uploadFromFile(multipartFile, userId)
         );
 
         // PostgreSQL rollback is handled by @Transactional — no manual deleteById
         verify(ontologyMetadataRepository, never()).deleteById(anyLong());
         // TDB2 graph should be cleaned up since it was saved before the failure
-        verify(jenaTDB2Repository).deleteGraph(providedName);
+        verify(jenaTDB2Repository).deleteGraph(ontologyIRI);
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
@@ -7,6 +7,8 @@ import com.dia.ismdtoolbackend.client.NkdSparqlClient;
 import com.dia.ismdtoolbackend.client.ValidationClient;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
+import com.dia.ismdtoolbackend.exception.InSchemeDecisionRequiredException;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.models.UserModel;
 import com.dia.ismdtoolbackend.mapper.OntologyMetadataMapper;
@@ -194,7 +196,7 @@ class OntologyUploadServiceImplTest {
 
         doNothing().when(jenaTDB2Repository).putOntologyModel(eq(ontologyIRI), any(OntModel.class));
 
-        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, userId);
+        OntologyMetadataModel result = ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null);
 
         assertNotNull(result);
         assertEquals(ontologyIRI, result.getGraphName());
@@ -218,7 +220,7 @@ class OntologyUploadServiceImplTest {
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
 
         assertThrows(OntologyUploadException.class, () ->
-                ontologyUploadService.uploadFromFile(multipartFile, userId));
+                ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null));
 
         // Nothing persisted — fail-fast before any TDB2/metadata write.
         // (verifyNoInteractions rather than never().putOntologyModel(..) — the latter
@@ -242,7 +244,7 @@ class OntologyUploadServiceImplTest {
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
 
         assertThrows(OntologyUploadException.class, () ->
-                ontologyUploadService.uploadFromFile(multipartFile, userId));
+                ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null));
 
         verifyNoInteractions(jenaTDB2Repository);
         verify(ontologyMetadataRepository, never()).save(any());
@@ -288,7 +290,7 @@ class OntologyUploadServiceImplTest {
         when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
         doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
 
-        ontologyUploadService.uploadFromFile(multipartFile, userId);
+        ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<ConceptMetadataEntity>> captor = ArgumentCaptor.forClass(List.class);
@@ -303,6 +305,125 @@ class OntologyUploadServiceImplTest {
                 "Alien concept outside graphName's namespace must NOT be claimed as owned");
     }
 
+    // --- Missing-inScheme decision flow ---
+
+    private static final String DECISION_ONTOLOGY = "https://slovník.gov.cz/a3791---registr";
+    private static final String DECISION_C1 = DECISION_ONTOLOGY + "/pojem/vysoká-škola";
+    private static final String DECISION_C2 = DECISION_ONTOLOGY + "/pojem/fakulta";
+    private static final String DECISION_POJEM =
+            "https://slovník.gov.cz/generický/datový-slovník-ofn-slovníků/pojem/pojem";
+
+    /** Two owned concepts, both missing skos:inScheme. */
+    private byte[] twoMissingInSchemeTtl() {
+        return String.format(
+                "@prefix owl: <http://www.w3.org/2002/07/owl#> ."
+                        + " <%s> a owl:Ontology ."
+                        + " <%s> a <%s> ."
+                        + " <%s> a <%s> .",
+                DECISION_ONTOLOGY, DECISION_C1, DECISION_POJEM, DECISION_C2, DECISION_POJEM
+        ).getBytes();
+    }
+
+    private void stubPersistenceForDecisionFlow(String userId) {
+        OntologyMetadataEntity savedEntity = new OntologyMetadataEntity();
+        savedEntity.setGraphName(DECISION_ONTOLOGY);
+        savedEntity.setUserId(userId);
+        savedEntity.setId(1L);
+        OntologyMetadataModel dto = new OntologyMetadataModel();
+        dto.setId(1L);
+        when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+        when(ontologyMetadataMapper.toEntity(any(OntologyMetadataModel.class))).thenReturn(savedEntity);
+        when(ontologyMetadataRepository.save(any(OntologyMetadataEntity.class))).thenReturn(savedEntity);
+        when(ontologyMetadataMapper.toDto(any(OntologyMetadataEntity.class))).thenReturn(dto);
+        when(ontologyMetadataRepository.findById(1L)).thenReturn(Optional.of(savedEntity));
+        when(conceptMetadataRepository.findByConceptIri(anyString())).thenReturn(Optional.empty());
+        when(conceptMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+        when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
+        doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
+    }
+
+    private List<String> capturedSavedConceptIris() {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<ConceptMetadataEntity>> captor = ArgumentCaptor.forClass(List.class);
+        verify(conceptMetadataRepository).saveAll(captor.capture());
+        return captor.getValue().stream().map(ConceptMetadataEntity::getConceptIri).toList();
+    }
+
+    @Test
+    void testUploadFromFile_missingInScheme_noDecision_throwsWithList() throws Exception {
+        String userId = "user123";
+        when(multipartFile.getBytes()).thenReturn(twoMissingInSchemeTtl());
+        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
+        when(multipartFile.isEmpty()).thenReturn(false);
+        when(ontologyMetadataRepository.findBySlug(anyString())).thenReturn(Optional.empty());
+        when(nkdSparqlClient.getPublishedResourcesList(anyList())).thenReturn(Collections.emptyList());
+
+        InSchemeDecisionRequiredException ex = assertThrows(InSchemeDecisionRequiredException.class, () ->
+                ontologyUploadService.uploadFromFile(multipartFile, userId, null, null));
+
+        assertEquals(DECISION_ONTOLOGY, ex.getGraphName());
+        List<String> missingIris = ex.getConceptsMissingInScheme().stream()
+                .map(c -> c.conceptIri()).toList();
+        assertTrue(missingIris.contains(DECISION_C1) && missingIris.contains(DECISION_C2),
+                "Both missing concepts must be reported");
+        ex.getConceptsMissingInScheme().forEach(c ->
+                assertEquals(DECISION_ONTOLOGY, c.proposedInScheme(),
+                        "Proposed inScheme must be the graphName"));
+
+        // Nothing persisted.
+        verifyNoInteractions(jenaTDB2Repository);
+        verify(ontologyMetadataRepository, never()).save(any());
+        verify(conceptMetadataRepository, never()).saveAll(any());
+    }
+
+    @Test
+    void testUploadFromFile_excludeAll_noOwnershipRows() throws Exception {
+        String userId = "user123";
+        when(multipartFile.getBytes()).thenReturn(twoMissingInSchemeTtl());
+        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
+        when(multipartFile.isEmpty()).thenReturn(false);
+        stubPersistenceForDecisionFlow(userId);
+
+        ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.EXCLUDE_ALL, null);
+
+        // Both concepts excluded → no inScheme → no ownership rows. saveAll may be called
+        // with an empty list or not at all; either way neither concept is claimed.
+        verify(conceptMetadataRepository, atMost(1)).saveAll(anyList());
+        // TDB2 still persisted (triples kept as context).
+        verify(jenaTDB2Repository).putOntologyModel(eq(DECISION_ONTOLOGY), any(OntModel.class));
+    }
+
+    @Test
+    void testUploadFromFile_perConcept_onlyChosenOwned() throws Exception {
+        String userId = "user123";
+        when(multipartFile.getBytes()).thenReturn(twoMissingInSchemeTtl());
+        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
+        when(multipartFile.isEmpty()).thenReturn(false);
+        stubPersistenceForDecisionFlow(userId);
+
+        ontologyUploadService.uploadFromFile(
+                multipartFile, userId, NormalizeMode.PER_CONCEPT, List.of(DECISION_C1));
+
+        List<String> saved = capturedSavedConceptIris();
+        assertTrue(saved.contains(DECISION_C1), "Chosen concept must be normalized and owned");
+        assertFalse(saved.contains(DECISION_C2), "Unchosen concept must be excluded (no ownership row)");
+    }
+
+    @Test
+    void testUploadFromFile_normalizeAll_bothOwned() throws Exception {
+        String userId = "user123";
+        when(multipartFile.getBytes()).thenReturn(twoMissingInSchemeTtl());
+        when(multipartFile.getOriginalFilename()).thenReturn("test.ttl");
+        when(multipartFile.isEmpty()).thenReturn(false);
+        stubPersistenceForDecisionFlow(userId);
+
+        ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null);
+
+        List<String> saved = capturedSavedConceptIris();
+        assertTrue(saved.contains(DECISION_C1) && saved.contains(DECISION_C2),
+                "NORMALIZE_ALL must own both previously-missing concepts");
+    }
+
     @Test
     void testUploadFromFile_IOExceptionHandling() throws Exception {
         String userId = "user123";
@@ -313,7 +434,7 @@ class OntologyUploadServiceImplTest {
 
         // The implementation catches IOException and wraps it, but RuntimeException propagates directly
         assertThrows(RuntimeException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, userId));
+            ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null));
 
         verify(ontologyMetadataRepository, never()).save(any());
     }
@@ -325,7 +446,7 @@ class OntologyUploadServiceImplTest {
         when(multipartFile.isEmpty()).thenReturn(true);
 
         assertThrows(EmptyFileException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, userId));
+            ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null));
 
         verify(ontologyMetadataRepository, never()).save(any());
     }
@@ -339,7 +460,7 @@ class OntologyUploadServiceImplTest {
         when(multipartFile.getContentType()).thenReturn("application/unknown");
 
         assertThrows(UnsupportedRdfFormatException.class, () ->
-                ontologyUploadService.uploadFromFile(multipartFile, userId));
+                ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null));
 
         verify(ontologyMetadataRepository, never()).save(any());
     }
@@ -373,7 +494,7 @@ class OntologyUploadServiceImplTest {
 
         doNothing().when(jenaTDB2Repository).putOntologyModel(anyString(), any(OntModel.class));
 
-        ontologyUploadService.uploadFromFile(multipartFile, userId);
+        ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null);
 
         // Verify metadata save happens
         verify(ontologyMetadataRepository).save(any(OntologyMetadataEntity.class));
@@ -398,7 +519,7 @@ class OntologyUploadServiceImplTest {
 
         // Expect exception to be thrown
         assertThrows(OntologyUploadException.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, userId)
+            ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null)
         );
 
         // TDB2 save fails before any metadata is created — no cleanup needed
@@ -438,7 +559,7 @@ class OntologyUploadServiceImplTest {
 
         // Expect exception to be thrown
         assertThrows(Exception.class, () ->
-            ontologyUploadService.uploadFromFile(multipartFile, userId)
+            ontologyUploadService.uploadFromFile(multipartFile, userId, NormalizeMode.NORMALIZE_ALL, null)
         );
 
         // PostgreSQL rollback is handled by @Transactional — no manual deleteById

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadTransactionalTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadTransactionalTest.java
@@ -106,7 +106,7 @@ class OntologyUploadTransactionalTest {
                 .when(jenaTDB2Repository).putOntologyModel(anyString(), any());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "Test Ontology", "user1"));
+                () -> uploadService.uploadFromFile(file, "user1"));
 
         assertTrue(thrown.getMessage().contains("TDB2"));
         // Metadata repository should not have been called
@@ -126,7 +126,7 @@ class OntologyUploadTransactionalTest {
         when(ontologyMetadataRepository.save(any())).thenThrow(new RuntimeException("DB constraint violation"));
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "Test Ontology", "user1"));
+                () -> uploadService.uploadFromFile(file, "user1"));
 
         // TDB2 should be cleaned up
         verify(jenaTDB2Repository).deleteGraph(anyString());
@@ -147,7 +147,7 @@ class OntologyUploadTransactionalTest {
                 .when(jenaTDB2Repository).deleteGraph(anyString());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "Test Ontology", "user1"));
+                () -> uploadService.uploadFromFile(file, "user1"));
 
         // Original exception should still propagate
         assertTrue(thrown.getMessage().contains("Failed to upload ontology"));
@@ -179,7 +179,7 @@ class OntologyUploadTransactionalTest {
                 .when(conceptMetadataRepository).saveAll(any());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "Test Ontology", "user1"));
+                () -> uploadService.uploadFromFile(file, "user1"));
 
         verify(jenaTDB2Repository).deleteGraph(anyString());
     }

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadTransactionalTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadTransactionalTest.java
@@ -3,6 +3,7 @@ package com.dia.ismdtoolbackend.service;
 import com.dia.ismdtoolbackend.client.NkdSparqlClient;
 import com.dia.ismdtoolbackend.client.ValidationClient;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
+import com.dia.ismdtoolbackend.enums.NormalizeMode;
 import com.dia.ismdtoolbackend.exception.OntologyUploadException;
 import com.dia.ismdtoolbackend.mapper.OntologyMetadataMapper;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
@@ -106,7 +107,7 @@ class OntologyUploadTransactionalTest {
                 .when(jenaTDB2Repository).putOntologyModel(anyString(), any());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "user1"));
+                () -> uploadService.uploadFromFile(file, "user1", NormalizeMode.NORMALIZE_ALL, null));
 
         assertTrue(thrown.getMessage().contains("TDB2"));
         // Metadata repository should not have been called
@@ -126,7 +127,7 @@ class OntologyUploadTransactionalTest {
         when(ontologyMetadataRepository.save(any())).thenThrow(new RuntimeException("DB constraint violation"));
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "user1"));
+                () -> uploadService.uploadFromFile(file, "user1", NormalizeMode.NORMALIZE_ALL, null));
 
         // TDB2 should be cleaned up
         verify(jenaTDB2Repository).deleteGraph(anyString());
@@ -147,7 +148,7 @@ class OntologyUploadTransactionalTest {
                 .when(jenaTDB2Repository).deleteGraph(anyString());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "user1"));
+                () -> uploadService.uploadFromFile(file, "user1", NormalizeMode.NORMALIZE_ALL, null));
 
         // Original exception should still propagate
         assertTrue(thrown.getMessage().contains("Failed to upload ontology"));
@@ -179,7 +180,7 @@ class OntologyUploadTransactionalTest {
                 .when(conceptMetadataRepository).saveAll(any());
 
         OntologyUploadException thrown = assertThrows(OntologyUploadException.class,
-                () -> uploadService.uploadFromFile(file, "user1"));
+                () -> uploadService.uploadFromFile(file, "user1", NormalizeMode.NORMALIZE_ALL, null));
 
         verify(jenaTDB2Repository).deleteGraph(anyString());
     }

--- a/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
@@ -40,7 +40,7 @@ class OFNTypeNormalizerTest {
         cls.addProperty(RDF.type, OWL2.Class);
         cls.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
 
-        OFNTypeNormalizer.normalize(model);
+        OFNTypeNormalizer.normalizeForNkd(model);
 
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertTrue(cls.hasProperty(inScheme, model.createResource(ONTOLOGY)),
@@ -54,7 +54,7 @@ class OFNTypeNormalizerTest {
         prop.addProperty(RDF.type, OWL2.DatatypeProperty);
         prop.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
 
-        OFNTypeNormalizer.normalize(model);
+        OFNTypeNormalizer.normalizeForNkd(model);
 
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertTrue(prop.hasProperty(inScheme, model.createResource(ONTOLOGY)),
@@ -68,7 +68,7 @@ class OFNTypeNormalizerTest {
         prop.addProperty(RDF.type, OWL2.ObjectProperty);
         prop.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
 
-        OFNTypeNormalizer.normalize(model);
+        OFNTypeNormalizer.normalizeForNkd(model);
 
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertTrue(prop.hasProperty(inScheme, model.createResource(ONTOLOGY)),
@@ -85,7 +85,7 @@ class OFNTypeNormalizerTest {
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         prop.addProperty(inScheme, model.createResource(otherScheme));
 
-        OFNTypeNormalizer.normalize(model);
+        OFNTypeNormalizer.normalizeForNkd(model);
 
         assertTrue(prop.hasProperty(inScheme, model.createResource(otherScheme)),
                 "Existing skos:inScheme must be preserved");
@@ -99,7 +99,7 @@ class OFNTypeNormalizerTest {
         Resource prop = model.createResource("https://example.org/something/not-a-concept");
         prop.addProperty(RDF.type, OWL2.DatatypeProperty);
 
-        OFNTypeNormalizer.normalize(model);
+        OFNTypeNormalizer.normalizeForNkd(model);
 
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertFalse(prop.hasProperty(inScheme),
@@ -277,5 +277,37 @@ class OFNTypeNormalizerTest {
 
         assertFalse(c.hasProperty(model.createProperty(SKOS_INSCHEME)),
                 "Empty allow-list (EXCLUDE_ALL) must add no inScheme");
+    }
+
+    // --- Read-path split: local does NOT derive inScheme, NKD does ---
+
+    @Test
+    void normalizeForLocalDetail_doesNotDeriveInScheme_butStillInfersRoleTags() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource cls = model.createResource(CLASS_IRI);
+        cls.addProperty(RDF.type, OWL2.Class);
+        cls.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        OFNTypeNormalizer.normalizeForLocalDetail(model);
+
+        // Role tags still inferred so the concept survives TurtleFilterUtil...
+        assertTrue(cls.hasProperty(RDF.type, SKOS.Concept),
+                "Local path must still infer skos:Concept role tag");
+        // ...but inScheme is NOT derived: local data is authoritative post-upload-fix.
+        assertFalse(cls.hasProperty(model.createProperty(SKOS_INSCHEME)),
+                "Local path must NOT derive skos:inScheme (redundant; trusts authoritative upload)");
+    }
+
+    @Test
+    void normalizeForNkd_derivesInScheme_fromPojemPattern() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource cls = model.createResource(CLASS_IRI);
+        cls.addProperty(RDF.type, OWL2.Class);
+        cls.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        OFNTypeNormalizer.normalizeForNkd(model);
+
+        assertTrue(cls.hasProperty(model.createProperty(SKOS_INSCHEME), model.createResource(ONTOLOGY)),
+                "NKD path must derive skos:inScheme by stripping /pojem/ from the concept IRI");
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
@@ -8,6 +8,9 @@ import org.apache.jena.vocabulary.OWL2;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
 
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.vocabulary.SKOS;
+
 import static com.dia.constants.VocabularyConstants.OFN_NAMESPACE;
 import static com.dia.constants.VocabularyConstants.POJEM;
 import static org.junit.jupiter.api.Assertions.*;
@@ -98,5 +101,101 @@ class OFNTypeNormalizerTest {
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertFalse(prop.hasProperty(inScheme),
                 "Resources outside the /pojem/ shape are not concepts and must be left alone");
+    }
+
+    // --- Graph-aware (upload-path) overload: normalize(model, graphName) ---
+
+    @Test
+    void normalizeWithGraphName_throws_whenGraphNameNull() {
+        Model model = ModelFactory.createDefaultModel();
+        assertThrows(IllegalArgumentException.class,
+                () -> OFNTypeNormalizer.normalize(model, null),
+                "Upload-path normalizer requires an authoritative graphName");
+    }
+
+    @Test
+    void normalizeWithGraphName_throws_whenGraphNameBlank() {
+        Model model = ModelFactory.createDefaultModel();
+        assertThrows(IllegalArgumentException.class,
+                () -> OFNTypeNormalizer.normalize(model, "   "));
+    }
+
+    /**
+     * End-state invariant: after the upload-path normalize, EVERY skos:Concept
+     * under graphName carries skos:inScheme. This is the resolution invariant the
+     * resolver depends on — the original stale orphans were concepts that slipped
+     * through with no inScheme.
+     */
+    @Test
+    void normalizeWithGraphName_everyOwnedConceptHasInScheme() {
+        Model model = ModelFactory.createDefaultModel();
+
+        Resource cls = model.createResource(CLASS_IRI);
+        cls.addProperty(RDF.type, OWL2.Class);
+        cls.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        Resource dprop = model.createResource(DATATYPE_PROP_IRI);
+        dprop.addProperty(RDF.type, OWL2.DatatypeProperty);
+        dprop.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        Resource oprop = model.createResource(OBJECT_PROP_IRI);
+        oprop.addProperty(RDF.type, OWL2.ObjectProperty);
+        oprop.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        OFNTypeNormalizer.normalize(model, ONTOLOGY);
+
+        Property inScheme = model.createProperty(SKOS_INSCHEME);
+        ResIterator concepts = model.listResourcesWithProperty(RDF.type, SKOS.Concept);
+        int checked = 0;
+        while (concepts.hasNext()) {
+            Resource c = concepts.next();
+            if (!c.isURIResource() || !c.getURI().startsWith(ONTOLOGY)) {
+                continue;
+            }
+            checked++;
+            assertTrue(c.hasProperty(inScheme),
+                    "Every owned skos:Concept must carry skos:inScheme after normalize: " + c.getURI());
+            assertTrue(c.hasProperty(inScheme, model.createResource(ONTOLOGY)),
+                    "inScheme must point to the authoritative graphName, not a /pojem/-derived value: " + c.getURI());
+        }
+        assertEquals(3, checked, "All three owned concepts should have been checked");
+    }
+
+    /**
+     * The gap that produced the original stale orphans: a bare skos:Concept with no
+     * owl:Class / ObjectProperty / DatatypeProperty type. The graph-aware normalizer
+     * must still give it inScheme → graphName.
+     */
+    @Test
+    void normalizeWithGraphName_addsInScheme_forBareSkosConcept() {
+        Model model = ModelFactory.createDefaultModel();
+        String bareIri = ONTOLOGY + "/pojem/bare-pojem";
+        Resource concept = model.createResource(bareIri);
+        concept.addProperty(RDF.type, SKOS.Concept);
+
+        OFNTypeNormalizer.normalize(model, ONTOLOGY);
+
+        Property inScheme = model.createProperty(SKOS_INSCHEME);
+        assertTrue(concept.hasProperty(inScheme, model.createResource(ONTOLOGY)),
+                "Bare skos:Concept under graphName must get inScheme → graphName");
+    }
+
+    /**
+     * Alien concept: an embedded concept whose IRI is NOT under graphName (e.g. a
+     * legislative reference) must NOT be claimed as owned — no inScheme → graphName.
+     */
+    @Test
+    void normalizeWithGraphName_leavesAlienConceptUnclaimed() {
+        Model model = ModelFactory.createDefaultModel();
+        String alienIri = "https://example.org/legislativa/128-2000/pojem/obec";
+        Resource alien = model.createResource(alienIri);
+        alien.addProperty(RDF.type, SKOS.Concept);
+        alien.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        OFNTypeNormalizer.normalize(model, ONTOLOGY);
+
+        Property inScheme = model.createProperty(SKOS_INSCHEME);
+        assertFalse(alien.hasProperty(inScheme, model.createResource(ONTOLOGY)),
+                "Alien concept must NOT be claimed with inScheme → graphName");
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/exporter/turtle/OFNTypeNormalizerTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.vocabulary.SKOS;
 
+import java.util.List;
+import java.util.Set;
+
 import static com.dia.constants.VocabularyConstants.OFN_NAMESPACE;
 import static com.dia.constants.VocabularyConstants.POJEM;
 import static org.junit.jupiter.api.Assertions.*;
@@ -197,5 +200,82 @@ class OFNTypeNormalizerTest {
         Property inScheme = model.createProperty(SKOS_INSCHEME);
         assertFalse(alien.hasProperty(inScheme, model.createResource(ONTOLOGY)),
                 "Alien concept must NOT be claimed with inScheme → graphName");
+    }
+
+    // --- detectOwnedConceptsMissingInScheme (pure detection) ---
+
+    @Test
+    void detect_returnsOwnedConceptsMissingInScheme_andDoesNotMutate() {
+        Model model = ModelFactory.createDefaultModel();
+        String missing = ONTOLOGY + "/pojem/bez-scheme";
+        Resource concept = model.createResource(missing);
+        concept.addProperty(RDF.type, SKOS.Concept);
+        concept.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        long sizeBefore = model.size();
+        List<String> result = OFNTypeNormalizer.detectOwnedConceptsMissingInScheme(model, ONTOLOGY);
+
+        assertEquals(List.of(missing), result, "Should report the one owned concept missing inScheme");
+        assertEquals(sizeBefore, model.size(), "detect must not mutate the model");
+        Property inScheme = model.createProperty(SKOS_INSCHEME);
+        assertFalse(concept.hasProperty(inScheme), "detect must not add inScheme");
+    }
+
+    @Test
+    void detect_ignoresConceptsThatAlreadyHaveInScheme() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource concept = model.createResource(CLASS_IRI);
+        concept.addProperty(RDF.type, SKOS.Concept);
+        concept.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+        concept.addProperty(model.createProperty(SKOS_INSCHEME), model.createResource(ONTOLOGY));
+
+        assertTrue(OFNTypeNormalizer.detectOwnedConceptsMissingInScheme(model, ONTOLOGY).isEmpty(),
+                "A concept that already has inScheme is not 'missing'");
+    }
+
+    @Test
+    void detect_ignoresAlienConcepts() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource alien = model.createResource("https://example.org/128-2000/pojem/obec");
+        alien.addProperty(RDF.type, SKOS.Concept);
+        alien.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        assertTrue(OFNTypeNormalizer.detectOwnedConceptsMissingInScheme(model, ONTOLOGY).isEmpty(),
+                "Alien concepts are not owned and must not appear in the missing list");
+    }
+
+    // --- normalize(model, graphName, allowList) selective stamping ---
+
+    @Test
+    void normalizeWithAllowList_stampsOnlyListedConcepts() {
+        Model model = ModelFactory.createDefaultModel();
+        String keep = ONTOLOGY + "/pojem/keep";
+        String drop = ONTOLOGY + "/pojem/drop";
+        for (String iri : List.of(keep, drop)) {
+            Resource c = model.createResource(iri);
+            c.addProperty(RDF.type, SKOS.Concept);
+            c.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+        }
+
+        OFNTypeNormalizer.normalize(model, ONTOLOGY, Set.of(keep));
+
+        Property inScheme = model.createProperty(SKOS_INSCHEME);
+        assertTrue(model.getResource(keep).hasProperty(inScheme, model.createResource(ONTOLOGY)),
+                "Allow-listed concept must be stamped");
+        assertFalse(model.getResource(drop).hasProperty(inScheme),
+                "Concept not in the allow-list must be left without inScheme (excluded)");
+    }
+
+    @Test
+    void normalizeWithEmptyAllowList_stampsNothing() {
+        Model model = ModelFactory.createDefaultModel();
+        Resource c = model.createResource(ONTOLOGY + "/pojem/x");
+        c.addProperty(RDF.type, SKOS.Concept);
+        c.addProperty(RDF.type, model.createResource(OFN_NAMESPACE + POJEM));
+
+        OFNTypeNormalizer.normalize(model, ONTOLOGY, Set.of());
+
+        assertFalse(c.hasProperty(model.createProperty(SKOS_INSCHEME)),
+                "Empty allow-list (EXCLUDE_ALL) must add no inScheme");
     }
 }


### PR DESCRIPTION
Summary

Motivation

 This branch removes providedName from ontology upload parameters and makes the RDF data authoritative for graph name and skos:inScheme identification on ontology upload path and turns missing inScheme into a conscious user decision. An edge case exists where concepts in uploaded ontology lack skos:inScheme (observed in NKD ontologies). The codebase had leaky derivation logic that extracts graph name from concept IRI. This feature resolves this issue.
  
  Changes (3 commits)

  1. providedName removed, graphName authority
  - Dropped the providedName request param and the filename/UUID fallback. Graph name now derives only from the data: owl:Ontology first, then skos:ConceptScheme for SKOS-only vocabularies. If neither exists, upload fails with a clear message instead of fabricating a name server side.
  - OFNTypeNormalizer gains a graph-aware normalize(model, graphName) that stamps inScheme → graphName only for owned concepts (IRI under graphName), leaving alien concepts untouched.
  
  2. Missing inScheme decision gate
  - errorCode=MISSING_INSCHEME_DECISION_REQUIRED and data = {graphName, conceptsMissingInScheme[]} for the FE to branch on.
  - Decision travels as multipart fields on re-upload: normalizeMode (NORMALIZE_ALL | EXCLUDE_ALL | PER_CONCEPT) + conceptsToNormalize (allow-list for PER_CONCEPT).
  - Exclude = drop ownership only: excluded concepts get no inScheme and no Postgres ownership row; their triples stay in the graph as inert context.
  - New: MissingConceptDto, MissingInSchemeDecisionDto, NormalizeMode, InSchemeDecisionRequiredException; ApiResponseDto gains an additive errorCode field (null for existing callers); GlobalExceptionHandler renders the 400.
  
  3. inScheme normalization split for the NKD read path
  - Split the read-path normalizer into normalizeForLocalDetail (role tags only — local data is authoritative post-upload, so it does not re-derive inScheme) and normalizeForNkd (role tags plus inScheme derivation, since upstream NKD data is out of our control and often omits it).
  - NkdSparqlClient now calls applyOFNTransformationsForNkd; the heuristic /pojem/-stripping derivation is confined to the NKD path only where it's reasonable for UI navigation purposes.


  Compatibility

  Breaking for the current FE: files that previously uploaded normally via silent normalization now return 400 until the FE sends a decision. Resolution invariant unchanged. @kasikfrantisek coordinate necessary FE changes before merging.

  Tests

  Added/updated coverage across OFNTypeNormalizerTest (detect/allow-list/local-vs-NKD split), OntologyUploadServiceImplTest (gate throws + nothing persisted, the three modes,
  ownership-row exclusion), OntologyControllerTest (param binding, 400 errorCode body), and the transactional test.