### PR TITLE
unresolving range fix

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
+++ b/src/main/java/com/dia/ismdtoolbackend/repository/JenaTDB2Repository.java
@@ -647,19 +647,23 @@ public class JenaTDB2Repository {
 
     /**
      * Returns the triples describing every property/relationship across ALL local
-     * graphs whose {@code rdfs:domain} is {@code conceptIri} — i.e. the members
-     * that point <em>at</em> this concept. Merged into the concept's own graph by
-     * the detail pipeline so the class-detail read
+     * graphs whose {@code rdfs:domain} <em>or</em> {@code rdfs:range} is {@code conceptIri}
+     * — i.e. the members that point <em>at</em> this concept. Merged into the concept's
+     * own graph by the detail pipeline so the class-detail read
      * ({@link com.dia.ismdtoolbackend.utility.detail.OntologyDetailExtractor#extractConceptPropertiesFromModel})
-     * sees properties that live in a different vocabulary graph than the class.
+     * sees members that live in a different vocabulary graph than the class.
      *
      * <p>The class-detail read fetches only the class's own named graph, so a
-     * cross-vocabulary {@code property rdfs:domain class} edge (the property living
-     * in graph A, the class in graph B) was invisible from the class side even
-     * though the property's own detail showed it. This closes that asymmetry.
+     * cross-vocabulary {@code member rdfs:domain class} (or {@code rdfs:range}) edge
+     * (the member living in graph A, the class in graph B) was invisible from the
+     * class side even though the member's own detail showed it. This closes that
+     * asymmetry. Range is matched too: a vztah whose range is this class would
+     * otherwise never surface on the class detail.
      *
      * <p>Returns exactly the triples the extractor reads off each member resource:
      * {@code rdf:type}, {@code skos:prefLabel}, {@code rdfs:domain}, {@code rdfs:range}.
+     * The member's actual domain/range edges are constructed (not the match edge), so a
+     * range-matched member still carries its own domain, and vice versa.
      */
     public Model fetchExternalDomainMembers(String conceptIri) {
         if (!SparqlIriValidator.isSafeHttpIri(conceptIri)) {
@@ -667,8 +671,8 @@ public class JenaTDB2Repository {
             return ModelFactory.createDefaultModel();
         }
         return executor.execute(
-                "fetching cross-graph domain members for " + conceptIri,
-                "Failed to fetch cross-graph domain members",
+                "fetching cross-graph domain/range members for " + conceptIri,
+                "Failed to fetch cross-graph domain/range members",
                 conn -> {
                     ParameterizedSparqlString pss = new ParameterizedSparqlString();
                     pss.append("PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ");
@@ -676,19 +680,20 @@ public class JenaTDB2Repository {
                     pss.append("PREFIX skos: <http://www.w3.org/2004/02/skos/core#> ");
                     pss.append("CONSTRUCT { ");
                     pss.append("  ?member rdf:type ?type . ");
-                    pss.append("  ?member rdfs:domain ?concept . ");
+                    pss.append("  ?member rdfs:domain ?domain . ");
                     pss.append("  ?member skos:prefLabel ?label . ");
                     pss.append("  ?member rdfs:range ?range . ");
                     pss.append("} WHERE { GRAPH ?g { ");
-                    pss.append("  ?member rdfs:domain ?concept . ");
+                    pss.append("  { ?member rdfs:domain ?concept } UNION { ?member rdfs:range ?concept } ");
                     pss.append("  ?member rdf:type ?type . ");
                     pss.append("  OPTIONAL { ?member skos:prefLabel ?label } ");
+                    pss.append("  OPTIONAL { ?member rdfs:domain ?domain } ");
                     pss.append("  OPTIONAL { ?member rdfs:range ?range } ");
                     pss.append("} }");
                     pss.setIri("concept", conceptIri);
                     try (QueryExecution qExec = conn.query(pss.asQuery())) {
                         Model result = qExec.execConstruct();
-                        log.debug("Fetched {} cross-graph domain-member triples for {}",
+                        log.debug("Fetched {} cross-graph domain/range-member triples for {}",
                                 result.size(), conceptIri);
                         return result;
                     }

--- a/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractor.java
@@ -238,7 +238,10 @@ public class OntologyDetailExtractor {
                 Object domainObj = conceptMap.get(DEFINICNI_OBOR);
                 String domain = domainObj instanceof String ? (String) domainObj : null;
 
-                if (conceptIri.equals(domain)) {
+                Object rangeObj = conceptMap.get(OBOR_HODNOT);
+                String range = rangeObj instanceof String ? (String) rangeObj : null;
+
+                if (conceptIri.equals(domain) || conceptIri.equals(range)) {
                     ConceptRelationshipsModel relationshipModel = new ConceptRelationshipsModel();
 
                     Map<String, String> nameMap = coerceToStringMap(conceptMap.get(NAZEV), relationshipIri, NAZEV);
@@ -263,14 +266,13 @@ public class OntologyDetailExtractor {
         Resource conceptResource = ontModel.getResource(conceptIri);
         Resource vztahType = ontModel.getResource(OFN_NAMESPACE + VZTAH);
 
-        ResIterator relationshipIterator = ontModel.listSubjectsWithProperty(
-            org.apache.jena.vocabulary.RDFS.domain,
-            conceptResource
-        );
+        Set<Resource> relationshipResources = new LinkedHashSet<>();
+        ontModel.listSubjectsWithProperty(org.apache.jena.vocabulary.RDFS.domain, conceptResource)
+                .forEachRemaining(relationshipResources::add);
+        ontModel.listSubjectsWithProperty(org.apache.jena.vocabulary.RDFS.range, conceptResource)
+                .forEachRemaining(relationshipResources::add);
 
-        while (relationshipIterator.hasNext()) {
-            Resource relationshipResource = relationshipIterator.next();
-
+        for (Resource relationshipResource : relationshipResources) {
             if (relationshipResource.hasProperty(ResourceFactory.createProperty(
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"), vztahType)) {
 

--- a/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorCrossGraphTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorCrossGraphTest.java
@@ -53,6 +53,8 @@ class OntologyDetailExtractorCrossGraphTest {
         extractor = new OntologyDetailExtractor(conceptMetadataRepository);
     }
 
+    private static final String RANGE_RELATIONSHIP_IRI = "https://example.org/vocab-b/pojem/má-bydliště";
+
     @Test
     void classDetail_includesCrossGraphPropertyAndRelationship() {
         Model model = buildPostMergeModel();
@@ -67,6 +69,58 @@ class OntologyDetailExtractorCrossGraphTest {
         assertThat(classDetail.getConceptRelationships())
                 .as("cross-graph relationship must surface on the class detail")
                 .anySatisfy(r -> assertThat(r.getIri()).isEqualTo(EXTERNAL_RELATIONSHIP_IRI));
+    }
+
+    /**
+     * A class is the {@code rdfs:range} (not the domain) of a relationship — that relationship
+     * must still surface on the class detail. Regression for the bug where a class only ever
+     * listed relationships where it was the domain, so a range-target class showed nothing.
+     */
+    @Test
+    void classDetail_includesRelationshipWhereClassIsRange() {
+        Model model = buildPostMergeModel();
+
+        // A relationship whose RANGE is the class (domain points elsewhere).
+        Resource vztahType = model.createResource(OFN_NAMESPACE + VZTAH);
+        Resource otherClass = model.createResource("https://example.org/vocab-b/pojem/adresa");
+        Resource rangeRel = model.createResource(RANGE_RELATIONSHIP_IRI);
+        rangeRel.addProperty(RDF.type, vztahType);
+        rangeRel.addProperty(SKOS.prefLabel, "má bydliště", "cs");
+        rangeRel.addProperty(RDFS.domain, otherClass);
+        rangeRel.addProperty(RDFS.range, model.createResource(CLASS_IRI));
+
+        OntologyDetailModel.ConceptDetailModel classDetail =
+                extractor.extractConceptDetail(model, CLASS_IRI, iri -> null);
+
+        assertThat(classDetail).isNotNull();
+        assertThat(classDetail.getConceptRelationships())
+                .as("a relationship whose range is the class must surface on the class detail")
+                .anySatisfy(r -> assertThat(r.getIri()).isEqualTo(RANGE_RELATIONSHIP_IRI));
+    }
+
+    /**
+     * A relationship that points BOTH its domain and range at the same class is listed once
+     * (deduped on IRI), not twice.
+     */
+    @Test
+    void classDetail_dedupesRelationshipWithClassAsBothDomainAndRange() {
+        Model model = buildPostMergeModel();
+
+        Resource vztahType = model.createResource(OFN_NAMESPACE + VZTAH);
+        Resource reflexive = model.createResource("https://example.org/vocab-b/pojem/zná");
+        reflexive.addProperty(RDF.type, vztahType);
+        reflexive.addProperty(SKOS.prefLabel, "zná", "cs");
+        reflexive.addProperty(RDFS.domain, model.createResource(CLASS_IRI));
+        reflexive.addProperty(RDFS.range, model.createResource(CLASS_IRI));
+
+        OntologyDetailModel.ConceptDetailModel classDetail =
+                extractor.extractConceptDetail(model, CLASS_IRI, iri -> null);
+
+        assertThat(classDetail).isNotNull();
+        assertThat(classDetail.getConceptRelationships())
+                .filteredOn(r -> "https://example.org/vocab-b/pojem/zná".equals(r.getIri()))
+                .as("a domain==range relationship must appear exactly once")
+                .hasSize(1);
     }
 
     /**

--- a/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorRangeResolutionTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/detail/OntologyDetailExtractorRangeResolutionTest.java
@@ -235,6 +235,28 @@ class OntologyDetailExtractorRangeResolutionTest {
                 .isEqualTo(new DataTypeDto("Literal", "Text"));
     }
 
+    /**
+     * The {@code bydlí-na} relationship has domain=osoba, range=adresa. The RANGE class
+     * (adresa) must list that relationship — regression for the bug where a class only
+     * surfaced relationships where it was the domain. Exercises the ConceptData (JSON) path.
+     */
+    @Test
+    void conceptDataPath_rangeClass_listsRelationshipWhereItIsRange() {
+        Model model = buildModel();
+
+        OntologyDetailModel detail = extractor.extractOntologyDetail(
+                model, OntologyDetailExtractor.iriResolver());
+
+        OntologyDetailModel.ConceptDetailModel rangeClass = detail.getConcepts().stream()
+                .filter(c -> OTHER_CLASS_IRI.equals(c.getIri()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("range class concept not extracted"));
+
+        assertThat(rangeClass.getConceptRelationships())
+                .as("the range class must list the relationship whose range is it")
+                .anySatisfy(r -> assertThat(r.getIri()).isEqualTo(REL_IRI));
+    }
+
     // ── helpers ──
 
     private OntologyDetailModel.ConceptDetailModel getClassConcept(OntologyDetailModel detail) {


### PR DESCRIPTION
Summary

Fixed class detail now resolves range-incoming relationships

  Root cause: a class only listed VZTAH concepts where it was the rdfs:domain; range-incoming edges were never resolved

  Three sites changed:

  1. OntologyDetailExtractor.extractConceptRelationships (JSON path — whole-ontology detail): now matches conceptIri == domain OR == range (reads OBOR_HODNOT).
  2. OntologyDetailExtractor.extractConceptRelationshipsFromModel (model path — single-concept detail: now iterates both RDFS.domain and RDFS.range subjects, deduped via LinkedHashSet so a domain==range vztah appears once.
  3. JenaTDB2Repository.fetchExternalDomainMembers (cross-graph hop): WHERE clause changed to { ?member rdfs:domain ?concept } UNION { ?member rdfs:range ?concept }, mirroring the already-correct findRelatedConceptUris. The CONSTRUCT now emits the member's own domain/range edges (via OPTIONAL binds) rather than hardcoding the match edge, so a range-matched member still carries its actual domain.