### PR TITLE
Concept edit class refactor and consolidation

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/ClassConceptEditModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/ClassConceptEditModel.java
@@ -3,7 +3,6 @@ package com.dia.ismdtoolbackend.models.concept;
 import com.dia.ismdtoolbackend.enums.ConceptType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
@@ -25,16 +24,5 @@ public class ClassConceptEditModel extends ConceptEditModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.TRIDA;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (!"TRIDA".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'TRIDA'");
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Třída", "á");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/ClassConceptModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/ClassConceptModel.java
@@ -3,7 +3,6 @@ package com.dia.ismdtoolbackend.models.concept;
 import com.dia.ismdtoolbackend.enums.ConceptType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
@@ -25,20 +24,5 @@ public class ClassConceptModel extends ConceptCreateModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.TRIDA;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (type == null || type.isEmpty()) {
-            throw new OntologyException("Typ třídy je povinný.");
-        }
-
-        if (!"TRIDA".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'TRIDA'");
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Třída", "á");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/ConceptCreateModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/ConceptCreateModel.java
@@ -45,6 +45,4 @@ public abstract class ConceptCreateModel {
     protected Boolean inTezaurus;
 
     public abstract ConceptType getConceptTypeEnum();
-
-    protected abstract void validateSpecificFields();
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/ConceptEditModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/ConceptEditModel.java
@@ -39,6 +39,4 @@ public abstract class ConceptEditModel {
     protected Boolean inTezaurus;
 
     public abstract ConceptType getConceptTypeEnum();
-
-    protected abstract void validateSpecificFields();
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/PropertyConceptEditModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/PropertyConceptEditModel.java
@@ -1,17 +1,13 @@
 package com.dia.ismdtoolbackend.models.concept;
 
 import com.dia.ismdtoolbackend.enums.ConceptType;
-import com.dia.utility.DataTypeConverter;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@Slf4j
 public class PropertyConceptEditModel extends ConceptEditModel {
     private String dataType;
     private String domain;
@@ -29,25 +25,5 @@ public class PropertyConceptEditModel extends ConceptEditModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.VLASTNOST;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (!"VLASTNOST".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'VLASTNOST'");
-        }
-
-        if ((domain == null || domain.trim().isEmpty()) &&
-                (dataType == null || dataType.trim().isEmpty())) {
-            log.warn("Property '{}' without domain or dataType", nameModel);
-        }
-
-        if (dataType != null && !dataType.trim().isEmpty()) {
-            DataTypeConverter.isValidXSDType(dataType.trim());
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Vlastnost", "á");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/PropertyConceptModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/PropertyConceptModel.java
@@ -1,17 +1,13 @@
 package com.dia.ismdtoolbackend.models.concept;
 
 import com.dia.ismdtoolbackend.enums.ConceptType;
-import com.dia.utility.DataTypeConverter;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@Slf4j
 public class PropertyConceptModel extends ConceptCreateModel {
     private String dataType;
     private String domain;
@@ -29,25 +25,5 @@ public class PropertyConceptModel extends ConceptCreateModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.VLASTNOST;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (!"VLASTNOST".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'VLASTNOST'");
-        }
-
-        if ((domain == null || domain.trim().isEmpty()) &&
-                (dataType == null || dataType.trim().isEmpty())) {
-            log.warn("Property '{}' without domain or dataType", nameModel);
-        }
-
-        if (dataType != null && !dataType.trim().isEmpty()) {
-            DataTypeConverter.isValidXSDType(dataType.trim());
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Vlastnost", "á");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/RelationshipConceptEditModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/RelationshipConceptEditModel.java
@@ -3,14 +3,11 @@ package com.dia.ismdtoolbackend.models.concept;
 import com.dia.ismdtoolbackend.enums.ConceptType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@Slf4j
 public class RelationshipConceptEditModel extends ConceptEditModel {
     private String domain;
     private String range;
@@ -28,21 +25,5 @@ public class RelationshipConceptEditModel extends ConceptEditModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.VZTAH;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (!"VZTAH".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'VZTAH'");
-        }
-
-        if ((domain == null || domain.trim().isEmpty()) ||
-                (range == null || range.trim().isEmpty())) {
-            log.warn("Relationship '{}' without domain/range", nameModel);
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Vztah", "ý");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/models/concept/RelationshipConceptModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/concept/RelationshipConceptModel.java
@@ -3,14 +3,11 @@ package com.dia.ismdtoolbackend.models.concept;
 import com.dia.ismdtoolbackend.enums.ConceptType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.jena.ontology.OntologyException;
 
 import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@Slf4j
 public class RelationshipConceptModel extends ConceptCreateModel {
     private String domain;
     private String range;
@@ -28,21 +25,5 @@ public class RelationshipConceptModel extends ConceptCreateModel {
     @Override
     public ConceptType getConceptTypeEnum() {
         return ConceptType.VZTAH;
-    }
-
-    @Override
-    protected void validateSpecificFields() {
-        if (!"VZTAH".equalsIgnoreCase(conceptType)) {
-            throw new OntologyException("ConceptType musí být 'VZTAH'");
-        }
-
-        if ((domain == null || domain.trim().isEmpty()) ||
-                (range == null || range.trim().isEmpty())) {
-            log.warn("Relationship '{}' without domain/range", nameModel);
-        }
-
-        ConceptValidationUtil.validatePrivacyPublicConflict(privacyProvisions, isPublic, "Vztah", "ý");
-        ConceptValidationUtil.validateCodeListDataset(codeListDataset);
-        ConceptValidationUtil.validateGovernanceFields(sharingMethod, acquisitionMethod, contentType);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/ConceptServiceImpl.java
@@ -5,6 +5,7 @@ import com.dia.ismdtoolbackend.controller.dto.GetConceptDto;
 import com.dia.ismdtoolbackend.entity.CommentEntity;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptCreateModel;
 import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
@@ -308,6 +309,12 @@ public class ConceptServiceImpl implements ConceptService {
             log.info("Edit completed: {} changes, IRI changed: {}, new IRI: {}",
                     editResult.changesCount, editResult.iriChanged, editResult.newConceptIRI);
             return editResult;
+        } catch (ConceptValidationException e) {
+            // Invalid user input → propagate unwrapped so it surfaces as HTTP 400
+            // (GlobalExceptionHandler maps ConceptValidationException to BAD_REQUEST).
+            // Wrapping in OntologyException here would turn it into a 500.
+            log.warn("Concept edit rejected — invalid input: {}", e.getMessage());
+            throw e;
         } catch (Exception e) {
             log.error("Failed to edit concept", e);
             throw new OntologyException("Nepodařilo se upravit pojem: " + e.getMessage());

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ClassConceptTypeEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ClassConceptTypeEditor.java
@@ -1,0 +1,39 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+
+import java.util.Set;
+
+/** Type-specific edit sequence for class concepts (TRIDA). */
+class ClassConceptTypeEditor implements ConceptTypeEditor {
+
+    private final ConceptFieldUpdaters fields;
+
+    ClassConceptTypeEditor(ConceptFieldUpdaters fields) {
+        this.fields = fields;
+    }
+
+    @Override
+    public void edit(ConceptEditModel editModel, ConceptEditor.EditContext context,
+                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        ClassConceptEditModel m = (ClassConceptEditModel) editModel;
+
+        fields.editCommonFields(m, context, model, toRemove, toAdd);
+
+        fields.updateClassTypeProperty(context.newConcept, m.getType(), context.oldConcept, model, toRemove, toAdd);
+        fields.updatePrivacyProvisionsList(context.newConcept, m.getPrivacyProvisions(), context.oldConcept, model, toRemove, toAdd);
+        fields.updateBroaderConceptList(context.newConcept, m.getBroaderConcept(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateSharedGovernanceMetadata(context.newConcept, m.getIsInPPDF(), m.getAgendaCode(),
+                m.getAgendaSystemCode(), m.getSharingMethod(), m.getAcquisitionMethod(),
+                m.getContentType(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateDataClassification(context.newConcept, m.getIsPublic(), m.getPrivacyProvisions(),
+                context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateCodeListDataset(context.newConcept, m.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditValidator.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditValidator.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.utility.editor;
 
 import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.ConceptValidationUtil;
 import com.dia.ismdtoolbackend.models.concept.DigitalObjectModel;
 import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
 import com.dia.ismdtoolbackend.models.concept.PropertyConceptEditModel;
@@ -63,7 +64,63 @@ class ConceptEditValidator {
         // property, relationship) — they can each be public/non-public.
         validateEliList("privacyProvisions", privacyProvisionsOf(editModel), problems);
 
+        // Domain rules previously declared on the *EditModel classes
+        // (validateSpecificFields) but never invoked in the live flow. Folded in
+        // here so they actually run on edit. The models stay pure data classes;
+        // ConceptValidationUtil remains the single source of truth for the rules.
+        validateDomainRules(editModel, problems);
+
         return problems;
+    }
+
+    /** Per-type bundle of the governance/privacy fields the domain rules check. */
+    private record GovernanceBundle(List<String> privacyProvisions, Boolean isPublic,
+                                    String codeListDataset, List<String> sharingMethod,
+                                    String acquisitionMethod, String contentType,
+                                    String entityName, String genderSuffix) {}
+
+    private GovernanceBundle governanceOf(ConceptEditModel editModel) {
+        if (editModel instanceof ClassConceptEditModel c) {
+            return new GovernanceBundle(c.getPrivacyProvisions(), c.getIsPublic(), c.getCodeListDataset(),
+                    c.getSharingMethod(), c.getAcquisitionMethod(), c.getContentType(), "Třída", "á");
+        }
+        if (editModel instanceof PropertyConceptEditModel p) {
+            return new GovernanceBundle(p.getPrivacyProvisions(), p.getIsPublic(), p.getCodeListDataset(),
+                    p.getSharingMethod(), p.getAcquisitionMethod(), p.getContentType(), "Vlastnost", "á");
+        }
+        if (editModel instanceof RelationshipConceptEditModel r) {
+            return new GovernanceBundle(r.getPrivacyProvisions(), r.getIsPublic(), r.getCodeListDataset(),
+                    r.getSharingMethod(), r.getAcquisitionMethod(), r.getContentType(), "Vztah", "ý");
+        }
+        return null;
+    }
+
+    /**
+     * Runs the {@link ConceptValidationUtil} domain rules (privacy/public conflict,
+     * NKOD code-list URL, governance-value allowlist) and folds any violation into
+     * the collected problems as an {@link InvalidInput}, so the whole edit is
+     * rejected atomically with one 400 rather than throwing per-rule.
+     */
+    private void validateDomainRules(ConceptEditModel editModel, List<InvalidInput> problems) {
+        GovernanceBundle g = governanceOf(editModel);
+        if (g == null) return;
+
+        record Check(String field, Runnable rule) {}
+        List<Check> checks = List.of(
+                new Check("isPublic", () -> ConceptValidationUtil.validatePrivacyPublicConflict(
+                        g.privacyProvisions(), g.isPublic(), g.entityName(), g.genderSuffix())),
+                new Check("codeListDataset", () -> ConceptValidationUtil.validateCodeListDataset(g.codeListDataset())),
+                new Check("governance", () -> ConceptValidationUtil.validateGovernanceFields(
+                        g.sharingMethod(), g.acquisitionMethod(), g.contentType()))
+        );
+
+        for (Check check : checks) {
+            try {
+                check.rule().run();
+            } catch (RuntimeException e) {
+                problems.add(new InvalidInput(check.field(), null, e.getMessage()));
+            }
+        }
     }
 
     private List<String> privacyProvisionsOf(ConceptEditModel editModel) {

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditValidator.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditValidator.java
@@ -1,0 +1,135 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.DigitalObjectModel;
+import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.PropertyConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.RelationshipConceptEditModel;
+import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
+import com.dia.utility.UtilityMethods;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pre-flight validation for a concept edit. Runs BEFORE any model mutation and
+ * collects every offending input so the whole edit can be rejected atomically
+ * (HTTP 400) with one message listing all problems — rather than silently
+ * dropping invalid values.
+ *
+ * <p>The validity predicates mirror exactly the checks the field updaters apply
+ * ({@link SparqlIriValidator#isEsbirkaEliIri}, {@link UtilityMethods#isValidAgendaValue},
+ * {@link UtilityMethods#isValidAISValue}, {@link UtilityMethods#isValidUrl},
+ * {@link UtilityMethods#isValidIRI}). A {@code null} field means "not provided"
+ * and a blank string / empty list means "clear" — neither is an error. Only a
+ * genuinely malformed value is reported.
+ *
+ * <p>Plain class (not a Spring bean) for the same reason as the other editor
+ * collaborators: it must not be replaced by a Mockito mock under
+ * {@code @InjectMocks ConceptEditor}.
+ */
+class ConceptEditValidator {
+
+    /** A single rejected input: which field, the offending value, and why. */
+    record InvalidInput(String field, String value, String reason) {
+        @Override
+        public String toString() {
+            return field + "='" + value + "' (" + reason + ")";
+        }
+    }
+
+    private static final String REASON_ELI = "není kanonické e-Sbírka ELI IRI";
+    private static final String REASON_AGENDA = "neplatný kód agendy";
+    private static final String REASON_AIS = "neplatný kód AIS";
+    private static final String REASON_URL = "URL je prázdné nebo neplatné";
+    private static final String REASON_IRI = "neplatné IRI";
+
+    List<InvalidInput> validate(ConceptEditModel editModel) {
+        List<InvalidInput> problems = new ArrayList<>();
+
+        // Common fields (all concept types)
+        validateEliList("definingLegalSource", editModel.getDefiningLegalSource(), problems);
+        validateEliList("relatedLegalSource", editModel.getRelatedLegalSource(), problems);
+        validateNonLegalList("definingNonLegalSource", editModel.getDefiningNonLegalSource(), problems);
+        validateNonLegalList("relatedNonLegalSource", editModel.getRelatedNonLegalSource(), problems);
+        validateExactMatch(editModel.getExactMatch(), problems);
+
+        // Governance metadata (agendaCode / agendaSystemCode live on the concrete
+        // *EditModel subtypes, not the abstract base — resolve per type).
+        validateAgenda(agendaCodeOf(editModel), problems);
+        validateAis(agendaSystemCodeOf(editModel), problems);
+
+        // Privacy provisions are carried by all three concept types (class,
+        // property, relationship) — they can each be public/non-public.
+        validateEliList("privacyProvisions", privacyProvisionsOf(editModel), problems);
+
+        return problems;
+    }
+
+    private List<String> privacyProvisionsOf(ConceptEditModel editModel) {
+        if (editModel instanceof ClassConceptEditModel c) return c.getPrivacyProvisions();
+        if (editModel instanceof PropertyConceptEditModel p) return p.getPrivacyProvisions();
+        if (editModel instanceof RelationshipConceptEditModel r) return r.getPrivacyProvisions();
+        return null;
+    }
+
+    private String agendaCodeOf(ConceptEditModel editModel) {
+        if (editModel instanceof ClassConceptEditModel c) return c.getAgendaCode();
+        if (editModel instanceof PropertyConceptEditModel p) return p.getAgendaCode();
+        if (editModel instanceof RelationshipConceptEditModel r) return r.getAgendaCode();
+        return null;
+    }
+
+    private String agendaSystemCodeOf(ConceptEditModel editModel) {
+        if (editModel instanceof ClassConceptEditModel c) return c.getAgendaSystemCode();
+        if (editModel instanceof PropertyConceptEditModel p) return p.getAgendaSystemCode();
+        if (editModel instanceof RelationshipConceptEditModel r) return r.getAgendaSystemCode();
+        return null;
+    }
+
+    private void validateEliList(String field, List<String> values, List<InvalidInput> problems) {
+        if (values == null) return;
+        for (String v : values) {
+            if (v == null || v.trim().isEmpty()) continue;   // blank entry = ignored, not invalid
+            String trimmed = v.trim();
+            if (!SparqlIriValidator.isEsbirkaEliIri(trimmed)) {
+                problems.add(new InvalidInput(field, trimmed, REASON_ELI));
+            }
+        }
+    }
+
+    private void validateNonLegalList(String field, List<DigitalObjectModel> values, List<InvalidInput> problems) {
+        if (values == null) return;
+        for (DigitalObjectModel d : values) {
+            String url = d == null ? null : d.getUrl();
+            if (url == null || url.trim().isEmpty() || !UtilityMethods.isValidUrl(url.trim())) {
+                problems.add(new InvalidInput(field, url, REASON_URL));
+            }
+        }
+    }
+
+    private void validateExactMatch(List<String> values, List<InvalidInput> problems) {
+        if (values == null) return;
+        for (String v : values) {
+            if (v == null || v.trim().isEmpty()) continue;   // blank entry = ignored
+            String trimmed = v.trim();
+            if (!UtilityMethods.isValidIRI(trimmed)) {
+                problems.add(new InvalidInput("exactMatch", trimmed, REASON_IRI));
+            }
+        }
+    }
+
+    private void validateAgenda(String agendaCode, List<InvalidInput> problems) {
+        if (agendaCode == null || agendaCode.trim().isEmpty()) return;   // blank = clear
+        if (!UtilityMethods.isValidAgendaValue(agendaCode)) {
+            problems.add(new InvalidInput("agendaCode", agendaCode, REASON_AGENDA));
+        }
+    }
+
+    private void validateAis(String aisCode, List<InvalidInput> problems) {
+        if (aisCode == null || aisCode.trim().isEmpty()) return;   // blank = clear
+        if (!UtilityMethods.isValidAISValue(aisCode)) {
+            problems.add(new InvalidInput("agendaSystemCode", aisCode, REASON_AIS));
+        }
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditor.java
@@ -1,25 +1,18 @@
 package com.dia.ismdtoolbackend.utility.editor;
 
+import com.dia.ismdtoolbackend.enums.ConceptType;
 import com.dia.ismdtoolbackend.exception.ConceptValidationException;
-import com.dia.ismdtoolbackend.models.DescriptionModel;
-import com.dia.ismdtoolbackend.models.NameModel;
 import com.dia.ismdtoolbackend.models.concept.*;
-import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
-import com.dia.utility.DataTypeConverter;
-import com.dia.utility.URIGenerator;
-import com.dia.utility.UtilityMethods;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.ontology.OntologyException;
 import org.apache.jena.rdf.model.*;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
-import static com.dia.constants.VocabularyConstants.*;
 import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
 
 @Component
@@ -27,13 +20,16 @@ import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
 @Slf4j
 public class ConceptEditor {
 
-    private static final String TYPE = "type";
-    private static final String AGENDA_CODE = "agendaCode";
-    private static final String AIS = "agendaSystemCode";
-    private static final String IS_PUBLIC = "isPublic";
-    private static final String IN_TEZAURUS = "inTezaurus";
+    private final ConceptIriFactory iriFactory = new ConceptIriFactory();
 
-    private final URIGenerator uriGenerator = new URIGenerator();
+    private final ConceptEditValidator validator = new ConceptEditValidator();
+
+    private final ConceptFieldUpdaters fieldUpdaters = new ConceptFieldUpdaters(iriFactory);
+
+    private final Map<ConceptType, ConceptTypeEditor> typeEditors = new EnumMap<>(Map.of(
+            ConceptType.TRIDA, new ClassConceptTypeEditor(fieldUpdaters),
+            ConceptType.VLASTNOST, new PropertyConceptTypeEditor(fieldUpdaters),
+            ConceptType.VZTAH, new RelationshipConceptTypeEditor(fieldUpdaters)));
 
     public EditResult editConcept(String conceptIri, ConceptEditModel editModel, Model model, String graphName) {
         Resource existingConcept = model.getResource(conceptIri);
@@ -42,8 +38,18 @@ public class ConceptEditor {
             throw new IllegalArgumentException("Concept with IRI " + conceptIri + " not found in the model");
         }
 
-        String effectiveNamespace = determineEffectiveNamespace(graphName);
-        uriGenerator.setEffectiveNamespace(effectiveNamespace);
+        // Pre-flight validation: reject the whole edit (HTTP 400) before any model
+        // mutation if any supplied value is invalid. Atomic — nothing is written on
+        // rejection. Mirrors the validity checks the field updaters apply.
+        List<ConceptEditValidator.InvalidInput> invalid = validator.validate(editModel);
+        if (!invalid.isEmpty()) {
+            String detail = invalid.stream()
+                    .map(ConceptEditValidator.InvalidInput::toString)
+                    .collect(Collectors.joining("; "));
+            throw new ConceptValidationException("Neplatné hodnoty v úpravě pojmu: " + detail);
+        }
+
+        iriFactory.useEffectiveNamespace(graphName);
 
         String newName = getNameForUriGeneration(editModel.getNameModel());
         String oldName = getNameForUriGeneration(existingConcept);
@@ -51,7 +57,7 @@ public class ConceptEditor {
 
         String newConceptIRI = conceptIri;
         if (nameChanged) {
-            newConceptIRI = uriGenerator.generateConceptURI(newName, editModel.getIdentifier());
+            newConceptIRI = iriFactory.generateConceptURI(newName, editModel.getIdentifier());
             log.info("Name changed from '{}' to '{}', updating IRI from {} to {}",
                     oldName, newName, conceptIri, newConceptIRI);
 
@@ -80,14 +86,12 @@ public class ConceptEditor {
                 renameConceptIRI(model, conceptIri, newConceptIRI, statementsToRemove, statementsToAdd);
             }
 
-            switch (editModel.getConceptTypeEnum()) {
-                case TRIDA -> editClassConcept((ClassConceptEditModel) editModel, context,
-                        model, statementsToRemove, statementsToAdd);
-                case VLASTNOST -> editPropertyConcept((PropertyConceptEditModel) editModel, context,
-                        model, statementsToRemove, statementsToAdd);
-                case VZTAH -> editRelationshipConcept((RelationshipConceptEditModel) editModel, context,
-                        model, statementsToRemove, statementsToAdd);
+            ConceptTypeEditor typeEditor = typeEditors.get(editModel.getConceptTypeEnum());
+            if (typeEditor == null) {
+                throw new IllegalArgumentException(
+                        "Unsupported concept type: " + editModel.getConceptTypeEnum());
             }
+            typeEditor.edit(editModel, context, model, statementsToRemove, statementsToAdd);
 
             model.remove(statementsToRemove.toArray(new Statement[0]));
             model.add(statementsToAdd.toArray(new Statement[0]));
@@ -116,650 +120,6 @@ public class ConceptEditor {
                 }
             }
         }
-    }
-
-    private void editClassConcept(ClassConceptEditModel editModel, EditContext context,
-                                   Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        editCommonFields(editModel, context, model, toRemove, toAdd);
-
-        updateStringProperty(context.newConcept, TYPE, editModel.getType(), context.oldConcept, model, toRemove, toAdd);
-        updatePrivacyProvisionsList(context.newConcept, editModel.getPrivacyProvisions(), context.oldConcept, model, toRemove, toAdd);
-        updateBroaderConceptList(context.newConcept, editModel.getBroaderConcept(), context.oldConcept, model, toRemove, toAdd);
-
-        updateSharedGovernanceMetadata(context.newConcept, editModel.getIsInPPDF(), editModel.getAgendaCode(),
-                editModel.getAgendaSystemCode(), editModel.getSharingMethod(), editModel.getAcquisitionMethod(),
-                editModel.getContentType(), context.oldConcept, model, toRemove, toAdd);
-
-        updateDataClassification(context.newConcept, editModel.getIsPublic(), editModel.getPrivacyProvisions(),
-                                context.oldConcept, model, toRemove, toAdd);
-
-        updateCodeListDataset(context.newConcept, editModel.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
-    }
-
-    private void editPropertyConcept(PropertyConceptEditModel editModel, EditContext context,
-                                      Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        editCommonFields(editModel, context, model, toRemove, toAdd);
-
-        updateDomainRange(context.newConcept, RDFS.domain, editModel.getDomain(), context.oldConcept, model, toRemove, toAdd);
-        updateDataTypeRange(context.newConcept, editModel.getDataType(), context.oldConcept, model, toRemove, toAdd);
-        updateSuperPropertyList(context.newConcept, editModel.getSuperProperty(), context.oldConcept, model, toRemove, toAdd);
-
-        updateSharedGovernanceMetadata(context.newConcept, editModel.getIsInPPDF(), editModel.getAgendaCode(),
-                editModel.getAgendaSystemCode(), editModel.getSharingMethod(), editModel.getAcquisitionMethod(),
-                editModel.getContentType(), context.oldConcept, model, toRemove, toAdd);
-
-        updateDataClassification(context.newConcept, editModel.getIsPublic(), editModel.getPrivacyProvisions(),
-                                context.oldConcept, model, toRemove, toAdd);
-
-        updateCodeListDataset(context.newConcept, editModel.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
-    }
-
-    private void editRelationshipConcept(RelationshipConceptEditModel editModel, EditContext context,
-                                          Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        editCommonFields(editModel, context, model, toRemove, toAdd);
-
-        updateDomainRange(context.newConcept, RDFS.domain, editModel.getDomain(), context.oldConcept, model, toRemove, toAdd);
-        updateDomainRange(context.newConcept, RDFS.range, editModel.getRange(), context.oldConcept, model, toRemove, toAdd);
-        updateSuperPropertyList(context.newConcept, editModel.getSuperRelation(), context.oldConcept, model, toRemove, toAdd);
-
-        updateSharedGovernanceMetadata(context.newConcept, editModel.getIsInPPDF(), editModel.getAgendaCode(),
-                editModel.getAgendaSystemCode(), editModel.getSharingMethod(), editModel.getAcquisitionMethod(),
-                editModel.getContentType(), context.oldConcept, model, toRemove, toAdd);
-
-        updateDataClassification(context.newConcept, editModel.getIsPublic(), editModel.getPrivacyProvisions(),
-                                context.oldConcept, model, toRemove, toAdd);
-
-        updateCodeListDataset(context.newConcept, editModel.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
-    }
-
-    private void editCommonFields(ConceptEditModel editModel, EditContext context,
-                                   Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        updateNameModel(context.newConcept, editModel.getNameModel(), context.oldConcept, model, toRemove, toAdd);
-        updateDescriptionModel(context.newConcept, editModel.getDescriptionModel(), context.oldConcept, model, toRemove, toAdd);
-        updateDefinitionModel(context.newConcept, editModel.getDefinitionModel(), context.oldConcept, model, toRemove, toAdd);
-        updateAltNameModel(context.newConcept, editModel.getAltNameModel(), context.oldConcept, model, toRemove, toAdd);
-        updateLegalSources(context.newConcept, editModel, context.oldConcept, model, toRemove, toAdd);
-        updateNonLegalSources(context.newConcept, editModel, context.oldConcept, model, toRemove, toAdd);
-        updateExactMatch(context.newConcept, editModel.getExactMatch(), context.oldConcept, model, toRemove, toAdd);
-        updateBooleanProperty(context.newConcept, IN_TEZAURUS, editModel.getInTezaurus(), context.oldConcept, model, toRemove, toAdd);
-    }
-
-    private void updateNameModel(Resource newConcept, NameModel nameModel, Resource oldConcept,
-                                 Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (nameModel == null || nameModel.getName() == null) return;
-
-        Map<String, String> existingNames = getAllPropertyValuesWithLanguage(oldConcept, SKOS.prefLabel);
-
-        Map<String, String> newNames = nameModel.getName();
-
-        Map<String, String> mergedNames = new HashMap<>(existingNames);
-        for (Map.Entry<String, String> entry : newNames.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
-                mergedNames.remove(entry.getKey());
-            } else {
-                mergedNames.put(entry.getKey(), entry.getValue().trim());
-            }
-        }
-
-        if (!existingNames.equals(mergedNames)) {
-            removeAllByPredicate(newConcept, SKOS.prefLabel, toRemove, toAdd);
-            for (Map.Entry<String, String> entry : mergedNames.entrySet()) {
-                String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                toAdd.add(model.createStatement(newConcept, SKOS.prefLabel,
-                        model.createLiteral(entry.getValue(), languageTag)));
-            }
-        }
-    }
-
-    private void updateDescriptionModel(Resource newConcept, DescriptionModel descModel, Resource oldConcept,
-                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (descModel == null) return;
-
-        Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
-
-        Map<String, String> existingDescriptions = getAllPropertyValuesWithLanguage(oldConcept, descProperty);
-
-        Map<String, String> newDescriptions = descModel.getDescription();
-
-        if (newDescriptions == null || newDescriptions.isEmpty()) {
-            if (!existingDescriptions.isEmpty()) {
-                removeAllByPredicate(newConcept, descProperty, toRemove, toAdd);
-            }
-            return;
-        }
-
-        Map<String, String> mergedDescriptions = new HashMap<>(existingDescriptions);
-        for (Map.Entry<String, String> entry : newDescriptions.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
-                mergedDescriptions.remove(entry.getKey());
-            } else {
-                mergedDescriptions.put(entry.getKey(), entry.getValue().trim());
-            }
-        }
-
-        if (!existingDescriptions.equals(mergedDescriptions)) {
-            removeAllByPredicate(newConcept, descProperty, toRemove, toAdd);
-            for (Map.Entry<String, String> entry : mergedDescriptions.entrySet()) {
-                String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                toAdd.add(model.createStatement(newConcept, descProperty,
-                        model.createLiteral(entry.getValue(), languageTag)));
-            }
-        }
-    }
-
-    private void updateDefinitionModel(Resource newConcept, DefinitionModel defModel, Resource oldConcept,
-                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (defModel == null) return;
-
-        Map<String, String> existingDefinitions = getAllPropertyValuesWithLanguage(oldConcept, SKOS.definition);
-
-        Map<String, String> newDefinitions = defModel.getDefinition();
-
-        if (newDefinitions == null || newDefinitions.isEmpty()) {
-            if (!existingDefinitions.isEmpty()) {
-                removeAllByPredicate(newConcept, SKOS.definition, toRemove, toAdd);
-            }
-            return;
-        }
-
-        Map<String, String> mergedDefinitions = new HashMap<>(existingDefinitions);
-        for (Map.Entry<String, String> entry : newDefinitions.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
-                mergedDefinitions.remove(entry.getKey());
-            } else {
-                mergedDefinitions.put(entry.getKey(), entry.getValue().trim());
-            }
-        }
-
-        if (!existingDefinitions.equals(mergedDefinitions)) {
-            removeAllByPredicate(newConcept, SKOS.definition, toRemove, toAdd);
-            for (Map.Entry<String, String> entry : mergedDefinitions.entrySet()) {
-                String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                toAdd.add(model.createStatement(newConcept, SKOS.definition,
-                        model.createLiteral(entry.getValue(), languageTag)));
-            }
-        }
-    }
-
-    private void updateAltNameModel(Resource newConcept, AltNameModel altNameModel, Resource oldConcept,
-                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (altNameModel == null) return;
-
-        Map<String, String> oldAltNamesByLang = getAllPropertyValuesWithLanguage(oldConcept, SKOS.altLabel);
-
-        Map<String, String> newAltNamesByLang = new HashMap<>();
-        if (altNameModel.getAltName() != null && !altNameModel.getAltName().isEmpty()) {
-            for (Map.Entry<String, String> entry : altNameModel.getAltName().entrySet()) {
-                if (entry.getValue() != null && !entry.getValue().trim().isEmpty()) {
-                    String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                    newAltNamesByLang.put(languageTag, entry.getValue().trim());
-                }
-            }
-        }
-
-        if (!oldAltNamesByLang.equals(newAltNamesByLang)) {
-            removeAllByPredicate(newConcept, SKOS.altLabel, toRemove, toAdd);
-            for (Map.Entry<String, String> entry : newAltNamesByLang.entrySet()) {
-                toAdd.add(model.createStatement(newConcept, SKOS.altLabel,
-                        model.createLiteral(entry.getValue(), entry.getKey())));
-            }
-        }
-    }
-
-    private void updateLegalSources(Resource newConcept, ConceptEditModel editModel, Resource oldConcept,
-                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        Property definingProp = model.createProperty(OFN_NAMESPACE + DEFINUJICI_USTANOVENI);
-        Property relatedProp = model.createProperty(OFN_NAMESPACE + SOUVISEJICI_USTANOVENI);
-
-        updateLegalSourceList(newConcept, definingProp, editModel.getDefiningLegalSource(),
-                oldConcept, model, toRemove, toAdd);
-        updateLegalSourceList(newConcept, relatedProp, editModel.getRelatedLegalSource(),
-                oldConcept, model, toRemove, toAdd);
-    }
-
-    private void updateNonLegalSources(Resource newConcept, ConceptEditModel editModel, Resource oldConcept,
-                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        Property definingProp = model.createProperty(uriGenerator.getEffectiveNamespace() + DEFINUJICI_NELEGISLATIVNI_ZDROJ);
-        Property relatedProp = model.createProperty(uriGenerator.getEffectiveNamespace() + SOUVISEJICI_NELEGISLATIVNI_ZDROJ);
-
-        updateNonLegalSourceList(newConcept, definingProp, editModel.getDefiningNonLegalSource(),
-                oldConcept, model, toRemove, toAdd);
-        updateNonLegalSourceList(newConcept, relatedProp, editModel.getRelatedNonLegalSource(),
-                oldConcept, model, toRemove, toAdd);
-    }
-
-    private void updateExactMatch(Resource newConcept, List<String> exactMatchList, Resource oldConcept,
-                                  Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (exactMatchList == null) return;
-
-        Property exactMatchProp = model.createProperty("http://www.w3.org/2004/02/skos/core#exactMatch");
-        Set<String> oldMatches = getResourceURIs(oldConcept, exactMatchProp);
-        Set<String> newMatches = new HashSet<>();
-
-        for (String iri : exactMatchList) {
-            if (iri != null && !iri.trim().isEmpty()) {
-                newMatches.add(iri.trim());
-            }
-        }
-
-        if (exactMatchList.isEmpty() || newMatches.isEmpty()) {
-            if (!oldMatches.isEmpty()) {
-                removeAllByPredicate(newConcept, exactMatchProp, toRemove, toAdd);
-            }
-        } else if (!oldMatches.equals(newMatches)) {
-            removeAllByPredicate(newConcept, exactMatchProp, toRemove, toAdd);
-            for (String match : newMatches) {
-                if (UtilityMethods.isValidIRI(match)) {
-                    toAdd.add(model.createStatement(newConcept, exactMatchProp, model.createResource(match)));
-                }
-            }
-        }
-    }
-
-    private void updateStringProperty(Resource newConcept, String propertyName, String newValue,
-                                       Resource oldConcept, Model model, Set<Statement> toRemove,
-                                       Set<Statement> toAdd) {
-        switch (propertyName) {
-            case TYPE -> updateClassType(newConcept, newValue, oldConcept, model, toRemove, toAdd);
-            case AGENDA_CODE -> updateAgenda(newConcept, newValue, oldConcept, model, toRemove, toAdd);
-            case AIS -> updateAIS(newConcept, newValue, oldConcept, model, toRemove, toAdd);
-            default -> log.warn("Unknown string property: {}", propertyName);
-        }
-    }
-
-    private void updateClassType(Resource newConcept, String newType, Resource oldConcept,
-                                  Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (newType == null) return;
-
-        Resource tspType = model.getResource(OFN_NAMESPACE + TSP);
-        Resource topType = model.getResource(OFN_NAMESPACE + TOP);
-
-        boolean oldHasTSP = oldConcept.hasProperty(RDF.type, tspType);
-        boolean oldHasTOP = oldConcept.hasProperty(RDF.type, topType);
-
-        boolean newHasTSP = newType.toLowerCase().contains("subjekt");
-        boolean newHasTOP = newType.toLowerCase().contains("objekt");
-
-        if (oldHasTSP && !newHasTSP) {
-            removeTypeStatement(newConcept, oldConcept, tspType, model, toRemove, toAdd);
-        }
-        if (oldHasTOP && !newHasTOP) {
-            removeTypeStatement(newConcept, oldConcept, topType, model, toRemove, toAdd);
-        }
-        if (!oldHasTSP && newHasTSP) {
-            toAdd.add(model.createStatement(newConcept, RDF.type, tspType));
-        }
-        if (!oldHasTOP && newHasTOP) {
-            toAdd.add(model.createStatement(newConcept, RDF.type, topType));
-        }
-    }
-
-    /**
-     * Removes a specific {@code rdf:type} value from the concept. Stages removal
-     * of the statement under the old IRI (still present in the model) AND strips
-     * any copy of it staged under the new IRI by {@code renameConceptIRI} — so a
-     * type that's being dropped does not survive a rename via the copy-all pass.
-     */
-    private void removeTypeStatement(Resource newConcept, Resource oldConcept, Resource typeValue,
-                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        toRemove.add(model.createStatement(oldConcept, RDF.type, typeValue));
-        toAdd.removeIf(stmt ->
-                stmt.getSubject().equals(newConcept) &&
-                        stmt.getPredicate().equals(RDF.type) &&
-                        stmt.getObject().equals(typeValue));
-    }
-
-    private void updateAgenda(Resource newConcept, String agendaCode, Resource oldConcept,
-                              Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (agendaCode == null) return;
-
-        Property agendaProperty = model.createProperty(DEFAULT_NS + AGENDOVY_104 + AGENDA_LONG);
-
-        if (agendaCode.trim().isEmpty()) {
-            removeAllByPredicate(oldConcept, agendaProperty, toRemove, toAdd);
-            return;
-        }
-
-        removeAllByPredicate(newConcept, agendaProperty, toRemove, toAdd);
-
-        if (UtilityMethods.isValidAgendaValue(agendaCode)) {
-            String transformed = UtilityMethods.transformAgendaValue(agendaCode);
-            if (DataTypeConverter.isUri(transformed)) {
-                toAdd.add(model.createStatement(newConcept, agendaProperty, model.createResource(transformed)));
-            } else {
-                Literal typedLiteral = DataTypeConverter.createTypedLiteral(transformed, model, null, AGENDA_LONG);
-                toAdd.add(model.createStatement(newConcept, agendaProperty, typedLiteral));
-            }
-        }
-    }
-
-    private void updateAIS(Resource newConcept, String aisCode, Resource oldConcept,
-                           Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (aisCode == null) return;
-
-        Property aisProperty = model.createProperty(DEFAULT_NS + AGENDOVY_104 + UDAJE_AIS);
-
-        if (aisCode.trim().isEmpty()) {
-            removeAllByPredicate(oldConcept, aisProperty, toRemove, toAdd);
-            return;
-        }
-
-        removeAllByPredicate(newConcept, aisProperty, toRemove, toAdd);
-
-        if (UtilityMethods.isValidAISValue(aisCode)) {
-            String transformed = UtilityMethods.transformAISValue(aisCode);
-            if (DataTypeConverter.isUri(transformed)) {
-                toAdd.add(model.createStatement(newConcept, aisProperty, model.createResource(transformed)));
-            } else {
-                Literal typedLiteral = DataTypeConverter.createTypedLiteral(transformed, model, null, UDAJE_AIS);
-                toAdd.add(model.createStatement(newConcept, aisProperty, typedLiteral));
-            }
-        }
-    }
-
-    private void updatePrivacyProvisionsList(Resource newConcept, List<String> privacyProvisions,
-                                             Resource oldConcept, Model model, Set<Statement> toRemove,
-                                             Set<Statement> toAdd) {
-        if (privacyProvisions == null) return;
-
-        Property provisionProperty = model.createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
-        Set<String> oldProvisions = getResourceURIs(oldConcept, provisionProperty);
-        Set<String> newProvisions = new HashSet<>();
-
-        for (String provision : privacyProvisions) {
-            if (provision == null || provision.trim().isEmpty()) continue;
-            String trimmed = provision.trim();
-            if (SparqlIriValidator.isEsbirkaEliIri(trimmed)) {
-                newProvisions.add(trimmed);
-            } else {
-                log.warn("Skipping privacy provision — not a canonical e-Sbírka ELI IRI: {}", trimmed);
-            }
-        }
-
-        if (privacyProvisions.isEmpty() || newProvisions.isEmpty()) {
-            if (!oldProvisions.isEmpty()) {
-                removeAllByPredicate(newConcept, provisionProperty, toRemove, toAdd);
-            }
-        } else if (!oldProvisions.equals(newProvisions)) {
-            removeAllByPredicate(newConcept, provisionProperty, toRemove, toAdd);
-            for (String provisionURI : newProvisions) {
-                toAdd.add(model.createStatement(newConcept, provisionProperty, model.createResource(provisionURI)));
-            }
-        }
-    }
-
-    private void updateGovernanceProperty(Resource newConcept, String newValue, String propertyName,
-                                           Resource oldConcept, Model model, Set<Statement> toRemove,
-                                           Set<Statement> toAdd) {
-        if (newValue == null) return;
-
-        Property property = model.createProperty(OFN_NAMESPACE + propertyName);
-        String oldIRI = getResourceURI(oldConcept, property);
-
-        if (newValue.trim().isEmpty()) {
-            if (oldIRI != null) {
-                removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            }
-            return;
-        }
-
-        String newIRI = generateGovernanceIRI(newValue, propertyName);
-
-        if (!Objects.equals(oldIRI, newIRI)) {
-            removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            if (newIRI != null) {
-                toAdd.add(model.createStatement(newConcept, property, model.createResource(newIRI)));
-            }
-        }
-    }
-
-    private void updateGovernancePropertyList(Resource newConcept, List<String> newValues,
-                                              Resource oldConcept, Model model, Set<Statement> toRemove,
-                                               Set<Statement> toAdd) {
-        if (newValues == null) return;
-
-        Property property = model.createProperty(OFN_NAMESPACE + ZPUSOB_SDILENI);
-        Set<String> oldIRIs = getResourceURIs(oldConcept, property);
-        Set<String> newIRIs = new HashSet<>();
-
-        for (String value : newValues) {
-            if (value != null && !value.trim().isEmpty()) {
-                String newIRI = generateGovernanceIRI(value, ZPUSOB_SDILENI);
-                if (newIRI != null) {
-                    newIRIs.add(newIRI);
-                }
-            }
-        }
-
-        if (newValues.isEmpty() || newIRIs.isEmpty()) {
-            if (!oldIRIs.isEmpty()) {
-                removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            }
-        } else if (!oldIRIs.equals(newIRIs)) {
-            removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            for (String iri : newIRIs) {
-                toAdd.add(model.createStatement(newConcept, property, model.createResource(iri)));
-            }
-        }
-    }
-
-    private void updateBroaderConceptList(Resource newConcept, List<String> broaderConcept, Resource oldConcept,
-                                       Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (broaderConcept == null) return;
-
-        Property hierarchyProp = model.createProperty(uriGenerator.getEffectiveNamespace() + "nadřazená-třída");
-        Set<String> oldBroader = getResourceURIs(oldConcept, RDFS.subClassOf);
-        Set<String> newBroader = parseBroaderConcepts(broaderConcept);
-
-        if (broaderConcept.isEmpty() || newBroader.isEmpty()) {
-            if (!oldBroader.isEmpty()) {
-                removeAllByPredicate(newConcept, RDFS.subClassOf, toRemove, toAdd);
-                removeAllByPredicate(newConcept, hierarchyProp, toRemove, toAdd);
-            }
-        } else if (!oldBroader.equals(newBroader)) {
-            removeAllByPredicate(newConcept, RDFS.subClassOf, toRemove, toAdd);
-            removeAllByPredicate(newConcept, hierarchyProp, toRemove, toAdd);
-            for (String broader : newBroader) {
-                toAdd.add(model.createStatement(newConcept, RDFS.subClassOf, model.createResource(broader)));
-                toAdd.add(model.createStatement(newConcept, hierarchyProp, model.createResource(broader)));
-            }
-        }
-    }
-
-    private void updateDomainRange(Resource newConcept, Property property, String newValue,
-                                    Resource oldConcept, Model model, Set<Statement> toRemove,
-                                    Set<Statement> toAdd) {
-        if (newValue == null) return;
-
-        String oldURI = getResourceURI(oldConcept, property);
-
-        if (newValue.trim().isEmpty()) {
-            if (oldURI != null) {
-                removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            }
-            return;
-        }
-
-        String newURI = DataTypeConverter.isUri(newValue) ? newValue : uriGenerator.generateConceptURI(newValue, null);
-
-        if (!Objects.equals(oldURI, newURI)) {
-            removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            toAdd.add(model.createStatement(newConcept, property, model.createResource(newURI)));
-        }
-    }
-
-    private void updateDataTypeRange(Resource newConcept, String dataType, Resource oldConcept,
-                                      Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (dataType == null) return;
-
-        String oldRangeURI = getResourceURI(oldConcept, RDFS.range);
-
-        if (dataType.trim().isEmpty()) {
-            if (oldRangeURI != null) {
-                removeAllByPredicate(newConcept, RDFS.range, toRemove, toAdd);
-            }
-            return;
-        }
-
-        String newRangeURI = DataTypeConverter.getXSDTypeURI(dataType.trim());
-
-        if (!Objects.equals(oldRangeURI, newRangeURI)) {
-            removeAllByPredicate(newConcept, RDFS.range, toRemove, toAdd);
-            toAdd.add(model.createStatement(newConcept, RDFS.range, model.createResource(newRangeURI)));
-        }
-    }
-
-    private void updateSuperPropertyList(Resource newConcept, List<String> superProperties, Resource oldConcept,
-                                          Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (superProperties == null) return;
-
-        Set<String> oldSuperProps = getResourceURIs(oldConcept, RDFS.subPropertyOf);
-        Set<String> newSuperProps = parseSuperProperties(superProperties);
-
-        if (superProperties.isEmpty() || newSuperProps.isEmpty()) {
-            if (!oldSuperProps.isEmpty()) {
-                removeAllByPredicate(newConcept, RDFS.subPropertyOf, toRemove, toAdd);
-            }
-        } else if (!oldSuperProps.equals(newSuperProps)) {
-            removeAllByPredicate(newConcept, RDFS.subPropertyOf, toRemove, toAdd);
-            for (String superProp : newSuperProps) {
-                toAdd.add(model.createStatement(newConcept, RDFS.subPropertyOf, model.createResource(superProp)));
-            }
-        }
-    }
-
-    private Set<String> parseSuperProperties(List<String> superProperties) {
-        if (superProperties == null || superProperties.isEmpty()) return Collections.emptySet();
-        Set<String> result = new HashSet<>();
-        for (String prop : superProperties) {
-            String trimmed = prop.trim();
-            if (!trimmed.isEmpty()) {
-                String uri = DataTypeConverter.isUri(trimmed) ? trimmed :
-                        uriGenerator.generateConceptURI(trimmed, null);
-                result.add(uri);
-            }
-        }
-        return result;
-    }
-
-    private void updateBooleanProperty(Resource newConcept, String propertyName, Boolean newValue,
-                                       Resource oldConcept, Model model, Set<Statement> toRemove,
-                                       Set<Statement> toAdd) {
-        if (newValue == null) return;
-
-        Property property = switch (propertyName) {
-            case JE_PPDF_LONG -> model.createProperty(DEFAULT_NS + AGENDOVY_104 + JE_PPDF_LONG);
-            case IS_PUBLIC -> model.createProperty(OFN_NAMESPACE_VS + JE_VEREJNY);
-            case IN_TEZAURUS -> model.createProperty(uriGenerator.getEffectiveNamespace() + IN_TEZAURUS);
-            default -> {
-                log.warn("Unknown boolean property: {}", propertyName);
-                yield null;
-            }
-        };
-
-        if (property == null) return;
-
-        String oldValue = getPropertyValue(oldConcept, property);
-        String newValueStr = newValue.toString();
-
-        if (!Objects.equals(oldValue, newValueStr)) {
-            removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            toAdd.add(model.createStatement(newConcept, property, model.createLiteral(newValueStr)));
-        }
-    }
-
-    private void updateLegalSourceList(Resource newConcept, Property property, List<String> newSources,
-                                        Resource oldConcept, Model model, Set<Statement> toRemove,
-                                        Set<Statement> toAdd) {
-        if (newSources == null) return;
-
-        Set<String> oldSourceURIs = getResourceURIs(oldConcept, property);
-        Set<String> newSourceURIs = new HashSet<>();
-
-        for (String source : newSources) {
-            if (source == null || source.trim().isEmpty()) continue;
-            String trimmed = source.trim();
-            if (SparqlIriValidator.isEsbirkaEliIri(trimmed)) {
-                newSourceURIs.add(trimmed);
-            } else {
-                log.warn("Skipping legal source — not a canonical e-Sbírka ELI IRI: {}", trimmed);
-            }
-        }
-
-        if (newSources.isEmpty() || newSourceURIs.isEmpty()) {
-            if (!oldSourceURIs.isEmpty()) {
-                removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            }
-            return;
-        }
-
-        if (!oldSourceURIs.equals(newSourceURIs)) {
-            removeAllByPredicate(newConcept, property, toRemove, toAdd);
-            for (String sourceURI : newSourceURIs) {
-                toAdd.add(model.createStatement(newConcept, property, model.createResource(sourceURI)));
-            }
-        }
-    }
-
-    private void updateNonLegalSourceList(Resource newConcept, Property property, List<DigitalObjectModel> newSources,
-                                           Resource oldConcept, Model model, Set<Statement> toRemove,
-                                           Set<Statement> toAdd) {
-        if (newSources == null) return;
-
-        List<DigitalObjectModel> validSources = newSources.stream()
-                .filter(this::isValidDigitalObject)
-                .toList();
-
-        long skipped = newSources.stream().filter(d -> !isValidDigitalObject(d)).count();
-        if (skipped > 0) {
-            log.warn("Skipped {} non-legal source(s) — url is blank or invalid", skipped);
-        }
-
-        if (validSources.isEmpty()) {
-            removeAllByPredicate(oldConcept, property, toRemove, toAdd);
-            return;
-        }
-
-        removeAllByPredicate(newConcept, property, toRemove, toAdd);
-
-        Resource digitalObjectType = model.createResource(DIGITALNI_OBJEKT);
-        Property schemaUrlProperty = model.createProperty(SCHEMA_URL);
-        Property dctermsTitle = model.createProperty(DCT_NS + "title");
-        Property dctermsDescription = model.createProperty(DCT_NS + "description");
-
-        for (DigitalObjectModel source : validSources) {
-            Resource digitalDocument = model.createResource();
-
-            toAdd.add(model.createStatement(digitalDocument, RDF.type, digitalObjectType));
-            toAdd.add(model.createStatement(digitalDocument, schemaUrlProperty,
-                    model.createResource(source.getUrl().trim())));
-
-            if (source.getName() != null && !source.getName().trim().isEmpty()) {
-                toAdd.add(model.createStatement(digitalDocument, dctermsTitle,
-                        model.createLiteral(source.getName().trim(), DEFAULT_LANG)));
-            }
-            if (source.getDescription() != null && !source.getDescription().trim().isEmpty()) {
-                toAdd.add(model.createStatement(digitalDocument, dctermsDescription,
-                        model.createLiteral(source.getDescription().trim(), DEFAULT_LANG)));
-            }
-
-            toAdd.add(model.createStatement(newConcept, property, digitalDocument));
-        }
-    }
-
-    private boolean isValidDigitalObject(DigitalObjectModel source) {
-        if (source == null) return false;
-        String url = source.getUrl();
-        if (url == null || url.trim().isEmpty()) return false;
-        return UtilityMethods.isValidUrl(url.trim());
     }
 
     /**
@@ -791,27 +151,6 @@ public class ConceptEditor {
         }
     }
 
-    private String getPropertyValue(Resource resource, Property property) {
-        Statement stmt = resource.getProperty(property);
-        return stmt != null && stmt.getObject().isLiteral() ? stmt.getObject().asLiteral().getString() : null;
-    }
-
-    private Map<String, String> getAllPropertyValuesWithLanguage(Resource resource, Property property) {
-        Map<String, String> valuesWithLang = new HashMap<>();
-        StmtIterator iter = resource.listProperties(property);
-        while (iter.hasNext()) {
-            Statement stmt = iter.next();
-            if (stmt.getObject().isLiteral()) {
-                Literal literal = stmt.getObject().asLiteral();
-                String lang = literal.getLanguage() != null && !literal.getLanguage().isEmpty()
-                        ? literal.getLanguage()
-                        : DEFAULT_LANG;
-                valuesWithLang.put(lang, literal.getString());
-            }
-        }
-        return valuesWithLang;
-    }
-
     private String getNameForUriGeneration(com.dia.ismdtoolbackend.models.NameModel nameModel) {
         if (nameModel == null || nameModel.getName() == null || nameModel.getName().isEmpty()) {
             return "";
@@ -827,7 +166,7 @@ public class ConceptEditor {
     }
 
     private String getNameForUriGeneration(Resource resource) {
-        Map<String, String> existingNames = getAllPropertyValuesWithLanguage(resource, SKOS.prefLabel);
+        Map<String, String> existingNames = RdfLangValues.byLanguage(resource, SKOS.prefLabel);
         if (existingNames.isEmpty()) {
             return "";
         }
@@ -840,170 +179,15 @@ public class ConceptEditor {
         return existingNames.values().iterator().next();
     }
 
-    private String getResourceURI(Resource resource, Property property) {
-        Statement stmt = resource.getProperty(property);
-        return stmt != null && stmt.getObject().isResource() ? stmt.getObject().asResource().getURI() : null;
-    }
-
-    private Set<String> getResourceURIs(Resource resource, Property property) {
-        Set<String> uris = new HashSet<>();
-        StmtIterator iter = resource.listProperties(property);
-        while (iter.hasNext()) {
-            Statement stmt = iter.next();
-            if (stmt.getObject().isResource()) {
-                uris.add(stmt.getObject().asResource().getURI());
-            }
-        }
-        return uris;
-    }
-
-    private void removeAllByPredicate(Resource resource, Property property, Set<Statement> toRemove, Set<Statement> toAdd) {
-        StmtIterator iter = resource.listProperties(property);
-        while (iter.hasNext()) {
-            toRemove.add(iter.next());
-        }
-
-        toAdd.removeIf(stmt ->
-                stmt.getSubject().equals(resource) &&
-                        stmt.getPredicate().equals(property)
-        );
-    }
-
-    private Set<String> parseBroaderConcepts(List<String> broaderConcept) {
-        if (broaderConcept == null || broaderConcept.isEmpty()) return Collections.emptySet();
-        Set<String> result = new HashSet<>();
-        for (String concept : broaderConcept) {
-            String trimmed = concept.trim();
-            if (!trimmed.isEmpty()) {
-                String uri = DataTypeConverter.isUri(trimmed) ? trimmed :
-                            uriGenerator.generateConceptURI(trimmed, null);
-                result.add(uri);
-            }
-        }
-        return result;
-    }
-
-    private String generateGovernanceIRI(String value, String propertyName) {
-        String sanitized = UtilityMethods.sanitizeForIRI(value);
-        return switch (propertyName) {
-            case TYP_OBSAHU -> "https://data.dia.gov.cz/zdroj/číselníky/typy-obsahu-údajů/položky/" + sanitized;
-            case ZPUSOB_SDILENI -> "https://data.dia.gov.cz/zdroj/číselníky/způsoby-sdílení-údajů/položky/" + sanitized;
-            case ZPUSOB_ZISKANI -> "https://data.dia.gov.cz/zdroj/číselníky/způsoby-získání-údajů/položky/" + sanitized;
-            default -> null;
-        };
-    }
-
-    private String determineEffectiveNamespace(String namespace) {
-        if (namespace != null && !namespace.trim().isEmpty() && UtilityMethods.isValidIRI(namespace)) {
-            return UtilityMethods.ensureNamespaceEndsWithDelimiter(namespace);
-        }
-        return DEFAULT_NS;
-    }
-
-    private void updateDataClassification(Resource newConcept, Boolean isPublic, List<String> privacyProvisions,
-                                          Resource oldConcept, Model model, Set<Statement> toRemove,
-                                          Set<Statement> toAdd) {
-        Resource verejnyLegal = model.getResource(OFN_NAMESPACE_LEGAL + VEREJNY_UDAJ);
-        Resource neverejnyLegal = model.getResource(OFN_NAMESPACE_LEGAL + NEVEREJNY_UDAJ);
-
-        if (oldConcept.hasProperty(RDF.type, verejnyLegal)) {
-            removeTypeStatement(newConcept, oldConcept, verejnyLegal, model, toRemove, toAdd);
-        }
-        if (oldConcept.hasProperty(RDF.type, neverejnyLegal)) {
-            removeTypeStatement(newConcept, oldConcept, neverejnyLegal, model, toRemove, toAdd);
-        }
-        boolean hasNonEmptyProvisions = privacyProvisions != null &&
-                privacyProvisions.stream().anyMatch(p -> p != null && !p.trim().isEmpty());
-
-        Property provisionProperty = model.createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
-        boolean hasValidProvisions = toAdd.stream().anyMatch(stmt ->
-                stmt.getSubject().equals(newConcept) &&
-                stmt.getPredicate().equals(provisionProperty));
-        if (Boolean.TRUE.equals(isPublic)) {
-            if (!hasNonEmptyProvisions) {
-                toAdd.add(model.createStatement(newConcept, RDF.type, verejnyLegal));
-            }
-        } else if (Boolean.FALSE.equals(isPublic)) {
-            if (!hasValidProvisions) {
-                return;
-            }
-            toAdd.add(model.createStatement(newConcept, RDF.type, neverejnyLegal));
-        }
-    }
-
-    private void updateSharedGovernanceMetadata(Resource newConcept, Boolean isInPPDF, String agendaCode,
-                                                 String agendaSystemCode, List<String> sharingMethod,
-                                                 String acquisitionMethod, String contentType,
-                                                 Resource oldConcept, Model model, Set<Statement> toRemove,
-                                                 Set<Statement> toAdd) {
-        updateBooleanProperty(newConcept, JE_PPDF_LONG, isInPPDF, oldConcept, model, toRemove, toAdd);
-        updateStringProperty(newConcept, AGENDA_CODE, agendaCode, oldConcept, model, toRemove, toAdd);
-        updateStringProperty(newConcept, AIS, agendaSystemCode, oldConcept, model, toRemove, toAdd);
-        updateGovernanceProperty(newConcept, contentType, TYP_OBSAHU, oldConcept, model, toRemove, toAdd);
-        updateGovernanceProperty(newConcept, acquisitionMethod, ZPUSOB_ZISKANI, oldConcept, model, toRemove, toAdd);
-        updateGovernancePropertyList(newConcept, sharingMethod, oldConcept, model, toRemove, toAdd);
-    }
-
-    private void updateCodeListDataset(Resource newConcept, String newDatasetUrl,
-                                         Resource oldConcept, Model model,
-                                         Set<Statement> toRemove, Set<Statement> toAdd) {
-        if (newDatasetUrl == null) return;
-
-        Property instanceDefinedByCodeList = model.createProperty(
-                OFN_NAMESPACE + MA_INSTANCE_DEFINOVANE_CISELNIKEM);
-
-        // Remove existing code list dataset structure (blank node and its statements)
-        if (oldConcept.hasProperty(instanceDefinedByCodeList)) {
-            StmtIterator stmtIter = oldConcept.listProperties(instanceDefinedByCodeList);
-            while (stmtIter.hasNext()) {
-                Statement stmt = stmtIter.next();
-                toRemove.add(stmt);
-                if (stmt.getObject().isResource()) {
-                    Resource blankNode = stmt.getObject().asResource();
-                    StmtIterator bnIter = blankNode.listProperties();
-                    while (bnIter.hasNext()) {
-                        toRemove.add(bnIter.next());
-                    }
-                }
-            }
-        }
-
-        // Add new structure if value is non-empty
-        if (!newDatasetUrl.trim().isEmpty()) {
-            Resource codeListType = model.createResource(
-                    OFN_NAMESPACE_LEGAL + CISELNIK);
-            Property datasetProperty = model.createProperty(
-                    OFN_NAMESPACE_LEGAL + MA_V_NKOD_ZASTRESUJICI_DATOVOU_SADU);
-
-            Resource codeListNode = model.createResource();
-            toAdd.add(model.createStatement(codeListNode, RDF.type, codeListType));
-            toAdd.add(model.createStatement(codeListNode, datasetProperty,
-                    model.createResource(newDatasetUrl.trim())));
-            toAdd.add(model.createStatement(newConcept, instanceDefinedByCodeList, codeListNode));
-        }
-    }
-
-    private static class EditContext {
+    static class EditContext {
         final Resource oldConcept;
         final Resource newConcept;
         final Model model;
-        final boolean iriChanged;
-        final Map<Property, List<Statement>> existingStatements;
 
         public EditContext(Model model, String oldIRI, String newIRI) {
             this.model = model;
             this.oldConcept = model.getResource(oldIRI);
             this.newConcept = model.getResource(newIRI);
-            this.iriChanged = !oldIRI.equals(newIRI);
-
-            this.existingStatements = new HashMap<>();
-            StmtIterator iter = oldConcept.listProperties();
-            while (iter.hasNext()) {
-                Statement stmt = iter.next();
-                existingStatements
-                        .computeIfAbsent(stmt.getPredicate(), k -> new ArrayList<>())
-                        .add(stmt);
-            }
         }
     }
 

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptFieldUpdaters.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptFieldUpdaters.java
@@ -1,0 +1,739 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.DescriptionModel;
+import com.dia.ismdtoolbackend.models.NameModel;
+import com.dia.ismdtoolbackend.models.concept.*;
+import com.dia.ismdtoolbackend.utility.security.SparqlIriValidator;
+import com.dia.utility.DataTypeConverter;
+import com.dia.utility.UtilityMethods;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+
+import java.util.*;
+
+import static com.dia.constants.VocabularyConstants.*;
+import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
+
+@Slf4j
+class ConceptFieldUpdaters {
+
+    private static final String TYPE = "type";
+    private static final String AGENDA_CODE = "agendaCode";
+    private static final String AIS = "agendaSystemCode";
+    private static final String IS_PUBLIC = "isPublic";
+    private static final String IN_TEZAURUS = "inTezaurus";
+
+    private final ConceptIriFactory iriFactory;
+
+    ConceptFieldUpdaters(ConceptIriFactory iriFactory) {
+        this.iriFactory = iriFactory;
+    }
+
+    /**
+     * Applies the class {@code type} value (TSP/TOP rdf:type transitions).
+     * Thin package-private entry point for {@link ClassConceptTypeEditor}, keeping
+     * the string-dispatch table ({@link #updateStringProperty}) an internal detail.
+     */
+    void updateClassTypeProperty(Resource newConcept, String newType, Resource oldConcept,
+                                 Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        updateStringProperty(newConcept, TYPE, newType, oldConcept, model, toRemove, toAdd);
+    }
+
+    void editCommonFields(ConceptEditModel editModel, ConceptEditor.EditContext context,
+                                   Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        updateNameModel(context.newConcept, editModel.getNameModel(), context.oldConcept, model, toRemove, toAdd);
+        updateDescriptionModel(context.newConcept, editModel.getDescriptionModel(), context.oldConcept, model, toRemove, toAdd);
+        updateDefinitionModel(context.newConcept, editModel.getDefinitionModel(), context.oldConcept, model, toRemove, toAdd);
+        updateAltNameModel(context.newConcept, editModel.getAltNameModel(), context.oldConcept, model, toRemove, toAdd);
+        updateLegalSources(context.newConcept, editModel, context.oldConcept, model, toRemove, toAdd);
+        updateNonLegalSources(context.newConcept, editModel, context.oldConcept, model, toRemove, toAdd);
+        updateExactMatch(context.newConcept, editModel.getExactMatch(), context.oldConcept, model, toRemove, toAdd);
+        updateBooleanProperty(context.newConcept, IN_TEZAURUS, editModel.getInTezaurus(), context.oldConcept, model, toRemove, toAdd);
+    }
+
+    private void updateNameModel(Resource newConcept, NameModel nameModel, Resource oldConcept,
+                                 Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (nameModel == null || nameModel.getName() == null) return;
+
+        // Name is required: an empty incoming map is a no-op (never a clear-all),
+        // which the merge produces naturally (merged == existing).
+        Map<String, String> existing = RdfLangValues.byLanguage(oldConcept, SKOS.prefLabel);
+        applyMergedLangProperty(newConcept, SKOS.prefLabel, existing, nameModel.getName(),
+                model, toRemove, toAdd);
+    }
+
+    private void updateDescriptionModel(Resource newConcept, DescriptionModel descModel, Resource oldConcept,
+                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (descModel == null) return;
+
+        Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
+        Map<String, String> existing = RdfLangValues.byLanguage(oldConcept, descProperty);
+        Map<String, String> incoming = descModel.getDescription();
+
+        // An empty/absent incoming map clears the field entirely.
+        if (incoming == null || incoming.isEmpty()) {
+            if (!existing.isEmpty()) {
+                removeAllByPredicate(newConcept, descProperty, toRemove, toAdd);
+            }
+            return;
+        }
+
+        applyMergedLangProperty(newConcept, descProperty, existing, incoming, model, toRemove, toAdd);
+    }
+
+    private void updateDefinitionModel(Resource newConcept, DefinitionModel defModel, Resource oldConcept,
+                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (defModel == null) return;
+
+        Map<String, String> existing = RdfLangValues.byLanguage(oldConcept, SKOS.definition);
+        Map<String, String> incoming = defModel.getDefinition();
+
+        // An empty/absent incoming map clears the field entirely.
+        if (incoming == null || incoming.isEmpty()) {
+            if (!existing.isEmpty()) {
+                removeAllByPredicate(newConcept, SKOS.definition, toRemove, toAdd);
+            }
+            return;
+        }
+
+        applyMergedLangProperty(newConcept, SKOS.definition, existing, incoming, model, toRemove, toAdd);
+    }
+
+    private void updateAltNameModel(Resource newConcept, AltNameModel altNameModel, Resource oldConcept,
+                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (altNameModel == null) return;
+
+        Map<String, String> oldAltNamesByLang = RdfLangValues.byLanguage(oldConcept, SKOS.altLabel);
+
+        Map<String, String> newAltNamesByLang = new HashMap<>();
+        if (altNameModel.getAltName() != null && !altNameModel.getAltName().isEmpty()) {
+            for (Map.Entry<String, String> entry : altNameModel.getAltName().entrySet()) {
+                if (entry.getValue() != null && !entry.getValue().trim().isEmpty()) {
+                    String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
+                        ? entry.getKey()
+                        : DEFAULT_LANG;
+                    newAltNamesByLang.put(languageTag, entry.getValue().trim());
+                }
+            }
+        }
+
+        if (!oldAltNamesByLang.equals(newAltNamesByLang)) {
+            removeAllByPredicate(newConcept, SKOS.altLabel, toRemove, toAdd);
+            for (Map.Entry<String, String> entry : newAltNamesByLang.entrySet()) {
+                toAdd.add(model.createStatement(newConcept, SKOS.altLabel,
+                        model.createLiteral(entry.getValue(), entry.getKey())));
+            }
+        }
+    }
+
+    private void updateLegalSources(Resource newConcept, ConceptEditModel editModel, Resource oldConcept,
+                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        Property definingProp = model.createProperty(OFN_NAMESPACE + DEFINUJICI_USTANOVENI);
+        Property relatedProp = model.createProperty(OFN_NAMESPACE + SOUVISEJICI_USTANOVENI);
+
+        updateLegalSourceList(newConcept, definingProp, editModel.getDefiningLegalSource(),
+                oldConcept, model, toRemove, toAdd);
+        updateLegalSourceList(newConcept, relatedProp, editModel.getRelatedLegalSource(),
+                oldConcept, model, toRemove, toAdd);
+    }
+
+    private void updateNonLegalSources(Resource newConcept, ConceptEditModel editModel, Resource oldConcept,
+                                        Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        Property definingProp = model.createProperty(iriFactory.getEffectiveNamespace() + DEFINUJICI_NELEGISLATIVNI_ZDROJ);
+        Property relatedProp = model.createProperty(iriFactory.getEffectiveNamespace() + SOUVISEJICI_NELEGISLATIVNI_ZDROJ);
+
+        updateNonLegalSourceList(newConcept, definingProp, editModel.getDefiningNonLegalSource(),
+                oldConcept, model, toRemove, toAdd);
+        updateNonLegalSourceList(newConcept, relatedProp, editModel.getRelatedNonLegalSource(),
+                oldConcept, model, toRemove, toAdd);
+    }
+
+    private void updateExactMatch(Resource newConcept, List<String> exactMatchList, Resource oldConcept,
+                                  Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (exactMatchList == null) return;
+
+        Property exactMatchProp = model.createProperty("http://www.w3.org/2004/02/skos/core#exactMatch");
+        Set<String> oldMatches = getResourceURIs(oldConcept, exactMatchProp);
+        Set<String> newMatches = new HashSet<>();
+
+        for (String iri : exactMatchList) {
+            if (iri != null && !iri.trim().isEmpty()) {
+                newMatches.add(iri.trim());
+            }
+        }
+
+        if (exactMatchList.isEmpty() || newMatches.isEmpty()) {
+            if (!oldMatches.isEmpty()) {
+                removeAllByPredicate(newConcept, exactMatchProp, toRemove, toAdd);
+            }
+        } else if (!oldMatches.equals(newMatches)) {
+            removeAllByPredicate(newConcept, exactMatchProp, toRemove, toAdd);
+            for (String match : newMatches) {
+                if (UtilityMethods.isValidIRI(match)) {
+                    toAdd.add(model.createStatement(newConcept, exactMatchProp, model.createResource(match)));
+                }
+            }
+        }
+    }
+
+    private void updateStringProperty(Resource newConcept, String propertyName, String newValue,
+                                       Resource oldConcept, Model model, Set<Statement> toRemove,
+                                       Set<Statement> toAdd) {
+        switch (propertyName) {
+            case TYPE -> updateClassType(newConcept, newValue, oldConcept, model, toRemove, toAdd);
+            case AGENDA_CODE -> updateAgenda(newConcept, newValue, oldConcept, model, toRemove, toAdd);
+            case AIS -> updateAIS(newConcept, newValue, oldConcept, model, toRemove, toAdd);
+            default -> log.warn("Unknown string property: {}", propertyName);
+        }
+    }
+
+    private void updateClassType(Resource newConcept, String newType, Resource oldConcept,
+                                  Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (newType == null) return;
+
+        Resource tspType = model.getResource(OFN_NAMESPACE + TSP);
+        Resource topType = model.getResource(OFN_NAMESPACE + TOP);
+
+        boolean oldHasTSP = oldConcept.hasProperty(RDF.type, tspType);
+        boolean oldHasTOP = oldConcept.hasProperty(RDF.type, topType);
+
+        boolean newHasTSP = newType.toLowerCase().contains("subjekt");
+        boolean newHasTOP = newType.toLowerCase().contains("objekt");
+
+        if (oldHasTSP && !newHasTSP) {
+            removeTypeStatement(newConcept, oldConcept, tspType, model, toRemove, toAdd);
+        }
+        if (oldHasTOP && !newHasTOP) {
+            removeTypeStatement(newConcept, oldConcept, topType, model, toRemove, toAdd);
+        }
+        if (!oldHasTSP && newHasTSP) {
+            toAdd.add(model.createStatement(newConcept, RDF.type, tspType));
+        }
+        if (!oldHasTOP && newHasTOP) {
+            toAdd.add(model.createStatement(newConcept, RDF.type, topType));
+        }
+    }
+
+    /**
+     * Removes a specific {@code rdf:type} value from the concept. Stages removal
+     * of the statement under the old IRI (still present in the model) AND strips
+     * any copy of it staged under the new IRI by {@code renameConceptIRI} — so a
+     * type that's being dropped does not survive a rename via the copy-all pass.
+     */
+    private void removeTypeStatement(Resource newConcept, Resource oldConcept, Resource typeValue,
+                                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        toRemove.add(model.createStatement(oldConcept, RDF.type, typeValue));
+        toAdd.removeIf(stmt ->
+                stmt.getSubject().equals(newConcept) &&
+                        stmt.getPredicate().equals(RDF.type) &&
+                        stmt.getObject().equals(typeValue));
+    }
+
+    private void updateAgenda(Resource newConcept, String agendaCode, Resource oldConcept,
+                              Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (agendaCode == null) return;
+
+        Property agendaProperty = model.createProperty(DEFAULT_NS + AGENDOVY_104 + AGENDA_LONG);
+
+        if (agendaCode.trim().isEmpty()) {
+            removeAllByPredicate(oldConcept, agendaProperty, toRemove, toAdd);
+            return;
+        }
+
+        removeAllByPredicate(newConcept, agendaProperty, toRemove, toAdd);
+
+        if (UtilityMethods.isValidAgendaValue(agendaCode)) {
+            String transformed = UtilityMethods.transformAgendaValue(agendaCode);
+            if (DataTypeConverter.isUri(transformed)) {
+                toAdd.add(model.createStatement(newConcept, agendaProperty, model.createResource(transformed)));
+            } else {
+                Literal typedLiteral = DataTypeConverter.createTypedLiteral(transformed, model, null, AGENDA_LONG);
+                toAdd.add(model.createStatement(newConcept, agendaProperty, typedLiteral));
+            }
+        }
+    }
+
+    private void updateAIS(Resource newConcept, String aisCode, Resource oldConcept,
+                           Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (aisCode == null) return;
+
+        Property aisProperty = model.createProperty(DEFAULT_NS + AGENDOVY_104 + UDAJE_AIS);
+
+        if (aisCode.trim().isEmpty()) {
+            removeAllByPredicate(oldConcept, aisProperty, toRemove, toAdd);
+            return;
+        }
+
+        removeAllByPredicate(newConcept, aisProperty, toRemove, toAdd);
+
+        if (UtilityMethods.isValidAISValue(aisCode)) {
+            String transformed = UtilityMethods.transformAISValue(aisCode);
+            if (DataTypeConverter.isUri(transformed)) {
+                toAdd.add(model.createStatement(newConcept, aisProperty, model.createResource(transformed)));
+            } else {
+                Literal typedLiteral = DataTypeConverter.createTypedLiteral(transformed, model, null, UDAJE_AIS);
+                toAdd.add(model.createStatement(newConcept, aisProperty, typedLiteral));
+            }
+        }
+    }
+
+    void updatePrivacyProvisionsList(Resource newConcept, List<String> privacyProvisions,
+                                             Resource oldConcept, Model model, Set<Statement> toRemove,
+                                             Set<Statement> toAdd) {
+        if (privacyProvisions == null) return;
+
+        Property provisionProperty = model.createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
+        Set<String> oldProvisions = getResourceURIs(oldConcept, provisionProperty);
+        Set<String> newProvisions = new HashSet<>();
+
+        for (String provision : privacyProvisions) {
+            if (provision == null || provision.trim().isEmpty()) continue;
+            String trimmed = provision.trim();
+            if (SparqlIriValidator.isEsbirkaEliIri(trimmed)) {
+                newProvisions.add(trimmed);
+            } else {
+                log.warn("Skipping privacy provision — not a canonical e-Sbírka ELI IRI: {}", trimmed);
+            }
+        }
+
+        if (privacyProvisions.isEmpty() || newProvisions.isEmpty()) {
+            if (!oldProvisions.isEmpty()) {
+                removeAllByPredicate(newConcept, provisionProperty, toRemove, toAdd);
+            }
+        } else if (!oldProvisions.equals(newProvisions)) {
+            removeAllByPredicate(newConcept, provisionProperty, toRemove, toAdd);
+            for (String provisionURI : newProvisions) {
+                toAdd.add(model.createStatement(newConcept, provisionProperty, model.createResource(provisionURI)));
+            }
+        }
+    }
+
+    private void updateGovernanceProperty(Resource newConcept, String newValue, String propertyName,
+                                           Resource oldConcept, Model model, Set<Statement> toRemove,
+                                           Set<Statement> toAdd) {
+        if (newValue == null) return;
+
+        Property property = model.createProperty(OFN_NAMESPACE + propertyName);
+        String oldIRI = getResourceURI(oldConcept, property);
+
+        if (newValue.trim().isEmpty()) {
+            if (oldIRI != null) {
+                removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            }
+            return;
+        }
+
+        String newIRI = iriFactory.generateGovernanceIRI(newValue, propertyName);
+
+        if (!Objects.equals(oldIRI, newIRI)) {
+            removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            if (newIRI != null) {
+                toAdd.add(model.createStatement(newConcept, property, model.createResource(newIRI)));
+            }
+        }
+    }
+
+    private void updateSharingMethodList(Resource newConcept, List<String> newValues,
+                                              Resource oldConcept, Model model, Set<Statement> toRemove,
+                                               Set<Statement> toAdd) {
+        if (newValues == null) return;
+
+        Property property = model.createProperty(OFN_NAMESPACE + ZPUSOB_SDILENI);
+        Set<String> oldIRIs = getResourceURIs(oldConcept, property);
+        Set<String> newIRIs = new HashSet<>();
+
+        for (String value : newValues) {
+            if (value != null && !value.trim().isEmpty()) {
+                String newIRI = iriFactory.generateGovernanceIRI(value, ZPUSOB_SDILENI);
+                if (newIRI != null) {
+                    newIRIs.add(newIRI);
+                }
+            }
+        }
+
+        if (newValues.isEmpty() || newIRIs.isEmpty()) {
+            if (!oldIRIs.isEmpty()) {
+                removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            }
+        } else if (!oldIRIs.equals(newIRIs)) {
+            removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            for (String iri : newIRIs) {
+                toAdd.add(model.createStatement(newConcept, property, model.createResource(iri)));
+            }
+        }
+    }
+
+    void updateBroaderConceptList(Resource newConcept, List<String> broaderConcept, Resource oldConcept,
+                                       Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (broaderConcept == null) return;
+
+        Property hierarchyProp = model.createProperty(iriFactory.getEffectiveNamespace() + "nadřazená-třída");
+        Set<String> oldBroader = getResourceURIs(oldConcept, RDFS.subClassOf);
+        Set<String> newBroader = parseBroaderConcepts(broaderConcept);
+
+        if (broaderConcept.isEmpty() || newBroader.isEmpty()) {
+            if (!oldBroader.isEmpty()) {
+                removeAllByPredicate(newConcept, RDFS.subClassOf, toRemove, toAdd);
+                removeAllByPredicate(newConcept, hierarchyProp, toRemove, toAdd);
+            }
+        } else if (!oldBroader.equals(newBroader)) {
+            removeAllByPredicate(newConcept, RDFS.subClassOf, toRemove, toAdd);
+            removeAllByPredicate(newConcept, hierarchyProp, toRemove, toAdd);
+            for (String broader : newBroader) {
+                toAdd.add(model.createStatement(newConcept, RDFS.subClassOf, model.createResource(broader)));
+                toAdd.add(model.createStatement(newConcept, hierarchyProp, model.createResource(broader)));
+            }
+        }
+    }
+
+    void updateDomainRange(Resource newConcept, Property property, String newValue,
+                                    Resource oldConcept, Model model, Set<Statement> toRemove,
+                                    Set<Statement> toAdd) {
+        if (newValue == null) return;
+
+        String oldURI = getResourceURI(oldConcept, property);
+
+        if (newValue.trim().isEmpty()) {
+            if (oldURI != null) {
+                removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            }
+            return;
+        }
+
+        String newURI = iriFactory.isUri(newValue) ? newValue : iriFactory.generateConceptURI(newValue, null);
+
+        if (!Objects.equals(oldURI, newURI)) {
+            removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            toAdd.add(model.createStatement(newConcept, property, model.createResource(newURI)));
+        }
+    }
+
+    void updateDataTypeRange(Resource newConcept, String dataType, Resource oldConcept,
+                                      Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (dataType == null) return;
+
+        String oldRangeURI = getResourceURI(oldConcept, RDFS.range);
+
+        if (dataType.trim().isEmpty()) {
+            if (oldRangeURI != null) {
+                removeAllByPredicate(newConcept, RDFS.range, toRemove, toAdd);
+            }
+            return;
+        }
+
+        String newRangeURI = DataTypeConverter.getXSDTypeURI(dataType.trim());
+
+        if (!Objects.equals(oldRangeURI, newRangeURI)) {
+            removeAllByPredicate(newConcept, RDFS.range, toRemove, toAdd);
+            toAdd.add(model.createStatement(newConcept, RDFS.range, model.createResource(newRangeURI)));
+        }
+    }
+
+    void updateSuperPropertyList(Resource newConcept, List<String> superProperties, Resource oldConcept,
+                                          Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (superProperties == null) return;
+
+        Set<String> oldSuperProps = getResourceURIs(oldConcept, RDFS.subPropertyOf);
+        Set<String> newSuperProps = parseSuperProperties(superProperties);
+
+        if (superProperties.isEmpty() || newSuperProps.isEmpty()) {
+            if (!oldSuperProps.isEmpty()) {
+                removeAllByPredicate(newConcept, RDFS.subPropertyOf, toRemove, toAdd);
+            }
+        } else if (!oldSuperProps.equals(newSuperProps)) {
+            removeAllByPredicate(newConcept, RDFS.subPropertyOf, toRemove, toAdd);
+            for (String superProp : newSuperProps) {
+                toAdd.add(model.createStatement(newConcept, RDFS.subPropertyOf, model.createResource(superProp)));
+            }
+        }
+    }
+
+    private Set<String> parseSuperProperties(List<String> superProperties) {
+        if (superProperties == null || superProperties.isEmpty()) return Collections.emptySet();
+        Set<String> result = new HashSet<>();
+        for (String prop : superProperties) {
+            String trimmed = prop.trim();
+            if (!trimmed.isEmpty()) {
+                String uri = iriFactory.isUri(trimmed) ? trimmed :
+                        iriFactory.generateConceptURI(trimmed, null);
+                result.add(uri);
+            }
+        }
+        return result;
+    }
+
+    private void updateBooleanProperty(Resource newConcept, String propertyName, Boolean newValue,
+                                       Resource oldConcept, Model model, Set<Statement> toRemove,
+                                       Set<Statement> toAdd) {
+        if (newValue == null) return;
+
+        Property property = switch (propertyName) {
+            case JE_PPDF_LONG -> model.createProperty(DEFAULT_NS + AGENDOVY_104 + JE_PPDF_LONG);
+            case IS_PUBLIC -> model.createProperty(OFN_NAMESPACE_VS + JE_VEREJNY);
+            case IN_TEZAURUS -> model.createProperty(iriFactory.getEffectiveNamespace() + IN_TEZAURUS);
+            default -> {
+                log.warn("Unknown boolean property: {}", propertyName);
+                yield null;
+            }
+        };
+
+        if (property == null) return;
+
+        String oldValue = getPropertyValue(oldConcept, property);
+        String newValueStr = newValue.toString();
+
+        if (!Objects.equals(oldValue, newValueStr)) {
+            removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            toAdd.add(model.createStatement(newConcept, property, model.createLiteral(newValueStr)));
+        }
+    }
+
+    private void updateLegalSourceList(Resource newConcept, Property property, List<String> newSources,
+                                        Resource oldConcept, Model model, Set<Statement> toRemove,
+                                        Set<Statement> toAdd) {
+        if (newSources == null) return;
+
+        Set<String> oldSourceURIs = getResourceURIs(oldConcept, property);
+        Set<String> newSourceURIs = new HashSet<>();
+
+        for (String source : newSources) {
+            if (source == null || source.trim().isEmpty()) continue;
+            String trimmed = source.trim();
+            if (SparqlIriValidator.isEsbirkaEliIri(trimmed)) {
+                newSourceURIs.add(trimmed);
+            } else {
+                log.warn("Skipping legal source — not a canonical e-Sbírka ELI IRI: {}", trimmed);
+            }
+        }
+
+        if (newSources.isEmpty() || newSourceURIs.isEmpty()) {
+            if (!oldSourceURIs.isEmpty()) {
+                removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            }
+            return;
+        }
+
+        if (!oldSourceURIs.equals(newSourceURIs)) {
+            removeAllByPredicate(newConcept, property, toRemove, toAdd);
+            for (String sourceURI : newSourceURIs) {
+                toAdd.add(model.createStatement(newConcept, property, model.createResource(sourceURI)));
+            }
+        }
+    }
+
+    private void updateNonLegalSourceList(Resource newConcept, Property property, List<DigitalObjectModel> newSources,
+                                           Resource oldConcept, Model model, Set<Statement> toRemove,
+                                           Set<Statement> toAdd) {
+        if (newSources == null) return;
+
+        List<DigitalObjectModel> validSources = newSources.stream()
+                .filter(this::isValidDigitalObject)
+                .toList();
+
+        long skipped = newSources.stream().filter(d -> !isValidDigitalObject(d)).count();
+        if (skipped > 0) {
+            log.warn("Skipped {} non-legal source(s) — url is blank or invalid", skipped);
+        }
+
+        if (validSources.isEmpty()) {
+            removeAllByPredicate(oldConcept, property, toRemove, toAdd);
+            return;
+        }
+
+        removeAllByPredicate(newConcept, property, toRemove, toAdd);
+
+        Resource digitalObjectType = model.createResource(DIGITALNI_OBJEKT);
+        Property schemaUrlProperty = model.createProperty(SCHEMA_URL);
+        Property dctermsTitle = model.createProperty(DCT_NS + "title");
+        Property dctermsDescription = model.createProperty(DCT_NS + "description");
+
+        for (DigitalObjectModel source : validSources) {
+            Resource digitalDocument = model.createResource();
+
+            toAdd.add(model.createStatement(digitalDocument, RDF.type, digitalObjectType));
+            toAdd.add(model.createStatement(digitalDocument, schemaUrlProperty,
+                    model.createResource(source.getUrl().trim())));
+
+            if (source.getName() != null && !source.getName().trim().isEmpty()) {
+                toAdd.add(model.createStatement(digitalDocument, dctermsTitle,
+                        model.createLiteral(source.getName().trim(), DEFAULT_LANG)));
+            }
+            if (source.getDescription() != null && !source.getDescription().trim().isEmpty()) {
+                toAdd.add(model.createStatement(digitalDocument, dctermsDescription,
+                        model.createLiteral(source.getDescription().trim(), DEFAULT_LANG)));
+            }
+
+            toAdd.add(model.createStatement(newConcept, property, digitalDocument));
+        }
+    }
+
+    private boolean isValidDigitalObject(DigitalObjectModel source) {
+        if (source == null) return false;
+        String url = source.getUrl();
+        if (url == null || url.trim().isEmpty()) return false;
+        return UtilityMethods.isValidUrl(url.trim());
+    }
+
+    /**
+     * Merges an incoming {@code lang -> value} map into the existing values of a
+     * language-tagged literal property and, if the result differs, rewrites the
+     * whole property. This is the shared MERGE semantics for prefLabel /
+     * description / definition (an edit touching one language preserves the
+     * others). A blank/empty incoming value deletes that language tag; a blank
+     * tag falls back to {@link com.dia.constants.ExportConstants.Common#DEFAULT_LANG}.
+     *
+     * <p>NOTE: callers decide what an empty/absent incoming map means. Name is
+     * required and never cleared; description/definition clear-all on an empty
+     * map before calling this. altLabel is intentionally NOT routed here — it is
+     * full-replace, not merge.
+     */
+    private void applyMergedLangProperty(Resource newConcept, Property property,
+                                         Map<String, String> existing, Map<String, String> incoming,
+                                         Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        Map<String, String> merged = new HashMap<>(existing);
+        for (Map.Entry<String, String> entry : incoming.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
+                merged.remove(entry.getKey());
+            } else {
+                merged.put(entry.getKey(), entry.getValue().trim());
+            }
+        }
+
+        if (existing.equals(merged)) return;
+
+        removeAllByPredicate(newConcept, property, toRemove, toAdd);
+        for (Map.Entry<String, String> entry : merged.entrySet()) {
+            String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
+                    ? entry.getKey()
+                    : DEFAULT_LANG;
+            toAdd.add(model.createStatement(newConcept, property,
+                    model.createLiteral(entry.getValue(), languageTag)));
+        }
+    }
+
+    private String getPropertyValue(Resource resource, Property property) {
+        Statement stmt = resource.getProperty(property);
+        return stmt != null && stmt.getObject().isLiteral() ? stmt.getObject().asLiteral().getString() : null;
+    }
+
+    private String getResourceURI(Resource resource, Property property) {
+        Statement stmt = resource.getProperty(property);
+        return stmt != null && stmt.getObject().isResource() ? stmt.getObject().asResource().getURI() : null;
+    }
+
+    private Set<String> getResourceURIs(Resource resource, Property property) {
+        Set<String> uris = new HashSet<>();
+        StmtIterator iter = resource.listProperties(property);
+        while (iter.hasNext()) {
+            Statement stmt = iter.next();
+            if (stmt.getObject().isResource()) {
+                uris.add(stmt.getObject().asResource().getURI());
+            }
+        }
+        return uris;
+    }
+
+    private void removeAllByPredicate(Resource resource, Property property, Set<Statement> toRemove, Set<Statement> toAdd) {
+        RdfLangValues.removeAllByPredicate(resource, property, toRemove, toAdd);
+    }
+
+    private Set<String> parseBroaderConcepts(List<String> broaderConcept) {
+        if (broaderConcept == null || broaderConcept.isEmpty()) return Collections.emptySet();
+        Set<String> result = new HashSet<>();
+        for (String concept : broaderConcept) {
+            String trimmed = concept.trim();
+            if (!trimmed.isEmpty()) {
+                String uri = iriFactory.isUri(trimmed) ? trimmed :
+                            iriFactory.generateConceptURI(trimmed, null);
+                result.add(uri);
+            }
+        }
+        return result;
+    }
+
+    void updateDataClassification(Resource newConcept, Boolean isPublic, List<String> privacyProvisions,
+                                          Resource oldConcept, Model model, Set<Statement> toRemove,
+                                          Set<Statement> toAdd) {
+        Resource verejnyLegal = model.getResource(OFN_NAMESPACE_LEGAL + VEREJNY_UDAJ);
+        Resource neverejnyLegal = model.getResource(OFN_NAMESPACE_LEGAL + NEVEREJNY_UDAJ);
+
+        if (oldConcept.hasProperty(RDF.type, verejnyLegal)) {
+            removeTypeStatement(newConcept, oldConcept, verejnyLegal, model, toRemove, toAdd);
+        }
+        if (oldConcept.hasProperty(RDF.type, neverejnyLegal)) {
+            removeTypeStatement(newConcept, oldConcept, neverejnyLegal, model, toRemove, toAdd);
+        }
+        boolean hasNonEmptyProvisions = privacyProvisions != null &&
+                privacyProvisions.stream().anyMatch(p -> p != null && !p.trim().isEmpty());
+
+        Property provisionProperty = model.createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
+        boolean hasValidProvisions = toAdd.stream().anyMatch(stmt ->
+                stmt.getSubject().equals(newConcept) &&
+                stmt.getPredicate().equals(provisionProperty));
+        if (Boolean.TRUE.equals(isPublic)) {
+            if (!hasNonEmptyProvisions) {
+                toAdd.add(model.createStatement(newConcept, RDF.type, verejnyLegal));
+            }
+        } else if (Boolean.FALSE.equals(isPublic)) {
+            if (!hasValidProvisions) {
+                return;
+            }
+            toAdd.add(model.createStatement(newConcept, RDF.type, neverejnyLegal));
+        }
+    }
+
+    void updateSharedGovernanceMetadata(Resource newConcept, Boolean isInPPDF, String agendaCode,
+                                                 String agendaSystemCode, List<String> sharingMethod,
+                                                 String acquisitionMethod, String contentType,
+                                                 Resource oldConcept, Model model, Set<Statement> toRemove,
+                                                 Set<Statement> toAdd) {
+        updateBooleanProperty(newConcept, JE_PPDF_LONG, isInPPDF, oldConcept, model, toRemove, toAdd);
+        updateStringProperty(newConcept, AGENDA_CODE, agendaCode, oldConcept, model, toRemove, toAdd);
+        updateStringProperty(newConcept, AIS, agendaSystemCode, oldConcept, model, toRemove, toAdd);
+        updateGovernanceProperty(newConcept, contentType, TYP_OBSAHU, oldConcept, model, toRemove, toAdd);
+        updateGovernanceProperty(newConcept, acquisitionMethod, ZPUSOB_ZISKANI, oldConcept, model, toRemove, toAdd);
+        updateSharingMethodList(newConcept, sharingMethod, oldConcept, model, toRemove, toAdd);
+    }
+
+    void updateCodeListDataset(Resource newConcept, String newDatasetUrl,
+                                         Resource oldConcept, Model model,
+                                         Set<Statement> toRemove, Set<Statement> toAdd) {
+        if (newDatasetUrl == null) return;
+
+        Property instanceDefinedByCodeList = model.createProperty(
+                OFN_NAMESPACE + MA_INSTANCE_DEFINOVANE_CISELNIKEM);
+
+        // Remove existing code list dataset structure (blank node and its statements)
+        if (oldConcept.hasProperty(instanceDefinedByCodeList)) {
+            StmtIterator stmtIter = oldConcept.listProperties(instanceDefinedByCodeList);
+            while (stmtIter.hasNext()) {
+                Statement stmt = stmtIter.next();
+                toRemove.add(stmt);
+                if (stmt.getObject().isResource()) {
+                    Resource blankNode = stmt.getObject().asResource();
+                    StmtIterator bnIter = blankNode.listProperties();
+                    while (bnIter.hasNext()) {
+                        toRemove.add(bnIter.next());
+                    }
+                }
+            }
+        }
+
+        // Add new structure if value is non-empty
+        if (!newDatasetUrl.trim().isEmpty()) {
+            Resource codeListType = model.createResource(
+                    OFN_NAMESPACE_LEGAL + CISELNIK);
+            Property datasetProperty = model.createProperty(
+                    OFN_NAMESPACE_LEGAL + MA_V_NKOD_ZASTRESUJICI_DATOVOU_SADU);
+
+            Resource codeListNode = model.createResource();
+            toAdd.add(model.createStatement(codeListNode, RDF.type, codeListType));
+            toAdd.add(model.createStatement(codeListNode, datasetProperty,
+                    model.createResource(newDatasetUrl.trim())));
+            toAdd.add(model.createStatement(newConcept, instanceDefinedByCodeList, codeListNode));
+        }
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptIriFactory.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptIriFactory.java
@@ -1,0 +1,68 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.utility.DataTypeConverter;
+import com.dia.utility.URIGenerator;
+import com.dia.utility.UtilityMethods;
+
+import static com.dia.constants.VocabularyConstants.*;
+
+/**
+ * Owns all IRI / namespace generation for the concept editor.
+ *
+ * <p>Deliberately a plain class (NOT a Spring {@code @Component}) holding its own
+ * {@link URIGenerator}. {@link ConceptEditor} instantiates it as a {@code new}
+ * field exactly as it previously held {@code new URIGenerator()}. Making this an
+ * injected bean would cause Mockito's {@code @InjectMocks ConceptEditor} in the
+ * test base to inject a mock here, replacing the real URI generation and breaking
+ * the URI-generation assertions.
+ *
+ * <p>The effective namespace is per-edit mutable state set once at the start of
+ * each {@code editConcept}, mirroring the previous behavior.
+ */
+class ConceptIriFactory {
+
+    private final URIGenerator uriGenerator = new URIGenerator();
+
+    /**
+     * Resolves and sets the effective namespace for the current edit. Falls back
+     * to {@link com.dia.constants.VocabularyConstants#DEFAULT_NS} when the supplied
+     * namespace is blank or not a valid IRI.
+     */
+    void useEffectiveNamespace(String namespace) {
+        uriGenerator.setEffectiveNamespace(determineEffectiveNamespace(namespace));
+    }
+
+    String getEffectiveNamespace() {
+        return uriGenerator.getEffectiveNamespace();
+    }
+
+    String generateConceptURI(String name, String identifier) {
+        return uriGenerator.generateConceptURI(name, identifier);
+    }
+
+    private String determineEffectiveNamespace(String namespace) {
+        if (namespace != null && !namespace.trim().isEmpty() && UtilityMethods.isValidIRI(namespace)) {
+            return UtilityMethods.ensureNamespaceEndsWithDelimiter(namespace);
+        }
+        return DEFAULT_NS;
+    }
+
+    /**
+     * Maps a governance code-list value to its canonical číselník položka IRI.
+     * Returns {@code null} for property names that have no governance code list.
+     */
+    String generateGovernanceIRI(String value, String propertyName) {
+        String sanitized = UtilityMethods.sanitizeForIRI(value);
+        return switch (propertyName) {
+            case TYP_OBSAHU -> "https://data.dia.gov.cz/zdroj/číselníky/typy-obsahu-údajů/položky/" + sanitized;
+            case ZPUSOB_SDILENI -> "https://data.dia.gov.cz/zdroj/číselníky/způsoby-sdílení-údajů/položky/" + sanitized;
+            case ZPUSOB_ZISKANI -> "https://data.dia.gov.cz/zdroj/číselníky/způsoby-získání-údajů/položky/" + sanitized;
+            default -> null;
+        };
+    }
+
+    /** True when the value is already a URI; mirrors {@link DataTypeConverter#isUri(String)}. */
+    boolean isUri(String value) {
+        return DataTypeConverter.isUri(value);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptTypeEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/ConceptTypeEditor.java
@@ -1,0 +1,19 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+
+import java.util.Set;
+
+/**
+ * Applies the type-specific edit sequence (class / property / relationship) for a
+ * concept. Each implementation stages its changes into {@code toRemove}/{@code toAdd}
+ * using the shared {@link ConceptFieldUpdaters} toolkit; the orchestration
+ * (rename, transaction, model apply) stays in {@link ConceptEditor}.
+ */
+interface ConceptTypeEditor {
+
+    void edit(ConceptEditModel editModel, ConceptEditor.EditContext context,
+              Model model, Set<Statement> toRemove, Set<Statement> toAdd);
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditor.java
@@ -100,7 +100,10 @@ public class OntologyEditor {
             return new EditResult(newOntologyIRI, iriActuallyChanged);
 
         } catch (Exception e) {
-            throw new OntologyException("Failed to edit ontology: " + iri);
+            log.error("Failed to edit ontology: {}", iri, e);
+            OntologyException ex = new OntologyException("Failed to edit ontology: " + iri + " - " + e.getMessage());
+            ex.initCause(e);
+            throw ex;
         } finally {
             if (supportsTransactions && !committed) {
                 try {
@@ -117,31 +120,10 @@ public class OntologyEditor {
                            Set<Statement> toRemove, Set<Statement> toAdd, String newOntologyIRI) {
         if (nameModel == null || nameModel.getName() == null) return;
 
-        Map<String, String> existingNames = getAllPropertyValuesWithLanguage(existingOntology, SKOS.prefLabel);
-
-        Map<String, String> newNames = nameModel.getName();
-
-        Map<String, String> mergedNames = new HashMap<>(existingNames);
-        for (Map.Entry<String, String> entry : newNames.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
-                mergedNames.remove(entry.getKey());
-            } else {
-                mergedNames.put(entry.getKey(), entry.getValue().trim());
-            }
-        }
-
-        if (!existingNames.equals(mergedNames)) {
-            Resource ontologyResource = model.getResource(newOntologyIRI);
-            removeAllByPredicate(existingOntology, SKOS.prefLabel, toRemove, toAdd);
-
-            for (Map.Entry<String, String> entry : mergedNames.entrySet()) {
-                String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                toAdd.add(model.createStatement(ontologyResource, SKOS.prefLabel,
-                        model.createLiteral(entry.getValue(), languageTag)));
-            }
-        }
+        // Name is required: an empty incoming map is a no-op (merged == existing).
+        Map<String, String> existing = RdfLangValues.byLanguage(existingOntology, SKOS.prefLabel);
+        applyMergedLangProperty(existingOntology, model.getResource(newOntologyIRI), SKOS.prefLabel,
+                existing, nameModel.getName(), model, toRemove, toAdd);
     }
 
     private void updateDescription(Resource existingOntology, DescriptionModel descModel, Model model,
@@ -149,38 +131,49 @@ public class OntologyEditor {
         if (descModel == null) return;
 
         Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
+        Map<String, String> existing = RdfLangValues.byLanguage(existingOntology, descProperty);
+        Map<String, String> incoming = descModel.getDescription();
 
-        Map<String, String> existingDescriptions = getAllPropertyValuesWithLanguage(existingOntology, descProperty);
-
-        Map<String, String> newDescriptions = descModel.getDescription();
-
-        if (newDescriptions == null || newDescriptions.isEmpty()) {
-            if (!existingDescriptions.isEmpty()) {
-                removeAllByPredicate(existingOntology, descProperty, toRemove, toAdd);
+        // An empty/absent incoming map clears the field entirely.
+        if (incoming == null || incoming.isEmpty()) {
+            if (!existing.isEmpty()) {
+                RdfLangValues.removeAllByPredicate(existingOntology, descProperty, toRemove, toAdd);
             }
             return;
         }
 
-        Map<String, String> mergedDescriptions = new HashMap<>(existingDescriptions);
-        for (Map.Entry<String, String> entry : newDescriptions.entrySet()) {
+        applyMergedLangProperty(existingOntology, model.getResource(newOntologyIRI), descProperty,
+                existing, incoming, model, toRemove, toAdd);
+    }
+
+    /**
+     * Merges an incoming {@code lang -> value} map into {@code existing} and, if
+     * changed, removes the property from {@code readResource} and rewrites the
+     * merged values onto {@code writeResource}. The read/write split lets an
+     * ontology rename relocate labels onto the new IRI in the same pass. Mirrors
+     * the MERGE semantics used for concept prefLabel/description/definition.
+     */
+    private void applyMergedLangProperty(Resource readResource, Resource writeResource, Property property,
+                                         Map<String, String> existing, Map<String, String> incoming,
+                                         Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        Map<String, String> merged = new HashMap<>(existing);
+        for (Map.Entry<String, String> entry : incoming.entrySet()) {
             if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
-                mergedDescriptions.remove(entry.getKey());
+                merged.remove(entry.getKey());
             } else {
-                mergedDescriptions.put(entry.getKey(), entry.getValue().trim());
+                merged.put(entry.getKey(), entry.getValue().trim());
             }
         }
 
-        if (!existingDescriptions.equals(mergedDescriptions)) {
-            Resource ontologyResource = model.getResource(newOntologyIRI);
-            removeAllByPredicate(existingOntology, descProperty, toRemove, toAdd);
+        if (existing.equals(merged)) return;
 
-            for (Map.Entry<String, String> entry : mergedDescriptions.entrySet()) {
-                String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
-                        ? entry.getKey()
-                        : DEFAULT_LANG;
-                toAdd.add(model.createStatement(ontologyResource, descProperty,
-                        model.createLiteral(entry.getValue(), languageTag)));
-            }
+        RdfLangValues.removeAllByPredicate(readResource, property, toRemove, toAdd);
+        for (Map.Entry<String, String> entry : merged.entrySet()) {
+            String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
+                    ? entry.getKey()
+                    : DEFAULT_LANG;
+            toAdd.add(model.createStatement(writeResource, property,
+                    model.createLiteral(entry.getValue(), languageTag)));
         }
     }
 
@@ -262,60 +255,12 @@ public class OntologyEditor {
         }
     }
 
-    private void removeAllByPredicate(Resource resource, Property property, Set<Statement> toRemove, Set<Statement> toAdd) {
-        StmtIterator iter = resource.listProperties(property);
-        while (iter.hasNext()) {
-            toRemove.add(iter.next());
-        }
-
-        toAdd.removeIf(stmt ->
-                stmt.getSubject().equals(resource) &&
-                        stmt.getPredicate().equals(property)
-        );
-    }
-
-    private Map<String, String> getAllPropertyValuesWithLanguage(Resource resource, Property property) {
-        Map<String, String> valuesWithLang = new HashMap<>();
-        StmtIterator iter = resource.listProperties(property);
-        while (iter.hasNext()) {
-            Statement stmt = iter.next();
-            if (stmt.getObject().isLiteral()) {
-                Literal literal = stmt.getObject().asLiteral();
-                String lang = literal.getLanguage() != null && !literal.getLanguage().isEmpty()
-                        ? literal.getLanguage()
-                        : DEFAULT_LANG;
-                valuesWithLang.put(lang, literal.getString());
-            }
-        }
-        return valuesWithLang;
-    }
-
     private String getNameForUriGeneration(NameModel nameModel) {
-        if (nameModel == null || nameModel.getName() == null || nameModel.getName().isEmpty()) {
-            return "";
-        }
-        Map<String, String> names = nameModel.getName();
-        if (names.containsKey("cs")) {
-            return names.get("cs");
-        }
-        if (names.containsKey(DEFAULT_LANG)) {
-            return names.get(DEFAULT_LANG);
-        }
-        return names.values().iterator().next();
+        return RdfLangValues.preferredName(nameModel == null ? null : nameModel.getName());
     }
 
     private String getNameForUriGeneration(Resource resource) {
-        Map<String, String> existingNames = getAllPropertyValuesWithLanguage(resource, SKOS.prefLabel);
-        if (existingNames.isEmpty()) {
-            return "";
-        }
-        if (existingNames.containsKey("cs")) {
-            return existingNames.get("cs");
-        }
-        if (existingNames.containsKey(DEFAULT_LANG)) {
-            return existingNames.get(DEFAULT_LANG);
-        }
-        return existingNames.values().iterator().next();
+        return RdfLangValues.preferredName(RdfLangValues.byLanguage(resource, SKOS.prefLabel));
     }
 
     public static class EditResult {

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/PropertyConceptTypeEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/PropertyConceptTypeEditor.java
@@ -1,0 +1,44 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.PropertyConceptEditModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDFS;
+
+import java.util.Set;
+
+/** Type-specific edit sequence for property concepts (VLASTNOST). */
+class PropertyConceptTypeEditor implements ConceptTypeEditor {
+
+    private final ConceptFieldUpdaters fields;
+
+    PropertyConceptTypeEditor(ConceptFieldUpdaters fields) {
+        this.fields = fields;
+    }
+
+    @Override
+    public void edit(ConceptEditModel editModel, ConceptEditor.EditContext context,
+                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        PropertyConceptEditModel m = (PropertyConceptEditModel) editModel;
+
+        fields.editCommonFields(m, context, model, toRemove, toAdd);
+
+        fields.updateDomainRange(context.newConcept, RDFS.domain, m.getDomain(), context.oldConcept, model, toRemove, toAdd);
+        fields.updateDataTypeRange(context.newConcept, m.getDataType(), context.oldConcept, model, toRemove, toAdd);
+        fields.updateSuperPropertyList(context.newConcept, m.getSuperProperty(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateSharedGovernanceMetadata(context.newConcept, m.getIsInPPDF(), m.getAgendaCode(),
+                m.getAgendaSystemCode(), m.getSharingMethod(), m.getAcquisitionMethod(),
+                m.getContentType(), context.oldConcept, model, toRemove, toAdd);
+
+        // Privacy provisions must be staged BEFORE data classification, which reads
+        // the staged provisions from toAdd to decide the public/private rdf:type.
+        fields.updatePrivacyProvisionsList(context.newConcept, m.getPrivacyProvisions(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateDataClassification(context.newConcept, m.getIsPublic(), m.getPrivacyProvisions(),
+                context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateCodeListDataset(context.newConcept, m.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/RdfLangValues.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/RdfLangValues.java
@@ -1,0 +1,75 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
+
+/** Small RDF read / staging helpers shared by the concept and ontology editors. */
+final class RdfLangValues {
+
+    private RdfLangValues() {
+    }
+
+    /**
+     * Collects all language-tagged literal values of {@code property} on
+     * {@code resource} as a {@code lang -> value} map. Literals with no language
+     * tag are keyed under {@link com.dia.constants.ExportConstants.Common#DEFAULT_LANG}.
+     */
+    static Map<String, String> byLanguage(Resource resource, Property property) {
+        Map<String, String> valuesWithLang = new HashMap<>();
+        StmtIterator iter = resource.listProperties(property);
+        while (iter.hasNext()) {
+            Statement stmt = iter.next();
+            if (stmt.getObject().isLiteral()) {
+                Literal literal = stmt.getObject().asLiteral();
+                String lang = literal.getLanguage() != null && !literal.getLanguage().isEmpty()
+                        ? literal.getLanguage()
+                        : DEFAULT_LANG;
+                valuesWithLang.put(lang, literal.getString());
+            }
+        }
+        return valuesWithLang;
+    }
+
+    /**
+     * Picks the name used for IRI generation from a {@code lang -> value} map,
+     * preferring {@code "cs"}, then {@link com.dia.constants.ExportConstants.Common#DEFAULT_LANG},
+     * then any value. Returns {@code ""} for a null/empty map.
+     */
+    static String preferredName(Map<String, String> names) {
+        if (names == null || names.isEmpty()) {
+            return "";
+        }
+        if (names.containsKey("cs")) {
+            return names.get("cs");
+        }
+        if (names.containsKey(DEFAULT_LANG)) {
+            return names.get(DEFAULT_LANG);
+        }
+        return names.values().iterator().next();
+    }
+
+    /**
+     * Stages removal of every {@code property} statement on {@code resource} and
+     * cancels any matching additions already staged in {@code toAdd}, so a
+     * remove-then-rewrite leaves only the intended new values.
+     */
+    static void removeAllByPredicate(Resource resource, Property property,
+                                     Set<Statement> toRemove, Set<Statement> toAdd) {
+        StmtIterator iter = resource.listProperties(property);
+        while (iter.hasNext()) {
+            toRemove.add(iter.next());
+        }
+        toAdd.removeIf(stmt ->
+                stmt.getSubject().equals(resource) &&
+                        stmt.getPredicate().equals(property));
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/RelationshipConceptTypeEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/RelationshipConceptTypeEditor.java
@@ -1,0 +1,44 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.RelationshipConceptEditModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDFS;
+
+import java.util.Set;
+
+/** Type-specific edit sequence for relationship concepts (VZTAH). */
+class RelationshipConceptTypeEditor implements ConceptTypeEditor {
+
+    private final ConceptFieldUpdaters fields;
+
+    RelationshipConceptTypeEditor(ConceptFieldUpdaters fields) {
+        this.fields = fields;
+    }
+
+    @Override
+    public void edit(ConceptEditModel editModel, ConceptEditor.EditContext context,
+                     Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
+        RelationshipConceptEditModel m = (RelationshipConceptEditModel) editModel;
+
+        fields.editCommonFields(m, context, model, toRemove, toAdd);
+
+        fields.updateDomainRange(context.newConcept, RDFS.domain, m.getDomain(), context.oldConcept, model, toRemove, toAdd);
+        fields.updateDomainRange(context.newConcept, RDFS.range, m.getRange(), context.oldConcept, model, toRemove, toAdd);
+        fields.updateSuperPropertyList(context.newConcept, m.getSuperRelation(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateSharedGovernanceMetadata(context.newConcept, m.getIsInPPDF(), m.getAgendaCode(),
+                m.getAgendaSystemCode(), m.getSharingMethod(), m.getAcquisitionMethod(),
+                m.getContentType(), context.oldConcept, model, toRemove, toAdd);
+
+        // Privacy provisions must be staged BEFORE data classification, which reads
+        // the staged provisions from toAdd to decide the public/private rdf:type.
+        fields.updatePrivacyProvisionsList(context.newConcept, m.getPrivacyProvisions(), context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateDataClassification(context.newConcept, m.getIsPublic(), m.getPrivacyProvisions(),
+                context.oldConcept, model, toRemove, toAdd);
+
+        fields.updateCodeListDataset(context.newConcept, m.getCodeListDataset(), context.oldConcept, model, toRemove, toAdd);
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/service/ConceptEditFlowIntegrationTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/ConceptEditFlowIntegrationTest.java
@@ -1,0 +1,169 @@
+package com.dia.ismdtoolbackend.service;
+
+import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
+import com.dia.ismdtoolbackend.mapper.ConceptMetadataMapper;
+import com.dia.ismdtoolbackend.models.NameModel;
+import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.ConceptMetadataModel;
+import com.dia.ismdtoolbackend.repository.CommentRepository;
+import com.dia.ismdtoolbackend.repository.ConceptMetadataRepository;
+import com.dia.ismdtoolbackend.repository.JenaTDB2Repository;
+import com.dia.ismdtoolbackend.repository.OntologyMetadataRepository;
+import com.dia.ismdtoolbackend.service.impl.ConceptDeviationComparator;
+import com.dia.ismdtoolbackend.service.impl.ConceptServiceImpl;
+import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
+import com.dia.ismdtoolbackend.service.impl.ReferencedConceptsEnricher;
+import com.dia.ismdtoolbackend.utility.creator.ConceptCreator;
+import com.dia.ismdtoolbackend.utility.detail.OntologyDetailExtractor;
+import com.dia.ismdtoolbackend.utility.editor.ConceptEditor;
+import com.dia.ismdtoolbackend.enums.ConceptType;
+import com.dia.ismdtoolbackend.client.NkdSparqlClient;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.dia.constants.VocabularyConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * End-to-end edit flow with the REAL ConceptEditor (and its real validator and
+ * field updaters) wired into ConceptServiceImpl. Only the persistence boundary
+ * (repositories, Fuseki, mapper) is mocked. This catches wiring regressions that
+ * the layer-isolated tests (which mock the editor) cannot — e.g. a valid edit
+ * actually mutating the model, and an invalid edit producing a 400 with no write.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ConceptEditFlowIntegrationTest {
+
+    @Mock private ConceptMetadataRepository conceptMetadataRepository;
+    @Mock private OntologyMetadataRepository ontologyMetadataRepository;
+    @Mock private ConceptMetadataMapper conceptMetadataMapper;
+    @Mock private ConceptCreator conceptCreator;
+    @Mock private JenaTDB2Repository jenaTDB2Repository;
+    @Mock private OntologyDetailExtractor detailExtractor;
+    @Mock private CommentRepository commentRepository;
+    @Mock private NkdSparqlClient nkdSparqlClient;
+    @Mock private ConceptDeviationComparator deviationComparator;
+    @Mock private RppSnapshotHolder rppSnapshotHolder;
+    @Mock private ReferencedConceptsEnricher referencedConceptsEnricher;
+
+    private ConceptServiceImpl conceptService;
+    private Model model;
+
+    private static final Long CONCEPT_ID = 1L;
+    private static final String CONCEPT_IRI = "http://example.org/pojem/test-concept";
+    private static final String GRAPH_NAME = "http://example.org/test-ontology";
+    private static final String VALID_ELI =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2006/187";
+
+    @BeforeEach
+    void setUp() {
+        // Real editor — the whole point of this test.
+        ConceptEditor realEditor = new ConceptEditor();
+        conceptService = new ConceptServiceImpl(
+                conceptMetadataRepository, ontologyMetadataRepository, conceptMetadataMapper,
+                conceptCreator, realEditor, jenaTDB2Repository, detailExtractor,
+                commentRepository, nkdSparqlClient, deviationComparator,
+                rppSnapshotHolder, referencedConceptsEnricher);
+
+        model = ModelFactory.createDefaultModel();
+        Resource concept = model.createResource(CONCEPT_IRI);
+        concept.addProperty(SKOS.prefLabel, model.createLiteral("Test Concept", "cs"));
+        concept.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));
+
+        ConceptMetadataEntity entity = new ConceptMetadataEntity();
+        entity.setId(CONCEPT_ID);
+        entity.setConceptIri(CONCEPT_IRI);
+        entity.setConceptName("Test Concept");
+        entity.setConceptType(ConceptType.TRIDA);
+        entity.setGraphName(GRAPH_NAME);
+        entity.setUserId("user123");
+
+        when(conceptMetadataRepository.findById(CONCEPT_ID)).thenReturn(Optional.of(entity));
+        when(jenaTDB2Repository.fetchGraph(GRAPH_NAME)).thenReturn(model);
+        when(conceptMetadataRepository.save(any(ConceptMetadataEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(conceptMetadataMapper.toDto(any(ConceptMetadataEntity.class))).thenReturn(new ConceptMetadataModel());
+    }
+
+    private ClassConceptEditModel editModel() {
+        ClassConceptEditModel m = new ClassConceptEditModel();
+        m.setConceptType("TRIDA");
+        return m;
+    }
+
+    @Test
+    void validEdit_mutatesModelAndPersists() {
+        ClassConceptEditModel m = editModel();
+        // change the description (no name change → no IRI rename)
+        var desc = new com.dia.ismdtoolbackend.models.DescriptionModel();
+        desc.setDescription(Map.of("cs", "Nový popis"));
+        m.setDescriptionModel(desc);
+        m.setPrivacyProvisions(List.of(VALID_ELI));
+        m.setIsPublic(Boolean.FALSE);
+
+        conceptService.editConcept(CONCEPT_ID, m);
+
+        // the real editor mutated the in-memory model, and the service persisted it
+        ArgumentCaptor<Model> saved = ArgumentCaptor.forClass(Model.class);
+        verify(jenaTDB2Repository).putOntologyModel(eq(GRAPH_NAME), saved.capture());
+
+        Resource concept = saved.getValue().getResource(CONCEPT_IRI);
+        Property descProp = saved.getValue().createProperty("http://purl.org/dc/terms/description");
+        assertTrue(concept.hasProperty(descProp), "description must be written");
+        Property provisionProp = saved.getValue().createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
+        assertTrue(concept.hasProperty(provisionProp, saved.getValue().createResource(VALID_ELI)),
+                "privacy provision must be written end-to-end");
+        verify(conceptMetadataRepository).save(any());
+    }
+
+    @Test
+    void invalidEdit_rejectedAs400_withNoWrite() {
+        ClassConceptEditModel m = editModel();
+        m.setExactMatch(List.of("not-a-valid-iri"));   // real validator rejects this
+
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class,
+                () -> conceptService.editConcept(CONCEPT_ID, m));
+
+        assertTrue(ex.getMessage().contains("exactMatch"), ex.getMessage());
+        // no persistence on rejection — atomic
+        verify(jenaTDB2Repository, never()).putOntologyModel(anyString(), any());
+        verify(conceptMetadataRepository, never()).save(any());
+    }
+
+    @Test
+    void nameChangeEdit_renamesIriEndToEnd() {
+        ClassConceptEditModel m = editModel();
+        NameModel newName = new NameModel();
+        newName.setName(Map.of("cs", "Nový název"));
+        m.setNameModel(newName);
+
+        conceptService.editConcept(CONCEPT_ID, m);
+
+        ArgumentCaptor<Model> saved = ArgumentCaptor.forClass(Model.class);
+        // IRI change path saves via the rename handler; capture whichever save ran
+        verify(jenaTDB2Repository, atLeastOnce()).putOntologyModel(anyString(), saved.capture());
+        // the old IRI no longer carries the prefLabel (it moved to the new IRI)
+        Resource oldConcept = saved.getValue().getResource(CONCEPT_IRI);
+        assertFalse(oldConcept.hasProperty(SKOS.prefLabel),
+                "after rename, the old IRI must not retain the prefLabel");
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/service/ConceptEditFlowIntegrationTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/ConceptEditFlowIntegrationTest.java
@@ -67,7 +67,6 @@ class ConceptEditFlowIntegrationTest {
     @Mock private ReferencedConceptsEnricher referencedConceptsEnricher;
 
     private ConceptServiceImpl conceptService;
-    private Model model;
 
     private static final Long CONCEPT_ID = 1L;
     private static final String CONCEPT_IRI = "http://example.org/pojem/test-concept";
@@ -85,7 +84,7 @@ class ConceptEditFlowIntegrationTest {
                 commentRepository, nkdSparqlClient, deviationComparator,
                 rppSnapshotHolder, referencedConceptsEnricher);
 
-        model = ModelFactory.createDefaultModel();
+        Model model = ModelFactory.createDefaultModel();
         Resource concept = model.createResource(CONCEPT_IRI);
         concept.addProperty(SKOS.prefLabel, model.createLiteral("Test Concept", "cs"));
         concept.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));

--- a/src/test/java/com/dia/ismdtoolbackend/service/ConceptServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/ConceptServiceImplTest.java
@@ -27,6 +27,7 @@ import com.dia.ismdtoolbackend.service.rpp.RppSnapshotHolder;
 import com.dia.ismdtoolbackend.utility.creator.ConceptCreator;
 import com.dia.ismdtoolbackend.utility.detail.OntologyDetailExtractor;
 import com.dia.ismdtoolbackend.utility.editor.ConceptEditor;
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
 import org.apache.jena.ontology.OntologyException;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -503,6 +504,27 @@ class ConceptServiceImplTest {
 
         assertTrue(exception.getMessage().contains("Nepodařilo se upravit pojem"));
         verify(jenaTDB2Repository, never()).putOntologyModel(anyString(), any());
+    }
+
+    @Test
+    void editConcept_ValidationException_propagatesUnwrappedAs400() {
+        // A ConceptValidationException from the editor (invalid input) must NOT be
+        // re-wrapped into OntologyException — that would turn the 400 into a 500.
+        ConceptEditModel editModel = createValidConceptEditModel();
+
+        testModel.add(testResource, testModel.createProperty("http://example.org/prop"), "value");
+
+        when(conceptMetadataRepository.findById(TEST_CONCEPT_ID)).thenReturn(Optional.of(testConceptEntity));
+        when(jenaTDB2Repository.fetchGraph(TEST_GRAPH_NAME)).thenReturn(testModel);
+        when(conceptEditor.editConcept(eq(TEST_CONCEPT_IRI), eq(editModel), any(Model.class), eq(TEST_GRAPH_NAME)))
+                .thenThrow(new ConceptValidationException("Neplatné hodnoty v úpravě pojmu: exactMatch"));
+
+        ConceptValidationException exception = assertThrows(ConceptValidationException.class,
+                () -> conceptService.editConcept(TEST_CONCEPT_ID, editModel));
+
+        assertTrue(exception.getMessage().contains("Neplatné hodnoty"));
+        verify(jenaTDB2Repository, never()).putOntologyModel(anyString(), any());
+        verify(conceptMetadataRepository, never()).save(any());
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/service/ConceptServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/ConceptServiceImplTest.java
@@ -887,11 +887,6 @@ class ConceptServiceImplTest {
             public ConceptType getConceptTypeEnum() {
                 return ConceptType.TRIDA;
             }
-
-            @Override
-            protected void validateSpecificFields() {
-                // Override method not applicable for this test
-            }
         };
         model.setConceptType("TRIDA");
 

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorClassConceptTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorClassConceptTest.java
@@ -110,9 +110,9 @@ class ConceptEditorClassConceptTest extends ConceptEditorTestBase {
         when(classConceptEditModel.getType()).thenReturn("subjekt");
         when(classConceptEditModel.getAgendaCode()).thenReturn("");
         when(classConceptEditModel.getAgendaSystemCode()).thenReturn(null);
-        when(classConceptEditModel.getContentType()).thenReturn("obsah");
-        when(classConceptEditModel.getAcquisitionMethod()).thenReturn("ziskani");
-        when(classConceptEditModel.getSharingMethod()).thenReturn(List.of("sdileni"));
+        when(classConceptEditModel.getContentType()).thenReturn("provozní");
+        when(classConceptEditModel.getAcquisitionMethod()).thenReturn("vlastní");
+        when(classConceptEditModel.getSharingMethod()).thenReturn(List.of("nesdílené"));
         when(classConceptEditModel.getIsPublic()).thenReturn(null);
         when(classConceptEditModel.getIsInPPDF()).thenReturn(null);
         when(classConceptEditModel.getBroaderConcept()).thenReturn(List.of("https://example.com/new-broader"));
@@ -702,7 +702,7 @@ class ConceptEditorClassConceptTest extends ConceptEditorTestBase {
         existing.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));
 
         stubAllClassFieldsNull(classConceptEditModel);
-        when(classConceptEditModel.getSharingMethod()).thenReturn(List.of("value-1", "value-2"));
+        when(classConceptEditModel.getSharingMethod()).thenReturn(List.of("nesdílené", "veřejně přístupné"));
 
         conceptEditor.editConcept(conceptIri, classConceptEditModel, model, null);
 
@@ -785,22 +785,24 @@ class ConceptEditorClassConceptTest extends ConceptEditorTestBase {
 
     // A11d – Data classification: public but has provisions
     @Test
-    void editConcept_ShouldNotAddVerejnyUdaj_WhenIsPublicTrueButHasProvisions() {
+    void editConcept_ShouldReject_WhenIsPublicTrueButHasProvisions() {
+        // isPublic=true together with privacy provisions is a contradiction and is
+        // now rejected up front by validation (400) — before reaching the editor.
         String conceptIri = DEFAULT_NS + "class-a11d";
         Resource existing = model.createResource(conceptIri);
         existing.addProperty(SKOS.prefLabel, model.createLiteral("Class a11d", "cs"));
         existing.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));
+        long sizeBefore = model.size();
 
         stubAllClassFieldsNull(classConceptEditModel);
         when(classConceptEditModel.getIsPublic()).thenReturn(Boolean.TRUE);
         when(classConceptEditModel.getPrivacyProvisions())
                 .thenReturn(List.of("https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2023/50"));
 
-        conceptEditor.editConcept(conceptIri, classConceptEditModel, model, null);
-
-        Resource updated = model.getResource(conceptIri);
-        Resource verejny = model.getResource(OFN_NAMESPACE_LEGAL + VEREJNY_UDAJ);
-        assertFalse(updated.hasProperty(RDF.type, verejny));
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(conceptIri, classConceptEditModel, model, null));
+        assertTrue(ex.getMessage().contains("veřejn"), ex.getMessage());
+        assertEquals(sizeBefore, model.size(), "rejected edit must not mutate the model");
     }
 
     // A12 – inTezaurus boolean update

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorClassConceptTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorClassConceptTest.java
@@ -6,6 +6,7 @@ import com.dia.ismdtoolbackend.models.concept.AltNameModel;
 import com.dia.ismdtoolbackend.models.concept.DefinitionModel;
 import com.dia.ismdtoolbackend.models.concept.DigitalObjectModel;
 import com.dia.ismdtoolbackend.enums.ConceptType;
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
 import com.dia.utility.URIGenerator;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static com.dia.constants.VocabularyConstants.*;
 import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
@@ -538,9 +540,10 @@ class ConceptEditorClassConceptTest extends ConceptEditorTestBase {
         assertFalse(updated.hasProperty(relatedProp));
     }
 
-    // A7 – Non-legal sources with blank/invalid url are skipped (treated as an empty list)
+    // A7 – Non-legal sources with blank/invalid url now REJECT the whole edit (HTTP 400),
+    // listing every offending field, and leave the model untouched (no partial write).
     @Test
-    void editConcept_ShouldSkipNonLegalSourcesWithInvalidUrl() {
+    void editConcept_ShouldRejectNonLegalSourcesWithInvalidUrl() {
         String conceptIri = DEFAULT_NS + "class-nonlegal-clear";
         Resource existing = model.createResource(conceptIri);
         existing.addProperty(SKOS.prefLabel, model.createLiteral("Class nonlegal clear", "cs"));
@@ -552,41 +555,33 @@ class ConceptEditorClassConceptTest extends ConceptEditorTestBase {
         existing.addProperty(definingProp, model.createResource(DEFAULT_NS + "digitální-dokument-1"));
         existing.addProperty(relatedProp, model.createResource(DEFAULT_NS + "digitální-dokument-2"));
 
-        when(classConceptEditModel.getConceptTypeEnum()).thenReturn(ConceptType.TRIDA);
-        when(classConceptEditModel.getNameModel()).thenReturn(null);
-        when(classConceptEditModel.getDescriptionModel()).thenReturn(null);
-        when(classConceptEditModel.getDefinitionModel()).thenReturn(null);
-        when(classConceptEditModel.getAltNameModel()).thenReturn(null);
+        long sizeBefore = model.size();
 
-        when(classConceptEditModel.getDefiningNonLegalSource())
+        // Only the fields the pre-flight validator reads need stubbing — validation
+        // throws before the type dispatch, so e.g. getConceptTypeEnum is never reached.
+        lenient().when(classConceptEditModel.getDefiningNonLegalSource())
                 .thenReturn(List.of(new DigitalObjectModel("Doc with no url", "Popis", "")));
-        when(classConceptEditModel.getRelatedNonLegalSource())
+        lenient().when(classConceptEditModel.getRelatedNonLegalSource())
                 .thenReturn(List.of(new DigitalObjectModel("Doc with invalid url", "Popis", "not a url")));
+        lenient().when(classConceptEditModel.getDefiningLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getRelatedLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAgendaCode()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAgendaSystemCode()).thenReturn(null);
+        lenient().when(classConceptEditModel.getExactMatch()).thenReturn(null);
+        lenient().when(classConceptEditModel.getPrivacyProvisions()).thenReturn(null);
 
-        when(classConceptEditModel.getDefiningLegalSource()).thenReturn(null);
-        when(classConceptEditModel.getRelatedLegalSource()).thenReturn(null);
-        when(classConceptEditModel.getType()).thenReturn(null);
-        when(classConceptEditModel.getAgendaCode()).thenReturn(null);
-        when(classConceptEditModel.getAgendaSystemCode()).thenReturn(null);
-        when(classConceptEditModel.getContentType()).thenReturn(null);
-        when(classConceptEditModel.getAcquisitionMethod()).thenReturn(null);
-        when(classConceptEditModel.getSharingMethod()).thenReturn(null);
-        when(classConceptEditModel.getIsPublic()).thenReturn(null);
-        when(classConceptEditModel.getIsInPPDF()).thenReturn(null);
-        when(classConceptEditModel.getBroaderConcept()).thenReturn(null);
-        when(classConceptEditModel.getExactMatch()).thenReturn(null);
-        when(classConceptEditModel.getInTezaurus()).thenReturn(null);
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(conceptIri, classConceptEditModel, model, null));
 
-        ConceptEditor.EditResult result =
-                conceptEditor.editConcept(conceptIri, classConceptEditModel, model, null);
+        // every offending field is named in the message
+        assertTrue(ex.getMessage().contains("definingNonLegalSource"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("relatedNonLegalSource"), ex.getMessage());
 
+        // no mutation occurred — the existing non-legal links are still present
         Resource updated = model.getResource(conceptIri);
-        assertNotNull(result);
-        assertFalse(result.iriChanged);
-        assertEquals(conceptIri, result.newConceptIRI);
-
-        assertFalse(updated.hasProperty(definingProp));
-        assertFalse(updated.hasProperty(relatedProp));
+        assertTrue(updated.hasProperty(definingProp));
+        assertTrue(updated.hasProperty(relatedProp));
+        assertEquals(sizeBefore, model.size(), "rejected edit must not change the model");
     }
 
     // A8 – IRI rename updates object references

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorFieldEdgeCasesTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorFieldEdgeCasesTest.java
@@ -261,7 +261,7 @@ class ConceptEditorFieldEdgeCasesTest {
         seedClass(iri);
         Property instanceDefinedBy = model.createProperty(OFN_NAMESPACE + MA_INSTANCE_DEFINOVANE_CISELNIKEM);
         ClassConceptEditModel m = classModel();
-        m.setCodeListDataset("https://data.gov.cz/dataset/ciselnik-1");
+        m.setCodeListDataset("https://data.gov.cz/zdroj/datové-sady/ciselnik-1");
 
         editor.editConcept(iri, m, model, null);
 

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorFieldEdgeCasesTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorFieldEdgeCasesTest.java
@@ -1,0 +1,326 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.PropertyConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.RelationshipConceptEditModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.dia.constants.VocabularyConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Granular branch coverage for the per-field updaters in ConceptFieldUpdaters,
+ * exercised through ConceptEditor with real edit models. Focus: the
+ * "clear-when-empty", "no-op-when-unchanged", "URI vs literal", and rdf:type
+ * transition branches that the higher-level tests don't all hit.
+ * <p>
+ * Edits keep the prefLabel unchanged so no IRI rename occurs — the concept is
+ * read back from its original IRI.
+ */
+class ConceptEditorFieldEdgeCasesTest {
+
+    private ConceptEditor editor;
+    private Model model;
+
+    @BeforeEach
+    void setUp() {
+        editor = new ConceptEditor();
+        model = ModelFactory.createDefaultModel();
+    }
+
+    private ClassConceptEditModel classModel() {
+        ClassConceptEditModel m = new ClassConceptEditModel();
+        m.setConceptType("TRIDA");
+        return m;
+    }
+
+    private PropertyConceptEditModel propertyModel() {
+        PropertyConceptEditModel m = new PropertyConceptEditModel();
+        m.setConceptType("VLASTNOST");
+        return m;
+    }
+
+    private RelationshipConceptEditModel relationshipModel() {
+        RelationshipConceptEditModel m = new RelationshipConceptEditModel();
+        m.setConceptType("VZTAH");
+        return m;
+    }
+
+    private Resource seedClass(String iri) {
+        Resource r = model.createResource(iri);
+        r.addProperty(SKOS.prefLabel, model.createLiteral("Třída", "cs"));
+        r.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));
+        return r;
+    }
+
+    private Resource seedProperty(String iri) {
+        Resource r = model.createResource(iri);
+        r.addProperty(SKOS.prefLabel, model.createLiteral("Vlastnost", "cs"));
+        r.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + VLASTNOST));
+        return r;
+    }
+
+    // ---- updateClassType: rdf:type subjekt/objekt transitions ----
+
+    @Test
+    void classType_addsTSP_whenNewlySubjekt() {
+        String iri = DEFAULT_NS + "ct-add-tsp";
+        seedClass(iri);
+        ClassConceptEditModel m = classModel();
+        m.setType("Typ subjektu práva");
+
+        editor.editConcept(iri, m, model, null);
+
+        assertTrue(model.getResource(iri).hasProperty(RDF.type, model.getResource(OFN_NAMESPACE + TSP)));
+    }
+
+    @Test
+    void classType_removesTSP_whenNoLongerSubjekt() {
+        String iri = DEFAULT_NS + "ct-remove-tsp";
+        Resource r = seedClass(iri);
+        r.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TSP));
+        ClassConceptEditModel m = classModel();
+        m.setType("Typ objektu práva");   // objekt, not subjekt
+
+        editor.editConcept(iri, m, model, null);
+
+        Resource updated = model.getResource(iri);
+        assertFalse(updated.hasProperty(RDF.type, model.getResource(OFN_NAMESPACE + TSP)),
+                "TSP should be removed when no longer subjekt");
+        assertTrue(updated.hasProperty(RDF.type, model.getResource(OFN_NAMESPACE + TOP)),
+                "TOP should be added for objekt");
+    }
+
+    @Test
+    void classType_noChange_whenStillSubjekt() {
+        String iri = DEFAULT_NS + "ct-noop";
+        Resource r = seedClass(iri);
+        r.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TSP));
+        ClassConceptEditModel m = classModel();
+        m.setType("Typ subjektu práva");   // still subjekt
+
+        editor.editConcept(iri, m, model, null);
+
+        assertTrue(model.getResource(iri).hasProperty(RDF.type, model.getResource(OFN_NAMESPACE + TSP)));
+    }
+
+    @Test
+    void classType_nullType_isNoOp() {
+        String iri = DEFAULT_NS + "ct-null";
+        seedClass(iri);
+        long before = model.size();
+        ClassConceptEditModel m = classModel();
+        m.setType(null);
+
+        editor.editConcept(iri, m, model, null);
+        assertEquals(before, model.size());
+    }
+
+    // ---- updateDomainRange: clear / no-op / URI passthrough ----
+
+    @Test
+    void domain_clearedWhenBlank() {
+        String iri = DEFAULT_NS + "dom-clear";
+        Resource r = seedProperty(iri);
+        r.addProperty(RDFS.domain, model.createResource(DEFAULT_NS + "old-domain"));
+        PropertyConceptEditModel m = propertyModel();
+        m.setDomain("");   // blank → clear
+
+        editor.editConcept(iri, m, model, null);
+        assertFalse(model.getResource(iri).hasProperty(RDFS.domain));
+    }
+
+    @Test
+    void domain_noOpWhenUnchanged() {
+        String iri = DEFAULT_NS + "dom-noop";
+        String domainIri = "https://example.org/Osoba";
+        Resource r = seedProperty(iri);
+        r.addProperty(RDFS.domain, model.createResource(domainIri));
+        long before = model.size();
+        PropertyConceptEditModel m = propertyModel();
+        m.setDomain(domainIri);   // same URI
+
+        editor.editConcept(iri, m, model, null);
+        assertEquals(before, model.size(), "unchanged domain must not restage");
+    }
+
+    @Test
+    void domain_blankWithNoExisting_isNoOp() {
+        String iri = DEFAULT_NS + "dom-blank-none";
+        seedProperty(iri);
+        long before = model.size();
+        PropertyConceptEditModel m = propertyModel();
+        m.setDomain("   ");
+
+        editor.editConcept(iri, m, model, null);
+        assertEquals(before, model.size());
+    }
+
+    // ---- updateDataTypeRange: clear / change ----
+
+    @Test
+    void dataType_clearedWhenBlank() {
+        String iri = DEFAULT_NS + "dt-clear";
+        Resource r = seedProperty(iri);
+        r.addProperty(RDFS.range, model.createResource("http://www.w3.org/2001/XMLSchema#string"));
+        PropertyConceptEditModel m = propertyModel();
+        m.setDataType("");
+
+        editor.editConcept(iri, m, model, null);
+        assertFalse(model.getResource(iri).hasProperty(RDFS.range));
+    }
+
+    // ---- updateBroaderConceptList: clear when emptied ----
+
+    @Test
+    void broaderConcept_clearedWhenEmptyList() {
+        String iri = DEFAULT_NS + "broader-clear";
+        Resource r = seedClass(iri);
+        r.addProperty(RDFS.subClassOf, model.createResource(DEFAULT_NS + "parent"));
+        ClassConceptEditModel m = classModel();
+        m.setBroaderConcept(List.of());   // empty → clear
+
+        editor.editConcept(iri, m, model, null);
+        assertFalse(model.getResource(iri).hasProperty(RDFS.subClassOf));
+    }
+
+    @Test
+    void broaderConcept_noOpWhenUnchanged() {
+        String iri = DEFAULT_NS + "broader-noop";
+        String parent = "https://example.org/Parent";
+        Resource r = seedClass(iri);
+        r.addProperty(RDFS.subClassOf, model.createResource(parent));
+        ClassConceptEditModel m = classModel();
+        m.setBroaderConcept(List.of(parent));
+
+        long before = model.size();
+        editor.editConcept(iri, m, model, null);
+        assertEquals(before, model.size());
+    }
+
+    // ---- updateAgenda / updateAIS: blank clears ----
+
+    @Test
+    void agenda_blankClearsExisting() {
+        String iri = DEFAULT_NS + "agenda-clear";
+        Resource r = seedClass(iri);
+        Property agendaProp = model.createProperty(DEFAULT_NS + AGENDOVY_104 + AGENDA_LONG);
+        r.addProperty(agendaProp, model.createLiteral("A123"));
+        ClassConceptEditModel m = classModel();
+        m.setAgendaCode("");
+
+        editor.editConcept(iri, m, model, null);
+        assertFalse(model.getResource(iri).hasProperty(agendaProp));
+    }
+
+    // ---- updateAgenda / updateAIS: valid value writes the property ----
+
+    @Test
+    void agenda_validValueIsWritten() {
+        String iri = DEFAULT_NS + "agenda-valid";
+        seedClass(iri);
+        Property agendaProp = model.createProperty(DEFAULT_NS + AGENDOVY_104 + AGENDA_LONG);
+        ClassConceptEditModel m = classModel();
+        m.setAgendaCode("A123");   // canonical agenda code
+
+        editor.editConcept(iri, m, model, null);
+
+        assertTrue(model.getResource(iri).hasProperty(agendaProp),
+                "a valid agenda code must be written");
+    }
+
+    @Test
+    void ais_validValueIsWritten() {
+        String iri = DEFAULT_NS + "ais-valid";
+        seedClass(iri);
+        Property aisProp = model.createProperty(DEFAULT_NS + AGENDOVY_104 + UDAJE_AIS);
+        ClassConceptEditModel m = classModel();
+        m.setAgendaSystemCode("5378");   // AIS codes are numeric (^\d+$)
+
+        editor.editConcept(iri, m, model, null);
+
+        assertTrue(model.getResource(iri).hasProperty(aisProp),
+                "a valid AIS code must be written");
+    }
+
+    // ---- updateCodeListDataset: create / clear blank-node structure ----
+
+    @Test
+    void codeListDataset_createsBlankNodeStructure_whenSet() {
+        String iri = DEFAULT_NS + "codelist-create";
+        seedClass(iri);
+        Property instanceDefinedBy = model.createProperty(OFN_NAMESPACE + MA_INSTANCE_DEFINOVANE_CISELNIKEM);
+        ClassConceptEditModel m = classModel();
+        m.setCodeListDataset("https://data.gov.cz/dataset/ciselnik-1");
+
+        editor.editConcept(iri, m, model, null);
+
+        Resource updated = model.getResource(iri);
+        assertTrue(updated.hasProperty(instanceDefinedBy), "code-list link must be created");
+        Resource blankNode = updated.getProperty(instanceDefinedBy).getObject().asResource();
+        Property datasetProp = model.createProperty(OFN_NAMESPACE_LEGAL + MA_V_NKOD_ZASTRESUJICI_DATOVOU_SADU);
+        assertTrue(blankNode.hasProperty(datasetProp), "blank node must carry the dataset URL");
+        assertTrue(blankNode.hasProperty(RDF.type, model.getResource(OFN_NAMESPACE_LEGAL + CISELNIK)),
+                "blank node must be typed as číselník");
+    }
+
+    @Test
+    void codeListDataset_removesExistingStructure_whenBlank() {
+        String iri = DEFAULT_NS + "codelist-clear";
+        Resource r = seedClass(iri);
+        // seed an existing code-list blank-node structure
+        Property instanceDefinedBy = model.createProperty(OFN_NAMESPACE + MA_INSTANCE_DEFINOVANE_CISELNIKEM);
+        Property datasetProp = model.createProperty(OFN_NAMESPACE_LEGAL + MA_V_NKOD_ZASTRESUJICI_DATOVOU_SADU);
+        Resource bn = model.createResource();
+        bn.addProperty(RDF.type, model.getResource(OFN_NAMESPACE_LEGAL + CISELNIK));
+        bn.addProperty(datasetProp, model.createResource("https://data.gov.cz/dataset/old"));
+        r.addProperty(instanceDefinedBy, bn);
+
+        ClassConceptEditModel m = classModel();
+        m.setCodeListDataset("");   // blank → remove structure
+
+        editor.editConcept(iri, m, model, null);
+
+        assertFalse(model.getResource(iri).hasProperty(instanceDefinedBy),
+                "code-list link must be removed");
+        assertFalse(bn.hasProperty(datasetProp), "blank node statements must be removed");
+    }
+
+    @Test
+    void codeListDataset_nullIsNoOp() {
+        String iri = DEFAULT_NS + "codelist-null";
+        seedClass(iri);
+        long before = model.size();
+        ClassConceptEditModel m = classModel();
+        m.setCodeListDataset(null);
+
+        editor.editConcept(iri, m, model, null);
+        assertEquals(before, model.size());
+    }
+
+    // ---- updateSuperPropertyList (relationship superRelation): clear ----
+
+    @Test
+    void superRelation_clearedWhenEmpty() {
+        String iri = DEFAULT_NS + "super-clear";
+        Resource r = model.createResource(iri);
+        r.addProperty(SKOS.prefLabel, model.createLiteral("Vztah", "cs"));
+        r.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + VZTAH));
+        r.addProperty(RDFS.subPropertyOf, model.createResource(DEFAULT_NS + "super"));
+        RelationshipConceptEditModel m = relationshipModel();
+        m.setSuperRelation(List.of());
+
+        editor.editConcept(iri, m, model, null);
+        assertFalse(model.getResource(iri).hasProperty(RDFS.subPropertyOf));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorLanguageMergeTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorLanguageMergeTest.java
@@ -1,0 +1,226 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.models.DescriptionModel;
+import com.dia.ismdtoolbackend.models.NameModel;
+import com.dia.ismdtoolbackend.models.concept.AltNameModel;
+import com.dia.ismdtoolbackend.models.concept.DefinitionModel;
+import com.dia.ismdtoolbackend.enums.ConceptType;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static com.dia.constants.VocabularyConstants.DEFAULT_NS;
+import static com.dia.constants.ExportConstants.Common.DEFAULT_LANG;
+
+/**
+ * Characterization tests that pin the language-map handling asymmetry BEFORE the
+ * ConceptEditor refactor, so the refactor provably preserves it:
+ *
+ *   - prefLabel / description / definition  → MERGE by language tag
+ *     (a single-language edit keeps the other languages)
+ *   - altLabel                              → FULL REPLACE
+ *     (a single-language edit drops the other languages)
+ *   - empty-string value for a tag          → deletes just that tag
+ *   - blank / missing tag                   → falls back to DEFAULT_LANG
+ *
+ * These are intentionally written against current behavior; they must stay green
+ * through every refactor step.
+ */
+class ConceptEditorLanguageMergeTest extends ConceptEditorTestBase {
+
+    private static final Property DC_DESCRIPTION =
+            org.apache.jena.rdf.model.ResourceFactory.createProperty("http://purl.org/dc/terms/description");
+
+    private Map<String, String> langValues(Resource resource, Property property) {
+        Map<String, String> out = new HashMap<>();
+        StmtIterator it = resource.listProperties(property);
+        while (it.hasNext()) {
+            var stmt = it.next();
+            var lit = stmt.getObject().asLiteral();
+            String lang = lit.getLanguage() != null && !lit.getLanguage().isEmpty() ? lit.getLanguage() : DEFAULT_LANG;
+            out.put(lang, lit.getString());
+        }
+        return out;
+    }
+
+    private void stubCommonNull() {
+        lenient().when(classConceptEditModel.getConceptTypeEnum()).thenReturn(ConceptType.TRIDA);
+        lenient().when(classConceptEditModel.getNameModel()).thenReturn(null);
+        lenient().when(classConceptEditModel.getDescriptionModel()).thenReturn(null);
+        lenient().when(classConceptEditModel.getDefinitionModel()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAltNameModel()).thenReturn(null);
+        lenient().when(classConceptEditModel.getDefiningLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getRelatedLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getDefiningNonLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getRelatedNonLegalSource()).thenReturn(null);
+        lenient().when(classConceptEditModel.getExactMatch()).thenReturn(null);
+        lenient().when(classConceptEditModel.getInTezaurus()).thenReturn(null);
+        lenient().when(classConceptEditModel.getType()).thenReturn(null);
+        lenient().when(classConceptEditModel.getPrivacyProvisions()).thenReturn(null);
+        lenient().when(classConceptEditModel.getBroaderConcept()).thenReturn(null);
+        lenient().when(classConceptEditModel.getIsInPPDF()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAgendaCode()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAgendaSystemCode()).thenReturn(null);
+        lenient().when(classConceptEditModel.getSharingMethod()).thenReturn(null);
+        lenient().when(classConceptEditModel.getAcquisitionMethod()).thenReturn(null);
+        lenient().when(classConceptEditModel.getContentType()).thenReturn(null);
+        lenient().when(classConceptEditModel.getIsPublic()).thenReturn(null);
+        lenient().when(classConceptEditModel.getCodeListDataset()).thenReturn(null);
+    }
+
+    private Resource seedBilingual(String iri, Property property) {
+        Resource existing = model.createResource(iri);
+        existing.addProperty(SKOS.prefLabel, model.createLiteral("Jméno", "cs"));
+        existing.addProperty(RDF.type, SKOS.Concept);
+        if (!property.equals(SKOS.prefLabel)) {
+            existing.addProperty(property, model.createLiteral("cs hodnota", "cs"));
+        } else {
+            // prefLabel case: replace the seeded single label with a bilingual pair
+            existing.removeAll(SKOS.prefLabel);
+            existing.addProperty(SKOS.prefLabel, model.createLiteral("cs hodnota", "cs"));
+        }
+        existing.addProperty(property, model.createLiteral("en value", "en"));
+        return existing;
+    }
+
+    // prefLabel MERGE: editing only cs keeps en.
+    // NOTE: changing the cs prefLabel renames the concept IRI, so we read the
+    // merged labels back from the NEW IRI returned by EditResult.
+    @Test
+    void prefLabel_isMergedByLanguage_notReplaced() {
+        String iri = DEFAULT_NS + "merge-name";
+        seedBilingual(iri, SKOS.prefLabel);
+
+        NameModel newName = new NameModel();
+        newName.setName(Map.of("cs", "Nové cs"));
+
+        stubCommonNull();
+        when(classConceptEditModel.getNameModel()).thenReturn(newName);
+
+        ConceptEditor.EditResult res = conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(res.newConceptIRI), SKOS.prefLabel);
+        assertEquals("Nové cs", result.get("cs"), "cs should be updated");
+        assertEquals("en value", result.get("en"), "en must survive the merge");
+        assertEquals(2, result.size());
+    }
+
+    // description MERGE
+    @Test
+    void description_isMergedByLanguage_notReplaced() {
+        String iri = DEFAULT_NS + "merge-desc";
+        seedBilingual(iri, DC_DESCRIPTION);
+
+        DescriptionModel newDesc = new DescriptionModel();
+        newDesc.setDescription(Map.of("cs", "Nový popis"));
+
+        stubCommonNull();
+        when(classConceptEditModel.getDescriptionModel()).thenReturn(newDesc);
+
+        conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(iri), DC_DESCRIPTION);
+        assertEquals("Nový popis", result.get("cs"));
+        assertEquals("en value", result.get("en"), "en description must survive the merge");
+    }
+
+    // definition MERGE
+    @Test
+    void definition_isMergedByLanguage_notReplaced() {
+        String iri = DEFAULT_NS + "merge-def";
+        seedBilingual(iri, SKOS.definition);
+
+        DefinitionModel newDef = new DefinitionModel();
+        newDef.setDefinition(Map.of("cs", "Nová definice"));
+
+        stubCommonNull();
+        when(classConceptEditModel.getDefinitionModel()).thenReturn(newDef);
+
+        conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(iri), SKOS.definition);
+        assertEquals("Nová definice", result.get("cs"));
+        assertEquals("en value", result.get("en"), "en definition must survive the merge");
+    }
+
+    // altLabel FULL REPLACE: editing only cs drops en (the asymmetry)
+    @Test
+    void altLabel_isFullyReplaced_notMerged() {
+        String iri = DEFAULT_NS + "replace-alt";
+        Resource existing = model.createResource(iri);
+        existing.addProperty(SKOS.prefLabel, model.createLiteral("Jméno", "cs"));
+        existing.addProperty(RDF.type, SKOS.Concept);
+        existing.addProperty(SKOS.altLabel, model.createLiteral("cs alt", "cs"));
+        existing.addProperty(SKOS.altLabel, model.createLiteral("en alt", "en"));
+
+        AltNameModel newAlt = new AltNameModel();
+        newAlt.setAltName(Map.of("cs", "Nový alt"));
+
+        stubCommonNull();
+        when(classConceptEditModel.getAltNameModel()).thenReturn(newAlt);
+
+        conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(iri), SKOS.altLabel);
+        assertEquals("Nový alt", result.get("cs"));
+        assertNull(result.get("en"), "en altLabel must be dropped — altLabel is full-replace");
+        assertEquals(1, result.size());
+    }
+
+    // empty-string value for a tag deletes just that tag from a merged field
+    @Test
+    void emptyStringValue_deletesOnlyThatLanguageTag() {
+        String iri = DEFAULT_NS + "merge-name-clear-one";
+        seedBilingual(iri, SKOS.prefLabel);
+
+        NameModel newName = new NameModel();
+        Map<String, String> m = new HashMap<>();
+        m.put("en", "");           // clear en
+        newName.setName(m);
+
+        stubCommonNull();
+        when(classConceptEditModel.getNameModel()).thenReturn(newName);
+
+        conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(iri), SKOS.prefLabel);
+        assertEquals("cs hodnota", result.get("cs"), "cs must remain");
+        assertNull(result.get("en"), "en cleared via empty string");
+        assertEquals(1, result.size());
+    }
+
+    // blank/missing tag falls back to DEFAULT_LANG.
+    // Seed with a non-default language only ("xx") so the assertion holds
+    // regardless of what DEFAULT_LANG resolves to.
+    @Test
+    void blankLanguageTag_fallsBackToDefaultLang() {
+        String iri = DEFAULT_NS + "merge-name-blanktag";
+        Resource existing = model.createResource(iri);
+        existing.addProperty(SKOS.prefLabel, model.createLiteral("Seed", "xx"));
+        existing.addProperty(RDF.type, SKOS.Concept);
+
+        NameModel newName = new NameModel();
+        Map<String, String> m = new HashMap<>();
+        m.put("", "Bez jazyka");   // blank tag
+        newName.setName(m);
+
+        stubCommonNull();
+        when(classConceptEditModel.getNameModel()).thenReturn(newName);
+
+        // Adding a label under DEFAULT_LANG changes the name → IRI rename; read from new IRI.
+        ConceptEditor.EditResult res = conceptEditor.editConcept(iri, classConceptEditModel, model, null);
+
+        Map<String, String> result = langValues(model.getResource(res.newConceptIRI), SKOS.prefLabel);
+        assertEquals("Bez jazyka", result.get(DEFAULT_LANG), "blank tag stored under DEFAULT_LANG");
+        assertEquals("Seed", result.get("xx"), "the non-default seed survives the merge");
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorPrivacyProvisionsTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorPrivacyProvisionsTest.java
@@ -1,0 +1,124 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.enums.ConceptType;
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.dia.constants.VocabularyConstants.*;
+import static org.apache.jena.vocabulary.RDF.type;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression: privacy provisions are carried by ALL concept types (class,
+ * property, relationship) — each can be public/non-public. The create path
+ * (ConceptCreator) already writes them for all three; the edit path previously
+ * only wrote them for class concepts, silently losing provisions on property /
+ * relationship edits. These tests pin that property and relationship edits both
+ * WRITE valid provisions and REJECT invalid ones.
+ */
+class ConceptEditorPrivacyProvisionsTest extends ConceptEditorTestBase {
+
+    private static final String VALID_ELI =
+            "https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2006/187";
+    private static final String INVALID_ELI = "https://example.org/not-eli";
+
+    private Property provisionProp() {
+        return model.createProperty(OFN_NAMESPACE_LEGAL + USTANOVENI_NEVEREJNOST);
+    }
+
+    private Resource seedProperty(String iri) {
+        Resource r = model.createResource(iri);
+        r.addProperty(org.apache.jena.vocabulary.SKOS.prefLabel, model.createLiteral("Vlastnost", "cs"));
+        r.addProperty(type, model.getResource(OFN_NAMESPACE + VLASTNOST));
+        return r;
+    }
+
+    private Resource seedRelationship(String iri) {
+        Resource r = model.createResource(iri);
+        r.addProperty(org.apache.jena.vocabulary.SKOS.prefLabel, model.createLiteral("Vztah", "cs"));
+        r.addProperty(type, model.getResource(OFN_NAMESPACE + VZTAH));
+        return r;
+    }
+
+    @Test
+    void propertyEdit_writesPrivacyProvisions() {
+        String iri = DEFAULT_NS + "prop-priv";
+        seedProperty(iri);
+
+        stubAllPropertyFieldsNull(propertyConceptEditModel);
+        when(propertyConceptEditModel.getPrivacyProvisions()).thenReturn(List.of(VALID_ELI));
+        when(propertyConceptEditModel.getIsPublic()).thenReturn(Boolean.FALSE);
+
+        conceptEditor.editConcept(iri, propertyConceptEditModel, model, null);
+
+        Resource updated = model.getResource(iri);
+        assertTrue(updated.hasProperty(provisionProp(), model.createResource(VALID_ELI)),
+                "property edit must persist the privacy provision IRI");
+    }
+
+    @Test
+    void relationshipEdit_writesPrivacyProvisions() {
+        String iri = DEFAULT_NS + "rel-priv";
+        seedRelationship(iri);
+
+        stubAllRelationshipFieldsNull(relationshipConceptEditModel);
+        when(relationshipConceptEditModel.getPrivacyProvisions()).thenReturn(List.of(VALID_ELI));
+        when(relationshipConceptEditModel.getIsPublic()).thenReturn(Boolean.FALSE);
+
+        conceptEditor.editConcept(iri, relationshipConceptEditModel, model, null);
+
+        Resource updated = model.getResource(iri);
+        assertTrue(updated.hasProperty(provisionProp(), model.createResource(VALID_ELI)),
+                "relationship edit must persist the privacy provision IRI");
+    }
+
+    @Test
+    void propertyEdit_rejectsInvalidPrivacyProvision() {
+        String iri = DEFAULT_NS + "prop-priv-bad";
+        seedProperty(iri);
+        long sizeBefore = model.size();
+
+        lenient().when(propertyConceptEditModel.getConceptTypeEnum()).thenReturn(ConceptType.VLASTNOST);
+        lenient().when(propertyConceptEditModel.getPrivacyProvisions()).thenReturn(List.of(INVALID_ELI));
+        lenient().when(propertyConceptEditModel.getDefiningLegalSource()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getRelatedLegalSource()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getDefiningNonLegalSource()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getRelatedNonLegalSource()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getExactMatch()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getAgendaCode()).thenReturn(null);
+        lenient().when(propertyConceptEditModel.getAgendaSystemCode()).thenReturn(null);
+
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(iri, propertyConceptEditModel, model, null));
+        assertTrue(ex.getMessage().contains("privacyProvisions"), ex.getMessage());
+        assertEquals(sizeBefore, model.size(), "rejected edit must not mutate the model");
+    }
+
+    @Test
+    void relationshipEdit_rejectsInvalidPrivacyProvision() {
+        String iri = DEFAULT_NS + "rel-priv-bad";
+        seedRelationship(iri);
+        long sizeBefore = model.size();
+
+        lenient().when(relationshipConceptEditModel.getConceptTypeEnum()).thenReturn(ConceptType.VZTAH);
+        lenient().when(relationshipConceptEditModel.getPrivacyProvisions()).thenReturn(List.of(INVALID_ELI));
+        lenient().when(relationshipConceptEditModel.getDefiningLegalSource()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getRelatedLegalSource()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getDefiningNonLegalSource()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getRelatedNonLegalSource()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getExactMatch()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getAgendaCode()).thenReturn(null);
+        lenient().when(relationshipConceptEditModel.getAgendaSystemCode()).thenReturn(null);
+
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(iri, relationshipConceptEditModel, model, null));
+        assertTrue(ex.getMessage().contains("privacyProvisions"), ex.getMessage());
+        assertEquals(sizeBefore, model.size(), "rejected edit must not mutate the model");
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorPropertyConceptTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorPropertyConceptTest.java
@@ -65,7 +65,7 @@ class ConceptEditorPropertyConceptTest extends ConceptEditorTestBase {
         when(propertyConceptEditModel.getIsInPPDF()).thenReturn(Boolean.TRUE);
         when(propertyConceptEditModel.getAgendaCode()).thenReturn(null);
         when(propertyConceptEditModel.getAgendaSystemCode()).thenReturn(null);
-        when(propertyConceptEditModel.getContentType()).thenReturn("novy-obsah");
+        when(propertyConceptEditModel.getContentType()).thenReturn("evidenční");
         when(propertyConceptEditModel.getAcquisitionMethod()).thenReturn(null);
         when(propertyConceptEditModel.getSharingMethod()).thenReturn(null);
         when(propertyConceptEditModel.getIsPublic()).thenReturn(null);

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorRelationshipConceptTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorRelationshipConceptTest.java
@@ -79,9 +79,9 @@ class ConceptEditorRelationshipConceptTest extends ConceptEditorTestBase {
         when(relationshipConceptEditModel.getIsInPPDF()).thenReturn(Boolean.TRUE);
         when(relationshipConceptEditModel.getAgendaCode()).thenReturn(null);
         when(relationshipConceptEditModel.getAgendaSystemCode()).thenReturn(null);
-        when(relationshipConceptEditModel.getContentType()).thenReturn("novy-obsah-rel");
-        when(relationshipConceptEditModel.getAcquisitionMethod()).thenReturn("ziskani-rel");
-        when(relationshipConceptEditModel.getSharingMethod()).thenReturn(List.of("sdileni-rel"));
+        when(relationshipConceptEditModel.getContentType()).thenReturn("identifikační");
+        when(relationshipConceptEditModel.getAcquisitionMethod()).thenReturn("jiných agend");
+        when(relationshipConceptEditModel.getSharingMethod()).thenReturn(List.of("poskytované na žádost"));
         when(relationshipConceptEditModel.getIsPublic()).thenReturn(null);
 
         when(relationshipConceptEditModel.getDefiningLegalSource()).thenReturn(null);

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorValidationTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorValidationTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import static com.dia.constants.VocabularyConstants.DEFAULT_NS;
 import static com.dia.constants.VocabularyConstants.OFN_NAMESPACE;
 import static com.dia.constants.VocabularyConstants.TRIDA;
+import static com.dia.constants.VocabularyConstants.VZTAH;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -136,5 +137,62 @@ class ConceptEditorValidationTest {
         m.setInTezaurus(Boolean.TRUE);
         ConceptEditor.EditResult result = conceptEditor.editConcept(conceptIri, m, model, null);
         assertNotNull(result);
+    }
+
+    // ---- domain rules folded in from the (previously unwired) *EditModel.validateSpecificFields ----
+
+    @Test
+    void rejectsPrivacyPublicConflict() {
+        ClassConceptEditModel m = baseModel();
+        m.setIsPublic(Boolean.TRUE);
+        m.setPrivacyProvisions(List.of("https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2006/187"));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("veřejn"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsInvalidCodeListDatasetUrl() {
+        ClassConceptEditModel m = baseModel();
+        m.setCodeListDataset("https://not-nkod.example/dataset/x");
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("NKOD"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsGovernanceValueNotInAllowlist() {
+        ClassConceptEditModel m = baseModel();
+        m.setSharingMethod(List.of("not-a-real-sharing-method"));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("způsob sdílení"), ex.getMessage());
+    }
+
+    @Test
+    void acceptsValidGovernanceValues() {
+        ClassConceptEditModel m = baseModel();
+        m.setSharingMethod(List.of("nesdílené"));
+        m.setAcquisitionMethod("vlastní");
+        m.setContentType("provozní");
+        ConceptEditor.EditResult result = conceptEditor.editConcept(conceptIri, m, model, null);
+        assertNotNull(result);
+    }
+
+    @Test
+    void privacyPublicConflict_appliesToRelationshipToo() {
+        // Verify the rule resolves per-type (Vztah, masculine suffix).
+        Model relModel = ModelFactory.createDefaultModel();
+        String relIri = DEFAULT_NS + "validated-rel";
+        Resource r = relModel.createResource(relIri);
+        r.addProperty(SKOS.prefLabel, relModel.createLiteral("Vztah", "cs"));
+        r.addProperty(RDF.type, relModel.getResource(OFN_NAMESPACE + VZTAH));
+
+        com.dia.ismdtoolbackend.models.concept.RelationshipConceptEditModel m =
+                new com.dia.ismdtoolbackend.models.concept.RelationshipConceptEditModel();
+        m.setConceptType("VZTAH");
+        m.setIsPublic(Boolean.TRUE);
+        m.setPrivacyProvisions(List.of("https://opendata.eselpoint.gov.cz/esel-esb/eli/cz/sb/2006/187"));
+
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(relIri, m, relModel, null));
+        assertTrue(ex.getMessage().contains("veřejn"), ex.getMessage());
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorValidationTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/ConceptEditorValidationTest.java
@@ -1,0 +1,140 @@
+package com.dia.ismdtoolbackend.utility.editor;
+
+import com.dia.ismdtoolbackend.exception.ConceptValidationException;
+import com.dia.ismdtoolbackend.models.concept.ClassConceptEditModel;
+import com.dia.ismdtoolbackend.models.concept.DigitalObjectModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.SKOS;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.dia.constants.VocabularyConstants.DEFAULT_NS;
+import static com.dia.constants.VocabularyConstants.OFN_NAMESPACE;
+import static com.dia.constants.VocabularyConstants.TRIDA;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Strict pre-flight validation: a concept edit that carries any invalid value is
+ * rejected as a whole (ConceptValidationException → HTTP 400), the message names
+ * every offender, and the model is left untouched (no partial write). Empty/blank
+ * values mean "clear" and are NOT rejected.
+ *
+ * <p>Uses real {@link ClassConceptEditModel} instances (not mocks) so the full
+ * field surface is exercised without stubbing ceremony.
+ */
+class ConceptEditorValidationTest {
+
+    private ConceptEditor conceptEditor;
+    private Model model;
+    private String conceptIri;
+
+    @BeforeEach
+    void setUp() {
+        conceptEditor = new ConceptEditor();
+        model = ModelFactory.createDefaultModel();
+        conceptIri = DEFAULT_NS + "validated-class";
+        Resource existing = model.createResource(conceptIri);
+        existing.addProperty(SKOS.prefLabel, model.createLiteral("Pojem", "cs"));
+        existing.addProperty(RDF.type, model.getResource(OFN_NAMESPACE + TRIDA));
+    }
+
+    private ClassConceptEditModel baseModel() {
+        ClassConceptEditModel m = new ClassConceptEditModel();
+        m.setConceptType("TRIDA");
+        return m;
+    }
+
+    private ConceptValidationException editExpectingRejection(ClassConceptEditModel m) {
+        long sizeBefore = model.size();
+        ConceptValidationException ex = assertThrows(ConceptValidationException.class, () ->
+                conceptEditor.editConcept(conceptIri, m, model, null));
+        assertEquals(sizeBefore, model.size(), "rejected edit must not mutate the model");
+        return ex;
+    }
+
+    @Test
+    void rejectsInvalidExactMatchIri() {
+        ClassConceptEditModel m = baseModel();
+        m.setExactMatch(List.of("not-an-iri"));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("exactMatch"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsNonCanonicalEliInDefiningLegalSource() {
+        ClassConceptEditModel m = baseModel();
+        m.setDefiningLegalSource(List.of("https://example.org/not-eli"));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("definingLegalSource"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsNonCanonicalEliInPrivacyProvisions() {
+        ClassConceptEditModel m = baseModel();
+        m.setPrivacyProvisions(List.of("https://example.org/not-eli"));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("privacyProvisions"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsBlankAndInvalidNonLegalUrls() {
+        ClassConceptEditModel m = baseModel();
+        m.setDefiningNonLegalSource(List.of(new DigitalObjectModel("Doc", "Popis", "")));
+        m.setRelatedNonLegalSource(List.of(new DigitalObjectModel("Doc2", "Popis", "not a url")));
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("definingNonLegalSource"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("relatedNonLegalSource"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsInvalidAgendaAndAisCodes() {
+        ClassConceptEditModel m = baseModel();
+        m.setAgendaCode("not-a-valid-agenda");
+        m.setAgendaSystemCode("not-a-valid-ais");
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("agendaCode"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("agendaSystemCode"), ex.getMessage());
+    }
+
+    @Test
+    void reportsAllOffendersInOneMessage() {
+        ClassConceptEditModel m = baseModel();
+        m.setExactMatch(List.of("bad-iri"));
+        m.setDefiningLegalSource(List.of("https://example.org/not-eli"));
+        m.setAgendaCode("bad-agenda");
+        ConceptValidationException ex = editExpectingRejection(m);
+        assertTrue(ex.getMessage().contains("exactMatch"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("definingLegalSource"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("agendaCode"), ex.getMessage());
+    }
+
+    @Test
+    void emptyValuesMeanClear_notRejected() {
+        // Empty list / blank string = "clear this field". Must NOT be rejected.
+        ClassConceptEditModel m = baseModel();
+        m.setExactMatch(List.of());
+        m.setDefiningLegalSource(List.of());
+        m.setAgendaCode("");
+        m.setAgendaSystemCode("   ");
+        m.setPrivacyProvisions(List.of());
+
+        // Should succeed (no exception), leaving a valid concept.
+        ConceptEditor.EditResult result = conceptEditor.editConcept(conceptIri, m, model, null);
+        assertNotNull(result);
+        assertFalse(result.iriChanged);
+    }
+
+    @Test
+    void validEdit_isAccepted() {
+        // A clean edit with no invalid inputs passes validation and applies.
+        ClassConceptEditModel m = baseModel();
+        m.setInTezaurus(Boolean.TRUE);
+        ConceptEditor.EditResult result = conceptEditor.editConcept(conceptIri, m, model, null);
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
Summary

  Breaks up the ConceptEditor class into focused, single-responsibility collaborators, closes concept validation test gaps (returning honest 400s), and closes real bugs surfaced along the way. Behavior-preserving where intended; the validation changes are deliberate and called out below.

  Why

  ConceptEditor performed stateful RDF model mutations, transaction management, IRI regeneration, and per-field updates all in one class. It was hard to read and test at the property level with real validation test gaps.
  
  What changed

  Decomposition (behavior-preserving) — ConceptEditor 1021 → 205 lines:
  - ConceptIriFactory — IRI / namespace / governance-IRI generation
  - ConceptFieldUpdaters — the ~25 per-field RDF updaters
  - ConceptTypeEditor + Class/Property/Relationship implementations — per-type edit sequences
  - RdfLangValues — shared RDF read/staging helpers (also de-duplicates OntologyEditor)
  - Collapsed the triplicated language-map merge logic into one helper; deleted dead code (EditContext.existingStatements/iriChanged); renamed misleading updateGovernancePropertyList → updateSharingMethodList
  
  Validation (intentional behavior change):
  - Invalid input is rejected up front with HTTP 400 listing every offender (no partial write), replacing the old silent warn-and-drop. New ConceptEditValidator.
  - Folded in the ConceptValidationUtil rules (privacy/public conflict, governance allowlist, NKOD code-list URL) that *EditModel.validateSpecificFields() declared. Coverage on those rules went 0% → 100%.
  - Removed the now-dead validateSpecificFields() from all 6 models + both abstract bases; models are now pure data classes.

  Bug fixes:
  - Privacy provisions are now written on property and relationship edits (previously only class concepts — silent data loss).
  - OntologyEditor no longer swallows exception cause/message on edit failure.

  Tests

  - New: ConceptEditorLanguageMergeTest, ConceptEditorValidationTest, ConceptEditorFieldEdgeCasesTest, ConceptEditorPrivacyProvisionsTest, ConceptEditFlowIntegrationTest (real service+editor+validator wired together).
  - ConceptFieldUpdaters branch coverage 66% → 76%; ConceptValidationUtil 0% → 93%.
  - Updated existing tests that used placeholder governance values (valid only while the rule was dormant) and the now-contradictory isPublic=true + provisions case (now asserts rejection).
