### PR TITLE
Feat/esbirka source interactive html resolution

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClient.java
@@ -49,6 +49,17 @@ public class EsbirkaSparqlClient {
                 this::mapLawRows);
     }
 
+    /**
+     * Exact law lookup by predpis number + year. Returns empty Optional when no law
+     * matches (e.g. the number/year combination does not exist in the dataset).
+     */
+    public Optional<LawModel> findLawByNumberYear(String number, int year) {
+        List<LawModel> rows = executeSelect("law by number/year",
+                EsbirkaSPARQLQuery.buildLawByNumberYearQuery(number, year),
+                this::mapLawRows);
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
     public List<LawVersionModel> fetchVersions(String lawIri) {
         return executeSelect("version list",
                 EsbirkaSPARQLQuery.buildVersionListQuery(lawIri),
@@ -59,6 +70,17 @@ public class EsbirkaSparqlClient {
         return executeSelect("fragment tree",
                 EsbirkaSPARQLQuery.buildFragmentTreeQuery(versionIri),
                 this::mapFragmentRows);
+    }
+
+    /**
+     * Whole-version content: every fragment with its rendered HTML body (obsah) in one
+     * round-trip. Same shape as {@link #fetchFragments} plus a (nullable) {@code bodyHtml}
+     * per row — structural fragments carry no body.
+     */
+    public List<FragmentModel> fetchVersionContent(String versionIri) {
+        return executeSelect("version content",
+                EsbirkaSPARQLQuery.buildVersionContentQuery(versionIri),
+                this::mapFragmentContentRows);
     }
 
     /**
@@ -136,6 +158,29 @@ public class EsbirkaSparqlClient {
             }
             String kind = parseKindFromIri(iri);
             out.add(new FragmentModel(iri, parent, citation, kind, order));
+        }
+        return out;
+    }
+
+    /**
+     * Like {@link #mapFragmentRows} but also reads the OPTIONAL {@code obsah} HTML body.
+     * A null body is expected and valid for structural fragments (Část/Hlava/…).
+     */
+    private List<FragmentModel> mapFragmentContentRows(ResultSet rs) {
+        List<FragmentModel> out = new ArrayList<>();
+        while (rs.hasNext()) {
+            QuerySolution sol = rs.next();
+            String iri = SparqlSolutions.resourceUri(sol, "fragment");
+            String parent = SparqlSolutions.resourceUri(sol, "parent");
+            String citation = SparqlSolutions.literalString(sol, "citace");
+            String order = SparqlSolutions.literalString(sol, "order");
+            String bodyHtml = SparqlSolutions.literalString(sol, "obsah");
+            if (iri == null || parent == null) {
+                log.warn("Fragment content row missing iri/parent; iri={}", iri);
+                continue;
+            }
+            String kind = parseKindFromIri(iri);
+            out.add(new FragmentModel(iri, parent, citation, kind, order, bodyHtml));
         }
         return out;
     }

--- a/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/CacheConfig.java
@@ -12,13 +12,15 @@ import java.util.concurrent.TimeUnit;
 /**
  * Caffeine-backed caches for read-only e-Sbírka SPARQL operations.
  *
- * <p>Three caches with distinct lifetimes:
+ * <p>Caches with distinct lifetimes:
  * <ul>
  *   <li>{@code esbirkaLawSearch} — law-search results, 60 min TTL (catalogue evolves daily).</li>
  *   <li>{@code esbirkaLawVersions} — version lists per law, 60 min TTL.</li>
  *   <li>{@code esbirkaFragmentResolution} — fragment citation + version metadata,
  *       24 h TTL (fragments are immutable; only is-latest can shift when a new
  *       version is published).</li>
+ *   <li>{@code esbirkaLawContent} — whole-version content trees (fragment tree + HTML
+ *       bodies), 24 h TTL, capped at 200 entries (~2 MB each; published text is immutable).</li>
  * </ul>
  *
  * <p>Per-cache specs require {@code registerCustomCache} rather than the shared
@@ -33,6 +35,11 @@ public class CacheConfig {
 
     static final long ESBIRKA_RESOLUTION_TTL_HOURS = 24;
     static final long ESBIRKA_RESOLUTION_MAX_ENTRIES = 5_000;
+
+    // Whole-version content payloads are large (~2 MB each), so cap entry count tightly
+    // and keep a long TTL — a published version's text is immutable.
+    static final long ESBIRKA_CONTENT_TTL_HOURS = 24;
+    static final long ESBIRKA_CONTENT_MAX_ENTRIES = 200;
 
     static final long CONCEPT_METADATA_TTL_HOURS = 24;
     static final long CONCEPT_METADATA_MAX_ENTRIES = 10_000;
@@ -54,6 +61,11 @@ public class CacheConfig {
         mgr.registerCustomCache("esbirkaFragmentResolution", Caffeine.newBuilder()
                 .expireAfterWrite(ESBIRKA_RESOLUTION_TTL_HOURS, TimeUnit.HOURS)
                 .maximumSize(ESBIRKA_RESOLUTION_MAX_ENTRIES)
+                .build());
+
+        mgr.registerCustomCache("esbirkaLawContent", Caffeine.newBuilder()
+                .expireAfterWrite(ESBIRKA_CONTENT_TTL_HOURS, TimeUnit.HOURS)
+                .maximumSize(ESBIRKA_CONTENT_MAX_ENTRIES)
                 .build());
 
         // Backs the concept-reference resolver (POST /api/ontology/concepts/resolve).

--- a/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/security/SecurityConfig.java
@@ -155,6 +155,7 @@ public class SecurityConfig {
                         "/api/eli/law/search",
                         "/api/eli/law/versions",
                         "/api/eli/law/fragments",
+                        "/api/eli/law/content",
                         "/api/eli/resolve",
                         "/api/codelist/**",
                         "/v3/api-docs/**",

--- a/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/EsbirkaController.java
@@ -3,6 +3,7 @@ package com.dia.ismdtoolbackend.controller;
 import com.dia.ismdtoolbackend.config.EsbirkaConfig;
 import com.dia.ismdtoolbackend.controller.dto.ApiResponseDto;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
+import com.dia.ismdtoolbackend.controller.dto.LawContentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
@@ -92,6 +93,30 @@ public class EsbirkaController {
             List<FragmentDto> results = esbirkaService.getFragments(versionIri);
             return ResponseEntity.ok(ApiResponseDto.success(results,
                     "Strom fragmentů úspěšně načten."));
+        } finally {
+            MDC.remove(LOG_REQUEST_ID);
+        }
+    }
+
+    @Operation(
+            summary = "Celé znění právního aktu podle reference číslo/rok",
+            description = "Přijímá referenci ve tvaru \"číslo/rok\" (např. \"49/1997\"), vyhledá daný " +
+                    "právní akt přesnou shodou, vybere jeho poslední znění a vrátí celé jeho znění: " +
+                    "hlavičku (IRI aktu, citace, znění, datum účinnosti), seznam všech znění (pro přepínač) " +
+                    "a strom fragmentů, kde každý uzel nese své HTML \"obsah\" tělo pro interaktivní " +
+                    "procházení a výběr sekcí. Pro částečný vstup (např. \"49\") použijte /law/search. " +
+                    "Výsledek je cachován (znění je neměnné)."
+    )
+    @GetMapping("/law/content")
+    public ResponseEntity<ApiResponseDto<LawContentDto>> getLawContent(
+            @RequestParam String law) {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(LOG_REQUEST_ID, requestId);
+        try {
+            log.info("e-Sbírka law content, law: {}", law);
+            LawContentDto result = esbirkaService.getLawContent(law);
+            return ResponseEntity.ok(ApiResponseDto.success(result,
+                    "Celé znění právního aktu úspěšně načteno."));
         } finally {
             MDC.remove(LOG_REQUEST_ID);
         }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/FragmentDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/FragmentDto.java
@@ -16,5 +16,11 @@ public class FragmentDto {
     private String kind;
     private String citation;
     private String order;
+    /**
+     * Rendered HTML body (obsah) of this fragment. Populated only by the whole-version
+     * content endpoint ({@code /api/eli/law/content}); null on the lean fragment-tree
+     * endpoint ({@code /api/eli/law/fragments}) and for structural fragments with no text.
+     */
+    private String bodyHtml;
     private List<FragmentDto> children = new ArrayList<>();
 }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/LawContentDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/LawContentDto.java
@@ -42,4 +42,12 @@ public class LawContentDto {
 
     /** Rendered fragment tree of {@link #versionIri}, each node carrying its HTML body. */
     private List<FragmentDto> fragments;
+
+    /**
+     * The whole version assembled into one coherent HTML body server-side: a document-ordered,
+     * nested tree of {@code <section data-eli=… data-kind=…>} wrappers, each containing its
+     * fragment's HTML body (when any) followed by its children. Lets the FE render the full law
+     * directly; {@link #fragments} remains available for tree-based navigation.
+     */
+    private String bodyHtml;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/controller/dto/LawContentDto.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/dto/LawContentDto.java
@@ -1,0 +1,45 @@
+package com.dia.ismdtoolbackend.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Full content of a law resolved from a number/year reference (e.g. "49/1997").
+ *
+ * <p>Carries the resolved law/version header so the FE can label the document
+ * ("Zákon č. 49/1997 Sb., znění od 1. 11. 2025") and offer a version switcher
+ * ({@link #versions}) without a second call, plus the rendered fragment tree
+ * ({@link #fragments}) with per-node HTML bodies for in-document browsing.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LawContentDto {
+
+    /** Resolved law IRI, e.g. .../eli/cz/sb/1997/49 */
+    private String lawIri;
+
+    /** Official citation of the law, e.g. "49/1997 Sb." */
+    private String citace;
+
+    /** IRI of the version whose content is in {@link #fragments} (the latest version). */
+    private String versionIri;
+
+    /** ELI path of that version, e.g. /eli/cz/sb/1997/49/2025-11-01 */
+    private String versionEliPath;
+
+    /** Effective-from date of the rendered version. */
+    private LocalDate versionDate;
+
+    /** All versions of this law, newest first; for an FE version switcher. */
+    private List<LawVersionDto> versions;
+
+    /** Rendered fragment tree of {@link #versionIri}, each node carrying its HTML body. */
+    private List<FragmentDto> fragments;
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/eli/FragmentModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/eli/FragmentModel.java
@@ -11,4 +11,11 @@ public class FragmentModel {
     private String citation;
     private String kind;
     private String order;
+    /** Rendered HTML body (obsah); null for structural fragments that carry no text. */
+    private String bodyHtml;
+
+    /** Structure-only constructor (no body); used by the lean fragment-tree path. */
+    public FragmentModel(String iri, String parentIri, String citation, String kind, String order) {
+        this(iri, parentIri, citation, kind, order, null);
+    }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQuery.java
+++ b/src/main/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQuery.java
@@ -63,6 +63,30 @@ public class EsbirkaSPARQLQuery {
     }
 
     /**
+     * Exact law lookup by predpis number + year (e.g. "49" + 1997 → 49/1997 Sb.).
+     * Uses equality on číslo-předpisu / rok-předpisu, NOT a citation substring match —
+     * a CONTAINS("49/1997") would wrongly match "149/1997", "249/1997", etc.
+     * číslo is xsd:string; rok is xsd:gYear — both compared via STR() for robustness.
+     */
+    public static String buildLawByNumberYearQuery(String number, int year) {
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.setCommandText("""
+                SELECT ?akt ?citace ?cislo ?rok ?sbirka WHERE {
+                  ?akt a <%1$správní-akt> ;
+                       <%1$scitace-právního-aktu> ?citace ;
+                       <%1$sčíslo-předpisu> ?cislo ;
+                       <%1$srok-předpisu> ?rok ;
+                       <%1$spatří-do-sbírky> ?sbirka .
+                  FILTER(STR(?cislo) = ?numNeedle && STR(?rok) = ?yearNeedle)
+                }
+                LIMIT 1
+                """.formatted(NS));
+        pss.setLiteral("numNeedle", number);
+        pss.setLiteral("yearNeedle", String.valueOf(year));
+        return pss.toString();
+    }
+
+    /**
      * Versions for a given law, ordered newest-first by účinnost-znění-od.
      * Latest flagged via equality with má-poslední-znění.
      * lawIri must be pre-validated by SparqlIriValidator.isEsbirkaEliIri at the controller boundary.
@@ -102,6 +126,39 @@ public class EsbirkaSPARQLQuery {
                   ?fragment <%1$smá-předka> ?parent ;
                             <%1$scitace-označení-fragmentu-znění-právního-aktu> ?citace ;
                             <%1$spořadí-fragmentu-znění-právního-aktu> ?order .
+                }
+                ORDER BY ?order
+                """.formatted(NS));
+        pss.setIri("inputZneni", versionIri);
+        return pss.toString();
+    }
+
+    /**
+     * Whole-version content query: every fragment of a version with its parent edge,
+     * citation, lex-sortable order key, AND its rendered HTML body (obsah) in a single
+     * round-trip. Used to deliver the full law text to the FE for in-document browsing
+     * without per-fragment {@code /resolve} calls.
+     *
+     * <p>The obsah join ({@code obsahuje-fragment/text-fragmentu}) MUST stay OPTIONAL:
+     * structural fragments (Část/Hlava/Díl/Oddíl) carry no text body, and a non-optional
+     * join silently drops them — breaking the navigable tree. (Verified: ~13% of fragments
+     * have no body for sampled versions.)
+     *
+     * <p>versionIri must be pre-validated by SparqlIriValidator.isEsbirkaEliIri at the
+     * controller boundary.
+     */
+    public static String buildVersionContentQuery(String versionIri) {
+        ParameterizedSparqlString pss = new ParameterizedSparqlString();
+        pss.setCommandText("""
+                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+                SELECT ?fragment ?parent ?citace ?order ?obsah
+                WHERE {
+                  ?inputZneni <%1$smá-fragment-znění> ?fragment .
+                  ?fragment <%1$smá-předka> ?parent ;
+                            <%1$scitace-označení-fragmentu-znění-právního-aktu> ?citace ;
+                            <%1$spořadí-fragmentu-znění-právního-aktu> ?order .
+                  OPTIONAL { ?fragment <%1$sobsahuje-fragment>/<%1$stext-fragmentu> ?obsah }
                 }
                 ORDER BY ?order
                 """.formatted(NS));

--- a/src/main/java/com/dia/ismdtoolbackend/service/EsbirkaService.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/EsbirkaService.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.service;
 
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
+import com.dia.ismdtoolbackend.controller.dto.LawContentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
@@ -14,6 +15,13 @@ public interface EsbirkaService {
     List<LawVersionDto> getVersions(String lawIri);
 
     List<FragmentDto> getFragments(String versionIri);
+
+    /**
+     * Resolve a "number/year" law reference (e.g. "49/1997") to the full rendered
+     * content of its latest version: header metadata, version list, and fragment tree
+     * with per-node HTML bodies.
+     */
+    LawContentDto getLawContent(String lawRef);
 
     ResolvedLegalSourceDto resolveLegalSource(String url);
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -2,6 +2,7 @@ package com.dia.ismdtoolbackend.service.impl;
 
 import com.dia.ismdtoolbackend.client.EsbirkaSparqlClient;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
+import com.dia.ismdtoolbackend.controller.dto.LawContentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
@@ -76,6 +77,119 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         }
         return assembleTree(rows, versionIri);
     }
+
+    /**
+     * Resolve a "number/year" law reference (e.g. "49/1997") to the full rendered
+     * content of its latest version.
+     *
+     * <p>Resolution chain: parse number/year → exact law lookup (NOT a citation
+     * substring match) → latest version (má-poslední-znění) → whole-version content
+     * query. The returned {@link LawContentDto} carries the resolved law/version header
+     * and the full version list (for an FE switcher) alongside the fragment tree, whose
+     * nodes each carry their rendered HTML body for in-document browsing.
+     *
+     * <p>Cached by the normalized {@code number/year} key — both the resolution and the
+     * (~2 MB) content payload are expensive, and a published version's text is immutable.
+     */
+    @Override
+    @Cacheable(cacheNames = "esbirkaLawContent", key = "#root.target.normalizeLawRef(#lawRef)")
+    public LawContentDto getLawContent(String lawRef) {
+        NumberYear ny = parseNumberYear(lawRef);
+
+        LawModel law = client.findLawByNumberYear(ny.number(), ny.year())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Právní akt č. " + ny.number() + "/" + ny.year() + " nebyl nalezen."));
+
+        List<LawVersionModel> versions = client.fetchVersions(law.getIri());
+        LawVersionModel latest = pickLatest(versions);
+        if (latest == null) {
+            throw new IllegalArgumentException(
+                    "Právní akt č. " + ny.number() + "/" + ny.year() + " nemá žádné znění.");
+        }
+
+        String versionIri = latest.getIri();
+        List<FragmentModel> rows = client.fetchVersionContent(versionIri);
+        if (rows.size() > FRAGMENT_ROW_WARN_THRESHOLD) {
+            log.warn("Version content for {} has {} rows (over {} threshold).",
+                    versionIri, rows.size(), FRAGMENT_ROW_WARN_THRESHOLD);
+        }
+
+        List<LawVersionDto> versionDtos = new ArrayList<>(versions.size());
+        for (LawVersionModel v : versions) {
+            versionDtos.add(toVersionDto(v));
+        }
+
+        return LawContentDto.builder()
+                .lawIri(law.getIri())
+                .citace(law.getCitace())
+                .versionIri(versionIri)
+                .versionEliPath(SparqlIriValidator.extractEsbirkaEliPath(versionIri))
+                .versionDate(latest.getUcinnostOd())
+                .versions(versionDtos)
+                .fragments(assembleTree(rows, versionIri))
+                .build();
+    }
+
+    /**
+     * Latest version = the one flagged via má-poslední-znění (LawVersionModel.latest).
+     * Falls back to the first row (fetchVersions orders newest-first by účinnost-znění-od)
+     * when no row is flagged — defensive against upstream data without the flag.
+     */
+    private static LawVersionModel pickLatest(List<LawVersionModel> versions) {
+        if (versions.isEmpty()) {
+            return null;
+        }
+        for (LawVersionModel v : versions) {
+            if (v.isLatest()) {
+                return v;
+            }
+        }
+        return versions.get(0);
+    }
+
+    /**
+     * Parse a "number/year" reference into its parts. Tolerates surrounding whitespace
+     * and a trailing " Sb." Rejects anything that isn't exactly number/year — partial
+     * input (e.g. "49") is the FE's cue to use /law/search instead.
+     */
+    static NumberYear parseNumberYear(String lawRef) {
+        if (lawRef == null || lawRef.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Zadejte referenci právního aktu ve tvaru číslo/rok (např. 49/1997).");
+        }
+        String cleaned = lawRef.trim();
+        int sb = cleaned.indexOf(" Sb");
+        if (sb > 0) {
+            cleaned = cleaned.substring(0, sb).trim();
+        }
+        int slash = cleaned.indexOf('/');
+        if (slash <= 0 || slash >= cleaned.length() - 1) {
+            throw new IllegalArgumentException(
+                    "Referenci zadejte ve tvaru číslo/rok (např. 49/1997).");
+        }
+        String number = cleaned.substring(0, slash).trim();
+        String yearStr = cleaned.substring(slash + 1).trim();
+        int year;
+        try {
+            year = Integer.parseInt(yearStr);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Rok v referenci musí být číslo (např. 49/1997).");
+        }
+        if (number.isBlank() || !number.chars().allMatch(Character::isDigit)) {
+            throw new IllegalArgumentException(
+                    "Číslo předpisu v referenci musí být číselné (např. 49/1997).");
+        }
+        return new NumberYear(number, year);
+    }
+
+    /** Cache-key normalization: trims and strips a trailing " Sb." so equivalent refs share a cache entry. */
+    public String normalizeLawRef(String lawRef) {
+        NumberYear ny = parseNumberYear(lawRef);
+        return ny.number() + "/" + ny.year();
+    }
+
+    record NumberYear(String number, int year) {}
 
     /**
      * Tree assembly. Top-level fragments have parent = {@code <versionIri>/dokument/norma}.
@@ -171,6 +285,7 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         dto.setKind(m.getKind());
         dto.setCitation(m.getCitation());
         dto.setOrder(m.getOrder());
+        dto.setBodyHtml(m.getBodyHtml());
         return dto;
     }
 

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -190,7 +190,13 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         return new NumberYear(number, year);
     }
 
-    /** Cache-key normalization: trims and strips a trailing " Sb." so equivalent refs share a cache entry. */
+    /**
+     * Cache-key normalization: trims and strips a trailing " Sb." so equivalent refs share a
+     * cache entry. <strong>Not dead code</strong> — invoked reflectively by the {@code @Cacheable}
+     * SpEL key on {@link #getLawContent} ({@code #root.target.normalizeLawRef(#lawRef)}); must
+     * stay {@code public} for SpEL {@code #root.target} to resolve it. Covered by
+     * {@code EsbirkaServiceImplTest.normalizeLawRefCollapsesEquivalentRefsToOneKey}.
+     */
     public String normalizeLawRef(String lawRef) {
         NumberYear ny = parseNumberYear(lawRef);
         return ny.number() + "/" + ny.year();

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -36,6 +36,7 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     static final int MAX_FRAGMENT_DEPTH = 10;
     static final int FRAGMENT_ROW_WARN_THRESHOLD = 5_000;
     private static final String NORMA_SUFFIX = "/dokument/norma";
+    private static final String POZNAMKY_SUFFIX = "/dokument/poznamkypodcarou";
 
     private final EsbirkaSparqlClient client;
     private final EsbirkaFragmentResolutionCache resolutionCache;
@@ -192,17 +193,25 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     record NumberYear(String number, int year) {}
 
     /**
-     * Tree assembly. Top-level fragments have parent = {@code <versionIri>/dokument/norma}.
-     * Multi-root is supported (any number of children of the norma node).
-     * Orphans (rows whose parent IRI is not in the result set and is not the norma root)
-     * are dropped with a warn-log. Depth is capped at {@link #MAX_FRAGMENT_DEPTH} as a
-     * defensive measure against cyclic / pathological data.
+     * Tree assembly. Top-level fragments are anchored under one of two structural roots:
+     * {@code <versionIri>/dokument/norma} (the body of the act) and
+     * {@code <versionIri>/dokument/poznamkypodcarou} (footnotes) — both contribute roots,
+     * so footnote fragments (which carry real text) are not dropped.
+     * Multi-root is supported (any number of children of either anchor).
+     *
+     * <p>Orphans (rows whose parent IRI is neither an anchor root nor present in the
+     * result set) are dropped with a warn-log. On large laws a known systematic source of
+     * orphans is intermediate {@code frag_*} grouping nodes that {@code má-fragment-znění}
+     * never returns (they carry no citace/order), orphaning their text-bearing children —
+     * tracked as a follow-up; see the orphan warn-log for the live count. Depth is capped
+     * at {@link #MAX_FRAGMENT_DEPTH} as a defensive measure against cyclic / pathological data.
      */
     List<FragmentDto> assembleTree(List<FragmentModel> rows, String versionIri) {
         if (rows.isEmpty()) {
             return List.of();
         }
         String normaRoot = versionIri + NORMA_SUFFIX;
+        String poznamkyRoot = versionIri + POZNAMKY_SUFFIX;
 
         Map<String, FragmentDto> nodes = new HashMap<>(rows.size());
         for (FragmentModel m : rows) {
@@ -211,24 +220,29 @@ public class EsbirkaServiceImpl implements EsbirkaService {
 
         List<FragmentDto> roots = new ArrayList<>();
         int orphanCount = 0;
+        String firstOrphanParent = null;
         for (FragmentModel m : rows) {
             FragmentDto self = nodes.get(m.getIri());
             String parent = m.getParentIri();
-            if (normaRoot.equals(parent)) {
+            if (normaRoot.equals(parent) || poznamkyRoot.equals(parent)) {
                 roots.add(self);
                 continue;
             }
             FragmentDto parentNode = nodes.get(parent);
             if (parentNode == null) {
                 orphanCount++;
+                if (firstOrphanParent == null) {
+                    firstOrphanParent = parent;
+                }
                 continue;
             }
             parentNode.getChildren().add(self);
         }
 
         if (orphanCount > 0) {
-            log.warn("Dropped {} orphan fragment row(s) for version {} (parent IRI not in result set and not norma root).",
-                    orphanCount, versionIri);
+            log.warn("Dropped {} orphan fragment row(s) for version {} (parent IRI neither an anchor root "
+                            + "nor in result set; sample parent IRI: {}).",
+                    orphanCount, versionIri, firstOrphanParent);
         }
 
         capDepth(roots, 1, versionIri);

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -126,6 +127,8 @@ public class EsbirkaServiceImpl implements EsbirkaService {
             versionDtos.add(toVersionDto(v));
         }
 
+        List<FragmentDto> fragments = assembleTree(rows, versionIri);
+
         return LawContentDto.builder()
                 .lawIri(law.getIri())
                 .citace(law.getCitace())
@@ -133,8 +136,45 @@ public class EsbirkaServiceImpl implements EsbirkaService {
                 .versionEliPath(SparqlIriValidator.extractEsbirkaEliPath(versionIri))
                 .versionDate(latest.getUcinnostOd())
                 .versions(versionDtos)
-                .fragments(assembleTree(rows, versionIri))
+                .fragments(fragments)
+                .bodyHtml(renderBodyHtml(fragments))
                 .build();
+    }
+
+    /**
+     * Assemble the whole-version HTML body server-side from the fragment tree.
+     *
+     * <p>Each fragment is wrapped in a {@code <section>} carrying its ELI path and kind as data
+     * attributes (FE hooks for deep-linking / styling); the fragment's own {@code bodyHtml}
+     * (null for structural fragments) precedes its children, so the output is a nested,
+     * document-ordered tree. Order is the tree's order — the server-side {@code ORDER BY ?order}
+     * preserved by {@link #assembleTree}.
+     */
+    private static String renderBodyHtml(List<FragmentDto> roots) {
+        StringBuilder sb = new StringBuilder();
+        for (FragmentDto root : roots) {
+            appendFragmentHtml(sb, root);
+        }
+        return sb.toString();
+    }
+
+    private static void appendFragmentHtml(StringBuilder sb, FragmentDto node) {
+        sb.append("<section data-eli=\"")
+                .append(HtmlUtils.htmlEscape(nullToEmpty(node.getEliPath())))
+                .append("\" data-kind=\"")
+                .append(HtmlUtils.htmlEscape(nullToEmpty(node.getKind())))
+                .append("\">");
+        if (node.getBodyHtml() != null) {
+            sb.append(node.getBodyHtml());
+        }
+        for (FragmentDto child : node.getChildren()) {
+            appendFragmentHtml(sb, child);
+        }
+        sb.append("</section>");
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
     }
 
     /**

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImpl.java
@@ -35,8 +35,14 @@ public class EsbirkaServiceImpl implements EsbirkaService {
 
     static final int MAX_FRAGMENT_DEPTH = 10;
     static final int FRAGMENT_ROW_WARN_THRESHOLD = 5_000;
-    private static final String NORMA_SUFFIX = "/dokument/norma";
-    private static final String POZNAMKY_SUFFIX = "/dokument/poznamkypodcarou";
+
+    /**
+     * Marker for the structural document containers of a version. Direct children of any
+     * {@code <versionIri>/dokument/<container>} (norma / poznamkypodcarou / prilohy / …) are
+     * tree roots. Used by {@link #assembleTree} to detect roots structurally rather than
+     * against a hardcoded container list.
+     */
+    private static final String DOKUMENT_INFIX = "/dokument/";
 
     private final EsbirkaSparqlClient client;
     private final EsbirkaFragmentResolutionCache resolutionCache;
@@ -193,25 +199,16 @@ public class EsbirkaServiceImpl implements EsbirkaService {
     record NumberYear(String number, int year) {}
 
     /**
-     * Tree assembly. Top-level fragments are anchored under one of two structural roots:
-     * {@code <versionIri>/dokument/norma} (the body of the act) and
-     * {@code <versionIri>/dokument/poznamkypodcarou} (footnotes) — both contribute roots,
-     * so footnote fragments (which carry real text) are not dropped.
-     * Multi-root is supported (any number of children of either anchor).
-     *
-     * <p>Orphans (rows whose parent IRI is neither an anchor root nor present in the
-     * result set) are dropped with a warn-log. On large laws a known systematic source of
-     * orphans is intermediate {@code frag_*} grouping nodes that {@code má-fragment-znění}
-     * never returns (they carry no citace/order), orphaning their text-bearing children —
-     * tracked as a follow-up; see the orphan warn-log for the live count. Depth is capped
-     * at {@link #MAX_FRAGMENT_DEPTH} as a defensive measure against cyclic / pathological data.
+     * Tree assembly. A fragment is a <em>root</em> when its parent is a structural document
+     * container — {@code <versionIri>/dokument/<container>} for any container (norma = the
+     * body, poznamkypodcarou = footnotes, prilohy = annexes, …); roots are detected
+     * structurally. Multi-root is supported.
      */
     List<FragmentDto> assembleTree(List<FragmentModel> rows, String versionIri) {
         if (rows.isEmpty()) {
             return List.of();
         }
-        String normaRoot = versionIri + NORMA_SUFFIX;
-        String poznamkyRoot = versionIri + POZNAMKY_SUFFIX;
+        String dokumentPrefix = versionIri + DOKUMENT_INFIX;
 
         Map<String, FragmentDto> nodes = new HashMap<>(rows.size());
         for (FragmentModel m : rows) {
@@ -223,30 +220,74 @@ public class EsbirkaServiceImpl implements EsbirkaService {
         String firstOrphanParent = null;
         for (FragmentModel m : rows) {
             FragmentDto self = nodes.get(m.getIri());
-            String parent = m.getParentIri();
-            if (normaRoot.equals(parent) || poznamkyRoot.equals(parent)) {
+            String anchor = resolveAnchor(m.getParentIri(), nodes, dokumentPrefix);
+            if (anchor == null) {
+                // Unresolvable parent: surface as a root so the fragment's text is never
+                // lost, but count it for the warn-log so the data anomaly stays visible.
                 roots.add(self);
-                continue;
-            }
-            FragmentDto parentNode = nodes.get(parent);
-            if (parentNode == null) {
                 orphanCount++;
                 if (firstOrphanParent == null) {
-                    firstOrphanParent = parent;
+                    firstOrphanParent = m.getParentIri();
                 }
-                continue;
+            } else if (ROOT_ANCHOR.equals(anchor)) {
+                roots.add(self);
+            } else {
+                nodes.get(anchor).getChildren().add(self);
             }
-            parentNode.getChildren().add(self);
         }
 
         if (orphanCount > 0) {
-            log.warn("Dropped {} orphan fragment row(s) for version {} (parent IRI neither an anchor root "
-                            + "nor in result set; sample parent IRI: {}).",
+            log.warn("Surfaced {} fragment row(s) as roots for version {} because their parent IRI "
+                            + "resolved to neither an existing node nor a dokument container "
+                            + "(sample parent IRI: {}).",
                     orphanCount, versionIri, firstOrphanParent);
         }
 
         capDepth(roots, 1, versionIri);
         return roots;
+    }
+
+    /** Sentinel returned by {@link #resolveAnchor} when a fragment resolves to a tree root. */
+    private static final String ROOT_ANCHOR = "ROOT";
+
+    /**
+     * Resolve where a fragment with the given parent IRI should attach.
+     * <ul>
+     *   <li>The IRI of an existing node → attach as that node's child.</li>
+     *   <li>{@link #ROOT_ANCHOR} → the fragment is a tree root (parent is, or walks up to,
+     *       a {@code <versionIri>/dokument/<container>} segment).</li>
+     *   <li>{@code null} → unresolvable; caller surfaces it as a root (no text lost) and warns.</li>
+     * </ul>
+     * Walks the parent IRI up by path segments (stripping a trailing slash first), stopping
+     * at the first existing node or {@code dokument/<container>} segment.
+     */
+    private static String resolveAnchor(String parentIri, Map<String, FragmentDto> nodes, String dokumentPrefix) {
+        if (parentIri == null) {
+            return null;
+        }
+        String cur = parentIri;
+        while (true) {
+            if (nodes.containsKey(cur)) {
+                return cur;
+            }
+            if (isDokumentRoot(cur, dokumentPrefix)) {
+                return ROOT_ANCHOR;
+            }
+            int slash = cur.lastIndexOf('/');
+            if (slash <= 0) {
+                return null;
+            }
+            cur = cur.substring(0, slash);
+        }
+    }
+
+    /** True when {@code iri} is exactly {@code <versionIri>/dokument/<single-segment>}. */
+    private static boolean isDokumentRoot(String iri, String dokumentPrefix) {
+        if (!iri.startsWith(dokumentPrefix)) {
+            return false;
+        }
+        String rest = iri.substring(dokumentPrefix.length());
+        return !rest.isEmpty() && rest.indexOf('/') < 0;
     }
 
     private void capDepth(List<FragmentDto> nodes, int depth, String versionIri) {

--- a/src/test/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClientTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/EsbirkaSparqlClientTest.java
@@ -248,6 +248,49 @@ class EsbirkaSparqlClientTest {
     }
 
     @Test
+    void fetchFragments_lastSegmentWithoutUnderscore_usesSegmentAsKind() {
+        // parseKindFromIri returns the whole last segment when it contains no underscore
+        // (e.g. a "poznamkypodcarou" container or a bare "frag" leaf).
+        String basePath = VERSION_IRI + "/dokument/norma";
+        String json = ("""
+                {
+                  "head": { "vars": ["fragment", "parent", "citace", "order"] },
+                  "results": { "bindings": [
+                    """ +
+                fragmentRow(basePath + "/poznamkypodcarou", basePath, "Poznámky", "FFFF") + ",\n" +
+                fragmentRow(basePath + "/frag",             basePath, "Frag",     "FFFE") +
+                """
+                  ] }
+                }
+                """);
+        stubSparql(json);
+        List<FragmentModel> out = client.fetchFragments(VERSION_IRI);
+        assertEquals(2, out.size());
+        assertEquals("poznamkypodcarou", out.get(0).getKind());
+        assertEquals("frag", out.get(1).getKind());
+    }
+
+    @Test
+    void fetchFragments_iriEndingInSlash_kindIsUnknown() {
+        // Defensive branch: an IRI whose last char is '/' has no parseable last segment.
+        String basePath = VERSION_IRI + "/dokument/norma";
+        String json = ("""
+                {
+                  "head": { "vars": ["fragment", "parent", "citace", "order"] },
+                  "results": { "bindings": [
+                    """ +
+                fragmentRow(basePath + "/trailing/", basePath, "Trailing", "FFFD") +
+                """
+                  ] }
+                }
+                """);
+        stubSparql(json);
+        List<FragmentModel> out = client.fetchFragments(VERSION_IRI);
+        assertEquals(1, out.size());
+        assertEquals("unknown", out.get(0).getKind());
+    }
+
+    @Test
     void fetchFragments_skipsRowMissingParent() {
         String json = """
                 {
@@ -267,6 +310,117 @@ class EsbirkaSparqlClientTest {
         List<FragmentModel> out = client.fetchFragments(VERSION_IRI);
         assertEquals(1, out.size());
         assertEquals("§ 2", out.get(0).getCitation());
+    }
+
+    // --- fetchVersionContent (obsah body mapping) ---------------------------
+
+    @Test
+    void fetchVersionContent_mapsBodyHtmlAndNullForStructuralFragments() {
+        // A textual fragment (par) carries an obsah HTML body; a structural fragment
+        // (cast) carries none — the OPTIONAL obsah join leaves it unbound, and the
+        // mapper must surface that as a null bodyHtml rather than dropping the row.
+        String basePath = VERSION_IRI + "/dokument/norma";
+        String json = ("""
+                {
+                  "head": { "vars": ["fragment", "parent", "citace", "order", "obsah"] },
+                  "results": { "bindings": [
+                    """ +
+                contentRow(basePath + "/cast_1", basePath, "Část 1", "6AC0", null) + ",\n" +
+                contentRow(basePath + "/cast_1/par_1", basePath + "/cast_1", "§ 1", "6AC1",
+                        "<var>§ 1</var> Tělo paragrafu.") +
+                """
+                  ] }
+                }
+                """);
+        stubSparql(json);
+
+        List<FragmentModel> out = client.fetchVersionContent(VERSION_IRI);
+        assertEquals(2, out.size());
+
+        FragmentModel structural = out.get(0);
+        assertEquals("cast", structural.getKind());
+        assertNull(structural.getBodyHtml(), "structural fragment must have null bodyHtml");
+
+        FragmentModel textual = out.get(1);
+        assertEquals("par", textual.getKind());
+        assertEquals("<var>§ 1</var> Tělo paragrafu.", textual.getBodyHtml());
+        assertEquals(basePath + "/cast_1", textual.getParentIri());
+        assertEquals("6AC1", textual.getOrder());
+    }
+
+    @Test
+    void fetchVersionContent_skipsRowMissingParent() {
+        // Same iri/parent guard as the lean fragment path: a row without a parent edge
+        // is dropped (it cannot be placed in the tree), even when it carries an obsah body.
+        String basePath = VERSION_IRI + "/dokument/norma";
+        String json = ("""
+                {
+                  "head": { "vars": ["fragment", "parent", "citace", "order", "obsah"] },
+                  "results": { "bindings": [
+                    { "fragment": {"type":"uri","value":"%1$s/par_1"},
+                      "citace":   {"type":"literal","value":"§ 1"},
+                      "order":    {"type":"literal","value":"6AC0"},
+                      "obsah":    {"type":"literal","value":"<var>orphan</var>"} },
+                    """ +
+                contentRow(basePath + "/par_2", basePath, "§ 2", "6AC1", "<var>§ 2</var>") +
+                """
+                  ] }
+                }
+                """).formatted(basePath);
+        stubSparql(json);
+
+        List<FragmentModel> out = client.fetchVersionContent(VERSION_IRI);
+        assertEquals(1, out.size());
+        assertEquals("§ 2", out.get(0).getCitation());
+        assertEquals("<var>§ 2</var>", out.get(0).getBodyHtml());
+    }
+
+    @Test
+    void fetchVersionContent_emptyResultSet() {
+        stubSparql("""
+                {
+                  "head": { "vars": ["fragment", "parent", "citace", "order", "obsah"] },
+                  "results": { "bindings": [] }
+                }
+                """);
+        assertEquals(0, client.fetchVersionContent(VERSION_IRI).size());
+    }
+
+    // --- findLawByNumberYear ------------------------------------------------
+
+    @Test
+    void findLawByNumberYear_happyPath_mapsFirstRow() {
+        String json = """
+                {
+                  "head": { "vars": ["akt", "citace", "cislo", "rok", "sbirka"] },
+                  "results": { "bindings": [
+                    { "akt":     {"type":"uri","value":"%s"},
+                      "citace":  {"type":"literal","value":"49/1997 Sb."},
+                      "cislo":   {"type":"literal","value":"49"},
+                      "rok":     {"type":"typed-literal","datatype":"http://www.w3.org/2001/XMLSchema#gYear","value":"1997"},
+                      "sbirka":  {"type":"literal","value":"sb"} }
+                  ] }
+                }
+                """.formatted(LAW_IRI);
+        stubSparql(json);
+
+        Optional<LawModel> out = client.findLawByNumberYear("49", 1997);
+        assertTrue(out.isPresent());
+        assertEquals(LAW_IRI, out.get().getIri());
+        assertEquals("49/1997 Sb.", out.get().getCitace());
+        assertEquals("49", out.get().getCislo());
+        assertEquals(Integer.valueOf(1997), out.get().getRok());
+    }
+
+    @Test
+    void findLawByNumberYear_noMatch_returnsEmptyOptional() {
+        stubSparql("""
+                {
+                  "head": { "vars": ["akt", "citace", "cislo", "rok", "sbirka"] },
+                  "results": { "bindings": [] }
+                }
+                """);
+        assertTrue(client.findLawByNumberYear("999", 1997).isEmpty());
     }
 
     // --- resolveFragment ----------------------------------------------------
@@ -401,6 +555,23 @@ class EsbirkaSparqlClientTest {
                   "parent":   {"type":"uri","value":"%s"},
                   "citace":   {"type":"literal","value":"%s"},
                   "order":    {"type":"literal","value":"%s"} }""".formatted(fragmentIri, parentIri, citace, order);
+    }
+
+    /**
+     * A whole-version content row. A null {@code obsah} omits the binding entirely —
+     * modelling an unbound OPTIONAL (structural fragment with no text body), which the
+     * mapper must surface as a null bodyHtml.
+     */
+    private static String contentRow(String fragmentIri, String parentIri, String citace,
+                                     String order, String obsah) {
+        String obsahBinding = obsah == null ? ""
+                : ",\n                  \"obsah\": {\"type\":\"literal\",\"value\":\"%s\"}".formatted(obsah);
+        return """
+                { "fragment": {"type":"uri","value":"%s"},
+                  "parent":   {"type":"uri","value":"%s"},
+                  "citace":   {"type":"literal","value":"%s"},
+                  "order":    {"type":"literal","value":"%s"}%s }"""
+                .formatted(fragmentIri, parentIri, citace, order, obsahBinding);
     }
 
     private static void stubSparql(String body) {

--- a/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/EsbirkaControllerTest.java
@@ -6,6 +6,7 @@ import com.dia.ismdtoolbackend.config.security.TestOntologySecurityService;
 import com.dia.ismdtoolbackend.config.security.TestSecurityConfig;
 import com.dia.ismdtoolbackend.config.security.WithMockSecurityUser;
 import com.dia.ismdtoolbackend.controller.dto.FragmentDto;
+import com.dia.ismdtoolbackend.controller.dto.LawContentDto;
 import com.dia.ismdtoolbackend.controller.dto.LawDto;
 import com.dia.ismdtoolbackend.controller.dto.LawVersionDto;
 import com.dia.ismdtoolbackend.controller.dto.ResolvedLegalSourceDto;
@@ -27,6 +28,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -181,7 +183,7 @@ class EsbirkaControllerTest {
     void fragmentsHappyPathReturnsTree() throws Exception {
         FragmentDto root = new FragmentDto(VERSION_IRI + "/par_1",
                 "/eli/cz/sb/2006/187/2026-04-01/par_1",
-                "par", "§ 1", "0001", new ArrayList<>());
+                "par", "§ 1", "0001", null, new ArrayList<>());
         when(esbirkaService.getFragments(VERSION_IRI)).thenReturn(List.of(root));
 
         mockMvc.perform(get("/api/eli/law/fragments").param("versionIri", VERSION_IRI))
@@ -204,6 +206,77 @@ class EsbirkaControllerTest {
                 .thenThrow(new SparqlEndpointUnavailableException("e-Sbírka", "e-Sbírka fragment tree fetch failed"));
 
         mockMvc.perform(get("/api/eli/law/fragments").param("versionIri", VERSION_IRI))
+                .andExpect(status().isServiceUnavailable());
+    }
+
+    // -------- /law/content --------
+
+    @Test
+    void contentHappyPathReturnsHeaderVersionsAndTree() throws Exception {
+        FragmentDto child = new FragmentDto(VERSION_IRI + "/par_1/odst_1",
+                "/eli/cz/sb/2006/187/2026-04-01/par_1/odst_1",
+                "odst", "§ 1 odst. 1", "0002", "<var>1.</var> Tělo.", new ArrayList<>());
+        List<FragmentDto> children = new ArrayList<>();
+        children.add(child);
+        FragmentDto root = new FragmentDto(VERSION_IRI + "/par_1",
+                "/eli/cz/sb/2006/187/2026-04-01/par_1",
+                "par", "§ 1", "0001", null, children);
+        LawVersionDto v = new LawVersionDto(VERSION_IRI, "/eli/cz/sb/2006/187/2026-04-01",
+                LocalDate.of(2026, 4, 1), null, "t", true);
+        LawContentDto dto = LawContentDto.builder()
+                .lawIri(LAW_IRI)
+                .citace("187/2006 Sb.")
+                .versionIri(VERSION_IRI)
+                .versionEliPath("/eli/cz/sb/2006/187/2026-04-01")
+                .versionDate(LocalDate.of(2026, 4, 1))
+                .versions(List.of(v))
+                .fragments(List.of(root))
+                .build();
+        when(esbirkaService.getLawContent("187/2006")).thenReturn(dto);
+
+        mockMvc.perform(get("/api/eli/law/content").param("law", "187/2006"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.lawIri").value(LAW_IRI))
+                .andExpect(jsonPath("$.data.citace").value("187/2006 Sb."))
+                .andExpect(jsonPath("$.data.versionIri").value(VERSION_IRI))
+                .andExpect(jsonPath("$.data.versions.length()").value(1))
+                .andExpect(jsonPath("$.data.fragments.length()").value(1))
+                .andExpect(jsonPath("$.data.fragments[0].bodyHtml").value(nullValue()))
+                .andExpect(jsonPath("$.data.fragments[0].children[0].bodyHtml").value("<var>1.</var> Tělo."))
+                .andExpect(jsonPath("$.message").value("Celé znění právního aktu úspěšně načteno."));
+    }
+
+    @Test
+    void contentPartialInputReturns400() throws Exception {
+        when(esbirkaService.getLawContent("49"))
+                .thenThrow(new IllegalArgumentException("Referenci zadejte ve tvaru číslo/rok (např. 49/1997)."));
+        mockMvc.perform(get("/api/eli/law/content").param("law", "49"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Referenci zadejte ve tvaru číslo/rok (např. 49/1997)."));
+    }
+
+    @Test
+    void contentUnknownLawReturns400() throws Exception {
+        when(esbirkaService.getLawContent("999/1997"))
+                .thenThrow(new IllegalArgumentException("Právní akt č. 999/1997 nebyl nalezen."));
+        mockMvc.perform(get("/api/eli/law/content").param("law", "999/1997"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Právní akt č. 999/1997 nebyl nalezen."));
+    }
+
+    @Test
+    void contentMissingParamReturns400() throws Exception {
+        mockMvc.perform(get("/api/eli/law/content"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void contentService503BubblesUp() throws Exception {
+        when(esbirkaService.getLawContent("187/2006"))
+                .thenThrow(new SparqlEndpointUnavailableException("e-Sbírka", "e-Sbírka version content fetch failed"));
+
+        mockMvc.perform(get("/api/eli/law/content").param("law", "187/2006"))
                 .andExpect(status().isServiceUnavailable());
     }
 

--- a/src/test/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQueryTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/query/EsbirkaSPARQLQueryTest.java
@@ -57,6 +57,28 @@ class EsbirkaSPARQLQueryTest {
     }
 
     @Test
+    void lawByNumberYear_parsesAndUsesExactEqualityNotContains() {
+        String q = EsbirkaSPARQLQuery.buildLawByNumberYearQuery("49", 1997);
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        assertTrue(q.contains("číslo-předpisu"), "must filter on číslo-předpisu (with č intact)");
+        assertTrue(q.contains("rok-předpisu"));
+        assertTrue(q.contains("STR(?cislo) = "), "exact equality on number, not CONTAINS");
+        assertTrue(q.contains("STR(?rok) = "), "exact equality on year");
+        assertFalse(q.contains("CONTAINS"), "must NOT use substring match (would hit 149/1997 etc.)");
+        // Values inlined as escaped literals via PSS.
+        assertTrue(q.contains("\"49\""));
+        assertTrue(q.contains("\"1997\""));
+        assertTrue(q.contains("LIMIT 1"));
+    }
+
+    @Test
+    void lawByNumberYear_numberInjectionIsEscaped() {
+        String q = EsbirkaSPARQLQuery.buildLawByNumberYearQuery("49\" ; DROP", 1997);
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        assertFalse(q.contains("49\" ; DROP"), "bare malicious string must not appear verbatim");
+    }
+
+    @Test
     void versionList_parsesAndContainsKeyPredicates() {
         String q = EsbirkaSPARQLQuery.buildVersionListQuery(LAW_IRI);
         assertDoesNotThrow(() -> QueryFactory.create(q));
@@ -82,6 +104,37 @@ class EsbirkaSPARQLQueryTest {
         assertTrue(q.contains("ORDER BY ?order"));
         assertTrue(q.contains("<" + VERSION_IRI + ">"),
                 "versionIri must be inlined as <iri> via ParameterizedSparqlString.setIri");
+    }
+
+    @Test
+    void versionContent_parsesAndContainsTreePredicatesPlusObsah() {
+        String q = EsbirkaSPARQLQuery.buildVersionContentQuery(VERSION_IRI);
+        assertDoesNotThrow(() -> QueryFactory.create(q));
+        // Same structural backbone as the lean fragment-tree query...
+        assertTrue(q.contains("má-fragment-znění"));
+        assertTrue(q.contains("má-předka"));
+        assertTrue(q.contains("citace-označení-fragmentu-znění-právního-aktu"));
+        assertTrue(q.contains("pořadí-fragmentu-znění-právního-aktu"));
+        assertTrue(q.contains("ORDER BY ?order"));
+        assertTrue(q.contains("<" + VERSION_IRI + ">"),
+                "versionIri must be inlined as <iri> via ParameterizedSparqlString.setIri");
+        // ...plus the HTML body.
+        assertTrue(q.contains("?obsah"), "obsah must be projected");
+        assertTrue(q.contains("obsahuje-fragment"));
+        assertTrue(q.contains("text-fragmentu"));
+    }
+
+    @Test
+    void versionContent_obsahJoinIsOptional() {
+        // Critical correctness invariant: structural fragments (Část/Hlava/…) carry no
+        // text body. A non-OPTIONAL obsah join would silently drop them and break the tree.
+        String q = EsbirkaSPARQLQuery.buildVersionContentQuery(VERSION_IRI);
+        int optionalCount = q.split("(?i)OPTIONAL").length - 1;
+        assertTrue(optionalCount >= 1, "obsah join MUST be OPTIONAL; found " + optionalCount);
+        // The obsah chain must sit inside an OPTIONAL block.
+        String afterOptional = q.substring(q.toUpperCase().indexOf("OPTIONAL"));
+        assertTrue(afterOptional.contains("obsahuje-fragment"),
+                "the obsahuje-fragment/text-fragmentu chain must be wrapped in OPTIONAL");
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
@@ -128,6 +128,26 @@ class EsbirkaServiceImplTest {
     }
 
     @Test
+    void poznamkyPodcarouFragmentsBecomeRoots() {
+        // Footnotes hang off <versionIri>/dokument/poznamkypodcarou, a second structural
+        // root alongside /dokument/norma. They carry real text and must not be dropped.
+        // (Live: labour law 262/2006 has 123 such footnote fragments, all text-bearing.)
+        String poznamkyRoot = VERSION_IRI + "/dokument/poznamkypodcarou";
+        String par = VERSION_IRI + "/par_1";
+        String fn1 = poznamkyRoot + "/frag_1";
+        String fn2 = poznamkyRoot + "/frag_2";
+        when(client.fetchFragments(VERSION_IRI)).thenReturn(List.of(
+                new FragmentModel(par, NORMA_ROOT, "§ 1", "par", "0001"),
+                new FragmentModel(fn1, poznamkyRoot, "1)", "frag", "9001"),
+                new FragmentModel(fn2, poznamkyRoot, "2)", "frag", "9002")));
+        List<FragmentDto> out = service.getFragments(VERSION_IRI);
+        assertEquals(3, out.size());
+        assertEquals(par, out.get(0).getIri());
+        assertEquals(fn1, out.get(1).getIri());
+        assertEquals(fn2, out.get(2).getIri());
+    }
+
+    @Test
     void multiRootIsSupported() {
         String par1 = VERSION_IRI + "/par_1";
         String par2 = VERSION_IRI + "/par_2";

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
@@ -322,6 +322,73 @@ class EsbirkaServiceImplTest {
     }
 
     @Test
+    void getLawContentAssemblesNestedBodyHtmlInDocumentOrder() {
+        // Server-side bodyHtml: a document-ordered, nested tree of <section> wrappers, each
+        // carrying its fragment's body (null for structural nodes) followed by its children.
+        when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
+                new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));
+        when(client.fetchVersions(LAW_IRI)).thenReturn(List.of(
+                new LawVersionModel(VERSION_IRI, LocalDate.of(2026, 4, 1), null, "t", true)));
+
+        // cast_1 (structural, no body) -> par_1 (body) -> odst_1 (body), then par_2 (body).
+        String cast = NORMA_ROOT + "/cast_1";
+        String par1 = cast + "/par_1";
+        String odst = par1 + "/odst_1";
+        String par2 = NORMA_ROOT + "/par_2";
+        when(client.fetchVersionContent(VERSION_IRI)).thenReturn(List.of(
+                new FragmentModel(cast, NORMA_ROOT, "Část 1", "cast", "0001", null),
+                new FragmentModel(par1, cast, "§ 1", "par", "0002", "<p>§ 1</p>"),
+                new FragmentModel(odst, par1, "§ 1 odst. 1", "odst", "0003", "<p>(1)</p>"),
+                new FragmentModel(par2, NORMA_ROOT, "§ 2", "par", "0004", "<p>§ 2</p>")));
+
+        com.dia.ismdtoolbackend.controller.dto.LawContentDto out = service.getLawContent("49/1997");
+
+        String body = out.getBodyHtml();
+        // Document order: §1 before its odst, both before §2.
+        assertTrue(body.indexOf("<p>§ 1</p>") < body.indexOf("<p>(1)</p>"), "§ 1 must precede its odst");
+        assertTrue(body.indexOf("<p>(1)</p>") < body.indexOf("<p>§ 2</p>"), "odst must precede § 2");
+        // Structural cast_1 contributes a wrapper but no body literal of its own.
+        assertTrue(body.contains("data-kind=\"cast\""), "structural node still wrapped");
+        assertTrue(body.contains("data-kind=\"odst\""));
+        // Nesting: odst_1's section is INSIDE par_1's section (no closing </section> between
+        // the §1 body and the (1) body — the odst opens before §1's section closes).
+        int par1Body = body.indexOf("<p>§ 1</p>");
+        int odstBody = body.indexOf("<p>(1)</p>");
+        assertEquals(0, countCloseSections(body, par1Body, odstBody),
+                "odst must nest inside par_1 — no </section> between their bodies");
+        // Balanced wrappers: one <section> open and close per fragment (4 fragments).
+        assertEquals(4, countOccurrences(body, "<section "), "one wrapper per fragment");
+        assertEquals(4, countOccurrences(body, "</section>"), "wrappers must be balanced");
+        // bodyHtml is emitted as-is (not escaped) — raw <p> tags survive.
+        assertTrue(body.contains("<p>§ 1</p>"));
+        // The tree is still present alongside the assembled body.
+        assertEquals(2, out.getFragments().size());
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int n = 0, i = 0;
+        while ((i = haystack.indexOf(needle, i)) >= 0) { n++; i += needle.length(); }
+        return n;
+    }
+
+    private static int countCloseSections(String s, int from, int to) {
+        return countOccurrences(s.substring(from, to), "</section>");
+    }
+
+    @Test
+    void getLawContentEmptyContentYieldsEmptyBodyHtml() {
+        when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
+                new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));
+        when(client.fetchVersions(LAW_IRI)).thenReturn(List.of(
+                new LawVersionModel(VERSION_IRI, LocalDate.of(2026, 4, 1), null, "t", true)));
+        when(client.fetchVersionContent(VERSION_IRI)).thenReturn(List.of());
+
+        com.dia.ismdtoolbackend.controller.dto.LawContentDto out = service.getLawContent("49/1997");
+        assertEquals("", out.getBodyHtml());
+        assertTrue(out.getFragments().isEmpty());
+    }
+
+    @Test
     void getLawContentPicksLatestEvenWhenNotFirstRow() {
         when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
                 new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
@@ -378,6 +378,30 @@ class EsbirkaServiceImplTest {
         assertThrows(IllegalArgumentException.class, () -> service.getLawContent("  "));
     }
 
+    // -------- normalizeLawRef: @Cacheable key generator --------
+
+    @Test
+    void normalizeLawRefCollapsesEquivalentRefsToOneKey() {
+        // normalizeLawRef is the SpEL key expression for @Cacheable on getLawContent
+        // (#root.target.normalizeLawRef(#lawRef)). It MUST collapse trim/Sb.-suffix
+        // variants to a single key, or equivalent refs each store a separate ~2 MB entry.
+        assertEquals("49/1997", service.normalizeLawRef("49/1997"));
+        assertEquals("49/1997", service.normalizeLawRef("  49/1997  "));
+        assertEquals("49/1997", service.normalizeLawRef("49/1997 Sb."));
+        assertEquals("49/1997", service.normalizeLawRef("  49/1997 Sb. "));
+        // Leading-zero year is normalized via Integer parse (1997, not "1997 ").
+        assertEquals("262/2006", service.normalizeLawRef("262/2006 Sb."));
+    }
+
+    @Test
+    void normalizeLawRefRejectsPartialInputLikeGetLawContent() {
+        // Same parser as getLawContent, so the cache-key path rejects junk identically
+        // rather than producing a bogus key.
+        assertThrows(IllegalArgumentException.class, () -> service.normalizeLawRef("49"));
+        assertThrows(IllegalArgumentException.class, () -> service.normalizeLawRef("abc/1997"));
+        assertThrows(IllegalArgumentException.class, () -> service.normalizeLawRef("  "));
+    }
+
     // -------- DTO mapping edge cases --------
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
@@ -161,21 +161,94 @@ class EsbirkaServiceImplTest {
     }
 
     @Test
-    void orphanRowsAreDroppedWithWarn() {
-        // par_1 is a root; "ghost" claims a parent that isn't in the result set.
-        String par = VERSION_IRI + "/par_1";
-        String ghost = VERSION_IRI + "/par_1/odst_1";
-        String missingParent = VERSION_IRI + "/par_99/odst_5";
+    void fragUnderParWhoseGrouperIsMissing_reparentsToNearestExistingAncestor() {
+        // e-Sbírka nests text fragments under intermediate frag_* grouping nodes that
+        // má-fragment-znění never returns. The child's parent IRI (.../par_1/frag_X) is not
+        // in the set; walking the IRI path up one segment lands on par_1, which IS. The text
+        // fragment must attach to par_1, not be dropped. (Live: 151/152 such rows on 262/2006.)
+        String par = NORMA_ROOT + "/par_1";
+        String missingGrouper = par + "/frag_6660499";
+        String text = missingGrouper + "/text_1";
         when(client.fetchFragments(VERSION_IRI)).thenReturn(List.of(
                 new FragmentModel(par, NORMA_ROOT, "§ 1", "par", "0001"),
-                new FragmentModel(ghost, par, "§ 1 odst. 1", "odst", "0002"),
-                new FragmentModel(missingParent, missingParent + "-no-such",
-                        "ghost", "odst", "0003")));
+                new FragmentModel(text, missingGrouper, "§ 1 text", "text", "0002")));
         List<FragmentDto> out = service.getFragments(VERSION_IRI);
         assertEquals(1, out.size());
         assertEquals(par, out.get(0).getIri());
         assertEquals(1, out.get(0).getChildren().size());
-        assertEquals(ghost, out.get(0).getChildren().get(0).getIri());
+        assertEquals(text, out.get(0).getChildren().get(0).getIri());
+    }
+
+    @Test
+    void prilohyDokumentContainerIsAThirdRoot() {
+        // Besides norma and poznamkypodcarou, annexes live under <V>/dokument/prilohy.
+        // A priloha fragment whose grouper parent is missing must walk up to the prilohy
+        // container and become a root. (Live: priloha_0 on 262/2006.)
+        String par = NORMA_ROOT + "/par_1";
+        String prilohyRoot = VERSION_IRI + "/dokument/prilohy";
+        String priloha = prilohyRoot + "/priloha_0";
+        when(client.fetchFragments(VERSION_IRI)).thenReturn(List.of(
+                new FragmentModel(par, NORMA_ROOT, "§ 1", "par", "0001"),
+                new FragmentModel(priloha, prilohyRoot + "/frag_6668611", "Příloha", "priloha", "9999")));
+        List<FragmentDto> out = service.getFragments(VERSION_IRI);
+        assertEquals(2, out.size());
+        assertEquals(par, out.get(0).getIri());
+        assertEquals(priloha, out.get(1).getIri());
+    }
+
+    @Test
+    void realisticMixedShape_losesNoFragment() {
+        // End-to-end regression mirroring labour law 262/2006's structure: a norma subtree
+        // with a text fragment nested under a MISSING frag_* grouper, a footnote root, and an
+        // annex whose grouper is also missing. Every input row must appear in the tree exactly
+        // once. (Pre-fix, ~11% of rows like these were dropped.)
+        String cast = NORMA_ROOT + "/cast_1";
+        String par = cast + "/par_1";
+        String missingGrouper = par + "/frag_100";
+        String text = missingGrouper + "/text_1";
+        String footnote = VERSION_IRI + "/dokument/poznamkypodcarou/frag_9";
+        String annexGrouper = VERSION_IRI + "/dokument/prilohy/frag_50";
+        String annex = VERSION_IRI + "/dokument/prilohy/priloha_0";
+
+        List<FragmentModel> rows = List.of(
+                new FragmentModel(cast, NORMA_ROOT, "Část 1", "cast", "0001"),
+                new FragmentModel(par, cast, "§ 1", "par", "0002"),
+                new FragmentModel(text, missingGrouper, "§ 1 text", "text", "0003"),
+                new FragmentModel(footnote, VERSION_IRI + "/dokument/poznamkypodcarou", "1)", "frag", "0004"),
+                new FragmentModel(annex, annexGrouper, "Příloha 1", "priloha", "0005"));
+        when(client.fetchFragments(VERSION_IRI)).thenReturn(rows);
+
+        List<FragmentDto> out = service.getFragments(VERSION_IRI);
+
+        // Walk the assembled tree and collect every IRI; must equal the 5 input IRIs.
+        java.util.Set<String> seen = new java.util.HashSet<>();
+        java.util.Deque<FragmentDto> stack = new java.util.ArrayDeque<>(out);
+        while (!stack.isEmpty()) {
+            FragmentDto n = stack.pop();
+            assertTrue(seen.add(n.getIri()), "fragment appeared twice: " + n.getIri());
+            stack.addAll(n.getChildren());
+        }
+        assertEquals(java.util.Set.of(cast, par, text, footnote, annex), seen,
+                "every input fragment must appear exactly once — no text lost");
+
+        // Roots: cast (norma child), footnote, annex. text/par are nested, not roots.
+        assertEquals(3, out.size());
+    }
+
+    @Test
+    void unresolvableParentIsSurfacedAsRootNotDropped() {
+        // A parent that resolves to neither an existing node nor a dokument container is a
+        // genuine data anomaly. We surface the fragment as a root (its text is never lost)
+        // and warn, rather than silently dropping it.
+        String par = NORMA_ROOT + "/par_1";
+        String ghost = VERSION_IRI + "/par_99/odst_5";
+        when(client.fetchFragments(VERSION_IRI)).thenReturn(List.of(
+                new FragmentModel(par, NORMA_ROOT, "§ 1", "par", "0001"),
+                new FragmentModel(ghost, ghost + "-no-such", "ghost", "odst", "0003")));
+        List<FragmentDto> out = service.getFragments(VERSION_IRI);
+        assertEquals(2, out.size());
+        assertEquals(par, out.get(0).getIri());
+        assertEquals(ghost, out.get(1).getIri());
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/impl/EsbirkaServiceImplTest.java
@@ -203,6 +203,88 @@ class EsbirkaServiceImplTest {
         assertEquals(5_001, out.size());
     }
 
+    // -------- getLawContent: number/year resolution --------
+
+    @Test
+    void getLawContentParsesNumberYearAndResolvesLatestVersion() {
+        when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
+                new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));
+        String olderIri = LAW_IRI + "/2020-01-01";
+        when(client.fetchVersions(LAW_IRI)).thenReturn(List.of(
+                new LawVersionModel(VERSION_IRI, LocalDate.of(2026, 4, 1), null, "t", true),
+                new LawVersionModel(olderIri, LocalDate.of(2020, 1, 1), null, "t", false)));
+        String par = VERSION_IRI + "/par_1";
+        when(client.fetchVersionContent(VERSION_IRI)).thenReturn(List.of(
+                new FragmentModel(par, NORMA_ROOT, "§ 1", "par", "0001", "<var>§ 1</var>")));
+
+        com.dia.ismdtoolbackend.controller.dto.LawContentDto out = service.getLawContent("49/1997");
+
+        assertEquals(LAW_IRI, out.getLawIri());
+        assertEquals("49/1997 Sb.", out.getCitace());
+        assertEquals(VERSION_IRI, out.getVersionIri());
+        assertEquals(LocalDate.of(2026, 4, 1), out.getVersionDate());
+        assertEquals(2, out.getVersions().size());
+        assertEquals(1, out.getFragments().size());
+        assertEquals("<var>§ 1</var>", out.getFragments().get(0).getBodyHtml());
+    }
+
+    @Test
+    void getLawContentPicksLatestEvenWhenNotFirstRow() {
+        when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
+                new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));
+        String latestIri = LAW_IRI + "/2026-04-01";
+        when(client.fetchVersions(LAW_IRI)).thenReturn(List.of(
+                new LawVersionModel(LAW_IRI + "/2020-01-01", LocalDate.of(2020, 1, 1), null, "t", false),
+                new LawVersionModel(latestIri, LocalDate.of(2026, 4, 1), null, "t", true)));
+        when(client.fetchVersionContent(latestIri)).thenReturn(List.of());
+
+        com.dia.ismdtoolbackend.controller.dto.LawContentDto out = service.getLawContent("49/1997");
+        assertEquals(latestIri, out.getVersionIri());
+    }
+
+    @Test
+    void getLawContentTrimsAndStripsSbSuffix() {
+        when(client.findLawByNumberYear("49", 1997)).thenReturn(java.util.Optional.of(
+                new LawModel(LAW_IRI, "49/1997 Sb.", "49", 1997, "sb")));
+        when(client.fetchVersions(LAW_IRI)).thenReturn(List.of(
+                new LawVersionModel(VERSION_IRI, LocalDate.of(2026, 4, 1), null, "t", true)));
+        when(client.fetchVersionContent(VERSION_IRI)).thenReturn(List.of());
+
+        com.dia.ismdtoolbackend.controller.dto.LawContentDto out = service.getLawContent("  49/1997 Sb. ");
+        assertEquals(LAW_IRI, out.getLawIri());
+    }
+
+    @Test
+    void getLawContentUnknownLawThrows() {
+        when(client.findLawByNumberYear("999", 1997)).thenReturn(java.util.Optional.empty());
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.getLawContent("999/1997"));
+        assertEquals("Právní akt č. 999/1997 nebyl nalezen.", ex.getMessage());
+    }
+
+    @Test
+    void getLawContentRejectsPartialInput() {
+        // bare number is the FE's cue to use /law/search instead
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.getLawContent("49"));
+        assertEquals("Referenci zadejte ve tvaru číslo/rok (např. 49/1997).", ex.getMessage());
+    }
+
+    @Test
+    void getLawContentRejectsNonNumericYear() {
+        assertThrows(IllegalArgumentException.class, () -> service.getLawContent("49/abc"));
+    }
+
+    @Test
+    void getLawContentRejectsNonNumericNumber() {
+        assertThrows(IllegalArgumentException.class, () -> service.getLawContent("abc/1997"));
+    }
+
+    @Test
+    void getLawContentRejectsBlank() {
+        assertThrows(IllegalArgumentException.class, () -> service.getLawContent("  "));
+    }
+
     // -------- DTO mapping edge cases --------
 
     @Test


### PR DESCRIPTION
Summary

  - This PR adds new GET law/content endpoint fetching complete law fragment tree and bodyHtml rendering for interactive UI work with legislative sources.
  - Accepts query parameter in law number/year format. Results are cached copying current eSbírka search results.