### PR TITLE
ci: fix Trivy dev-scan trigger and tune Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,30 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Scheduled version-update PRs open against dev for review before reaching main.
+    # NOTE: security updates always target the default branch and ignore this.
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
     registries:
       - validator-packages
+    # One grouped PR per run instead of a separate PR per dependency.
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
+
+  # Watches action versions pinned in .github/workflows/ (actions/checkout, etc.).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,14 +8,14 @@ name: Trivy Image Scan
 #   main branch -> ghcr.io/datagov-cz/ismd-tool-backend:latest        (deployed to test + prod)
 #
 # Triggers:
-#   * After "Build Docker on Dev"  completes -> scan dev image
+#   * After "Build Dev Branch"  completes -> scan dev image
 #   * After "Build Docker on Main" completes -> scan main image
 #   * Weekly Monday 07:00 UTC               -> scan BOTH (CVE-feed drift)
 #   * Manual dispatch                        -> pick dev/main/both
 
 on:
   workflow_run:
-    workflows: ["Build Docker on Dev", "Build Docker on Main"]
+    workflows: ["Build Dev Branch", "Build Docker on Main"]
     types: [completed]
   schedule:
     - cron: '0 7 * * 1'
@@ -42,7 +42,7 @@ jobs:
   scan-dev:
     name: Scan dev image
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Docker on Dev' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Build Dev Branch' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && (inputs.image_variant == 'dev' || inputs.image_variant == 'both'))
     uses: datagov-cz/ismd-infrastructure/.github/workflows/trivy-reusable.yml@dev


### PR DESCRIPTION
### Fix Trivy dev image scan trigger
The `trivy.yml` `workflow_run` trigger referenced a workflow named
`"Build Docker on Dev"`, but the actual workflow is named `"Build Dev Branch"`.
The name mismatch meant the dev image scan never fired after a dev build.
Corrected the name in both the `workflow_run.workflows` list and the
`scan-dev` job condition.

### Tune Dependabot config
Updated `.github/dependabot.yml`:
- Route scheduled maven version-update PRs to `dev` (`target-branch`) so they're
  reviewed before reaching main. Security updates still target the default branch.
- Group updates into one PR per run instead of one per dependency.
- Add a **github-actions** ecosystem to keep workflow action versions current.

## Notes
- Dependabot only activates once the config reaches the default branch (main),
  via the usual dev → main promotion.