### PR TITLE
Feat/validator integration consolidation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <ismd-validator-common.version>1.0.16</ismd-validator-common.version>
+        <ismd-validator-common.version>1.0.17</ismd-validator-common.version>
         <jena.version>5.4.0</jena.version>
         <jacoco.version>0.8.15</jacoco.version>
         <jacoco.line.minimum>0.55</jacoco.line.minimum>

--- a/src/main/java/com/dia/ismdtoolbackend/client/ValidationClient.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/ValidationClient.java
@@ -1,100 +1,126 @@
 package com.dia.ismdtoolbackend.client;
 
 import com.dia.dto.CatalogRecordDto;
+import com.dia.ismdtoolbackend.client.validation.ValidationCallExecutor;
+import com.dia.ismdtoolbackend.config.ValidationServiceConfig;
 import com.dia.ismdtoolbackend.controller.dto.CatalogRecordRequestDto;
 import com.dia.ismdtoolbackend.controller.dto.ValidationRequestDto;
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
 import com.dia.validation.ValidationReport;
 import com.dia.validation.ValidationReportDto;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
 
 import java.util.Optional;
 
+/**
+ * Client for the externally-deployed ISMD validator. All calls go through
+ * {@link ValidationCallExecutor}, which applies the connect/read timeouts (via the dedicated
+ * {@code validationRestClient}), a circuit breaker, and the unavailable-vs-rejected exception
+ * mapping. Two surfaces:
+ * <ul>
+ *   <li>{@link #requestValidation} — STRICT: propagates 503 (validator down) / 400 (validator
+ *       rejected the input) so the blocking {@code /validate} endpoint surfaces the real cause.</li>
+ *   <li>{@link #requestValidationLenient} — LENIENT: returns empty on any failure, for the
+ *       advisory upload path that must never block ingest.</li>
+ * </ul>
+ */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class ValidationClient {
 
-    @Value("${validation.service.url}")
-    private String validationServiceUrl;
+    private final String validationServiceUrl;
+    private final RestClient validationRestClient;
+    private final ValidationCallExecutor callExecutor;
 
-    private final RestClient restClient;
+    public ValidationClient(ValidationServiceConfig validationServiceConfig,
+                            RestClient validationRestClient,
+                            ValidationCallExecutor callExecutor) {
+        this.validationServiceUrl = validationServiceConfig.getUrl();
+        this.validationRestClient = validationRestClient;
+        this.callExecutor = callExecutor;
+    }
 
+    /**
+     * Validate an ontology, propagating typed failures: a validator outage surfaces as
+     * {@link ValidationServiceUnavailableException} (503); a validator rejection (4xx) surfaces
+     * as {@code OntologyValidationException} (400) carrying the validator's own message. For the
+     * blocking {@code /validate} endpoint.
+     *
+     * @return the report (present even when the validator returns an empty/2xx body would yield
+     *         null — see {@link Optional#empty()} for that defensive case)
+     */
     public Optional<ValidationReport> requestValidation(String ttlContent, String iri) {
-        try {
-            log.debug("Requesting TTL validation for ontology: {}", iri);
+        validateInputs(ttlContent, iri);
+        log.debug("Requesting TTL validation for ontology: {}", iri);
 
-            if (ttlContent == null || ttlContent.trim().isEmpty()) {
-                throw new IllegalArgumentException("TTL obsah nesmí být prázdný");
-            }
+        ValidationReportDto response = callExecutor.strict("validation of " + iri,
+                () -> postValidate(ttlContent, iri));
 
-            if (iri == null || iri.trim().isEmpty()) {
-                throw new IllegalArgumentException("IRI slovníku nesmí být prázdné");
-            }
+        if (response != null) {
+            log.info("Validation completed for ontology {}", iri);
+            return Optional.of(response);
+        }
+        return Optional.empty();
+    }
 
-            ValidationRequestDto requestDto = new ValidationRequestDto(ttlContent, iri);
+    /**
+     * Advisory validation for the upload path: returns empty on ANY validator failure (down or
+     * rejection) so a validator problem never blocks ontology ingest. The breaker still observes
+     * outages. Input-precondition failures still throw (they are caller bugs, not validator state).
+     */
+    public Optional<ValidationReport> requestValidationLenient(String ttlContent, String iri) {
+        validateInputs(ttlContent, iri);
+        log.debug("Requesting advisory TTL validation for ontology: {}", iri);
 
-            ValidationReportDto response = restClient.post()
-                    .uri(validationServiceUrl + "/api/validator/validate")
-                    .header("Content-Type", "application/json")
-                    .body(requestDto)
-                    .retrieve()
-                    .body(ValidationReportDto.class);
+        ValidationReportDto response = callExecutor.lenient("upload validation of " + iri,
+                () -> postValidate(ttlContent, iri), null);
 
-            if (response != null) {
-                log.info("Validation completed for ontology {}", iri);
-                return Optional.of(response);
-            }
+        return Optional.ofNullable(response);
+    }
 
-            return Optional.empty();
+    private ValidationReportDto postValidate(String ttlContent, String iri) {
+        ValidationRequestDto requestDto = new ValidationRequestDto(ttlContent, iri);
+        return validationRestClient.post()
+                .uri(validationServiceUrl + "/api/validator/validate")
+                .header("Content-Type", "application/json")
+                .body(requestDto)
+                .retrieve()
+                .body(ValidationReportDto.class);
+    }
 
-        } catch (RestClientException e) {
-            log.warn("Validation service unavailable for ontology {}: {}", iri, e.getMessage());
-            return Optional.empty();
-        } catch (Exception e) {
-            log.error("Unexpected error during validation for ontology {}: {}", iri, e.getMessage(), e);
-            return Optional.empty();
+    private void validateInputs(String ttlContent, String iri) {
+        if (ttlContent == null || ttlContent.trim().isEmpty()) {
+            throw new IllegalArgumentException("TTL obsah nesmí být prázdný");
+        }
+        if (iri == null || iri.trim().isEmpty()) {
+            throw new IllegalArgumentException("IRI slovníku nesmí být prázdné");
         }
     }
 
     public Optional<CatalogRecordDto> requestCatalogRecord(CatalogRecordRequestDto requestDto) {
-        try {
-            String iri = requestDto.getValidationReport().getOntologyIri();
-            log.debug("Requesting catalog record for ontology: {}", iri);
-            String ttlContent = requestDto.getTtlContent();
-
-            if (ttlContent == null || ttlContent.trim().isEmpty()) {
-                throw new IllegalArgumentException("TTL obsah nesmí být prázdný");
-            }
-
-            if (requestDto.getValidationReport() == null) {
-                throw new IllegalArgumentException("Zpráva z kontroly nesmí být prázdná");
-            }
-
-            CatalogRecordDto response = restClient.post()
-                    .uri(validationServiceUrl + "/api/validator/catalog-record")
-                    .header("Content-Type", "application/json")
-                    .body(requestDto)
-                    .retrieve()
-                    .body(CatalogRecordDto.class);
-
-            if (response != null) {
-                log.info("Catalog record request completed for ontology {}", iri);
-                return Optional.of(response);
-            }
-
-            return Optional.empty();
-
-        } catch (RestClientException e) {
-            log.warn("Validation service unavailable for ontology {}", e.getMessage());
-            return Optional.empty();
-        } catch (Exception e) {
-            log.error("Unexpected error during catalog record request for ontology {}", e.getMessage(), e);
-            return Optional.empty();
+        if (requestDto.getValidationReport() == null) {
+            throw new IllegalArgumentException("Zpráva z kontroly nesmí být prázdná");
         }
+        String ttlContent = requestDto.getTtlContent();
+        if (ttlContent == null || ttlContent.trim().isEmpty()) {
+            throw new IllegalArgumentException("TTL obsah nesmí být prázdný");
+        }
+
+        String iri = requestDto.getValidationReport().getOntologyIri();
+        log.debug("Requesting catalog record for ontology: {}", iri);
+
+        // Best-effort (lenient): a validator problem must not fail the caller. Routes through
+        // the same timed client + breaker as validation.
+        CatalogRecordDto response = callExecutor.lenient("catalog record for " + iri, () ->
+                validationRestClient.post()
+                        .uri(validationServiceUrl + "/api/validator/catalog-record")
+                        .header("Content-Type", "application/json")
+                        .body(requestDto)
+                        .retrieve()
+                        .body(CatalogRecordDto.class), null);
+
+        return Optional.ofNullable(response);
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCallExecutor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCallExecutor.java
@@ -1,0 +1,92 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import com.dia.ismdtoolbackend.config.ValidationServiceConfig;
+import com.dia.ismdtoolbackend.exception.OntologyValidationException;
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+
+import java.util.function.Supplier;
+
+/**
+ * Single call path for the external validator. Wraps a {@link Supplier} with a circuit breaker and
+ * classifies failures into two distinct outcomes:
+ *
+ * <ul>
+ *   <li><strong>Unavailable</strong> — connect/read timeout, connection refused, 5xx, or an
+ *       otherwise unusable response → {@link ValidationServiceUnavailableException} (HTTP 503),
+ *       counted by the breaker. The validator is down or broken.</li>
+ *   <li><strong>Rejected</strong> — the validator answered with a 4xx (e.g. malformed TTL) →
+ *       {@link OntologyValidationException} (HTTP 400) carrying the validator's own message.</li>
+ * </ul>
+ *
+ * <p>{@link #strict} propagates these typed exceptions (used by the blocking {@code /validate}
+ * endpoint). {@link #lenient} swallows any failure and returns a fallback after logging (used
+ * by the advisory upload path, which must never block ingest).
+ */
+@Slf4j
+@Component
+public class ValidationCallExecutor {
+
+    private static final String ENDPOINT_LABEL = "Validační služba";
+
+    private final ValidationCircuitBreaker breaker;
+    private final ValidatorErrorMessageExtractor errorExtractor;
+
+    public ValidationCallExecutor(ValidationServiceConfig config) {
+        this.breaker = new ValidationCircuitBreaker(
+                ENDPOINT_LABEL,
+                config.getBreaker().getFailureThreshold(),
+                config.getBreaker().getCooldown().toMillis());
+        this.errorExtractor = new ValidatorErrorMessageExtractor();
+    }
+
+    /**
+     * Run {@code action} through the breaker, mapping low-level failures to typed exceptions.
+     * A 4xx from the validator becomes a 400 ({@link OntologyValidationException}); anything
+     * indicating the validator is down/unusable becomes a 503
+     * ({@link ValidationServiceUnavailableException}).
+     */
+    public <T> T strict(String label, Supplier<T> action) {
+        return breaker.call(() -> {
+            try {
+                return action.get();
+            } catch (HttpClientErrorException e) {
+                String message = errorExtractor.extract(e);
+                log.warn("Validator rejected {}: {}", label, message);
+                throw new OntologyValidationException(message);
+            } catch (HttpServerErrorException e) {
+                throw unavailable(label + " — validator returned " + e.getStatusCode(), e);
+            } catch (ResourceAccessException e) {
+                throw unavailable(label + " — validator unreachable: " + e.getMessage(), e);
+            } catch (RestClientException e) {
+                throw unavailable(label + " — validator call failed: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    /**
+     * Run {@code action}; on ANY failure log a warning and return {@code fallback}. The breaker
+     * still observes unavailability (a swallowed outage still trips it for the strict path), but
+     * the caller never sees an exception. For the advisory upload path.
+     */
+    public <T> T lenient(String label, Supplier<T> action, T fallback) {
+        try {
+            return strict(label, action);
+        } catch (OntologyValidationException e) {
+            log.warn("Validator rejected {} (advisory, ignored): {}", label, e.getMessage());
+            return fallback;
+        } catch (ValidationServiceUnavailableException e) {
+            log.warn("Validator unavailable for {} (advisory, ignored): {}", label, e.getMessage());
+            return fallback;
+        }
+    }
+
+    private ValidationServiceUnavailableException unavailable(String message, Throwable cause) {
+        return new ValidationServiceUnavailableException(ENDPOINT_LABEL, message, cause);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreaker.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreaker.java
@@ -54,6 +54,15 @@ public final class ValidationCircuitBreaker {
                 throw new ValidationServiceUnavailableException(endpointLabel,
                         endpointLabel + " circuit breaker open (last failure " + elapsed + "ms ago)");
             }
+            // Cooldown expired → half-open. Elect exactly ONE trial caller: the thread that
+            // wins this CAS advances openedAt to now (so any concurrent threads see a fresh
+            // open window and fast-fail above), then runs the single trial. Losers fall through
+            // to the fast-fail on their next read. Without this, every thread that crossed the
+            // cooldown boundary would hit a possibly-still-dead validator at once.
+            if (!openedAt.compareAndSet(openSince, System.currentTimeMillis())) {
+                throw new ValidationServiceUnavailableException(endpointLabel,
+                        endpointLabel + " circuit breaker open (trial in progress)");
+            }
         }
         try {
             T result = action.get();

--- a/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreaker.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreaker.java
@@ -1,0 +1,97 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Per-service circuit breaker for validator calls - kept a separate type so the validator path trips only on
+ * {@link ValidationServiceUnavailableException}.
+ *
+ * <p>Three states implicit in two fields ({@code consecutiveFailures}, {@code openedAt}):
+ * <ul>
+ *   <li><strong>Closed</strong> — calls flow through; failures increment a counter.</li>
+ *   <li><strong>Open</strong> — after {@link #failureThreshold} consecutive failures, calls
+ *       fail fast for {@link #cooldownMillis}.</li>
+ *   <li><strong>Half-open</strong> (implicit) — once cooldown expires, one trial call passes
+ *       through. Success closes the breaker; failure re-opens it for another cooldown window.</li>
+ * </ul>
+ *
+ * <p>Only {@link ValidationServiceUnavailableException} counts as a failure — a validator 4xx
+ * rejection ({@code OntologyValidationException}) propagates untouched and does not trip the
+ * breaker.
+ *
+ * <p>Stateful, thread-safe.
+ */
+@Slf4j
+public final class ValidationCircuitBreaker {
+
+    private final String endpointLabel;
+    private final int failureThreshold;
+    private final long cooldownMillis;
+
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final AtomicLong openedAt = new AtomicLong(0);
+
+    public ValidationCircuitBreaker(String endpointLabel, int failureThreshold, long cooldownMillis) {
+        this.endpointLabel = endpointLabel;
+        this.failureThreshold = failureThreshold;
+        this.cooldownMillis = cooldownMillis;
+    }
+
+    /**
+     * Execute {@code action}, with circuit-breaker fast-fail when the validator has been failing
+     * recently. Only {@link ValidationServiceUnavailableException} counts toward the threshold.
+     */
+    public <T> T call(Supplier<T> action) {
+        long openSince = openedAt.get();
+        if (openSince > 0) {
+            long elapsed = System.currentTimeMillis() - openSince;
+            if (elapsed < cooldownMillis) {
+                throw new ValidationServiceUnavailableException(endpointLabel,
+                        endpointLabel + " circuit breaker open (last failure " + elapsed + "ms ago)");
+            }
+        }
+        try {
+            T result = action.get();
+            onSuccess();
+            return result;
+        } catch (ValidationServiceUnavailableException e) {
+            onFailure();
+            throw e;
+        }
+    }
+
+    private void onSuccess() {
+        if (openedAt.getAndSet(0) > 0) {
+            log.info("{} circuit breaker closed after successful call.", endpointLabel);
+        }
+        consecutiveFailures.set(0);
+    }
+
+    private void onFailure() {
+        int failures = consecutiveFailures.incrementAndGet();
+        if (failures < failureThreshold) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long prev = openedAt.getAndSet(now);
+        if (prev == 0) {
+            log.warn("{} circuit breaker opened after {} consecutive failures (cooldown {}ms).",
+                    endpointLabel, failures, cooldownMillis);
+        } else {
+            log.warn("{} circuit breaker stays open (trial call failed; cooldown extended by {}ms).",
+                    endpointLabel, cooldownMillis);
+        }
+    }
+
+    // Visible for testing
+    boolean isOpen() {
+        long openSince = openedAt.get();
+        if (openSince == 0) return false;
+        return System.currentTimeMillis() - openSince < cooldownMillis;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractor.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.client.validation;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.dia.validation.ValidatorErrorResponse;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.client.HttpClientErrorException;
@@ -9,22 +10,21 @@ import org.springframework.web.client.HttpClientErrorException;
  * Pulls a readable reason out of the validator's 4xx error body so the tool can surface
  * the validator's <em>own</em> message instead of a generic rejection.
  *
- * <p>The validator returns a structured body {@code {error, message, timestamp, requestId}}.
- * We read the {@code message} field loosely (no shared type yet) and <strong>fall back to the
- * raw body string</strong> when the body is absent or not the expected shape.
+ * <p>The validator returns the shared {@link ValidatorErrorResponse} body
+ * ({@code {error, message, timestamp, requestId}}). We deserialize that type and read its
+ * {@code message}, falling back to the <strong>raw body string</strong> when the body is absent,
+ * not that shape (e.g. an HTML page from a reverse proxy), or carries no usable message.
  *
- * <p>The shared {@code com.dia.validation.ValidatorErrorResponse} (added on the validator's feat
- * branch) has the same {@code message} field this reads, so this works unchanged once that lands
- * in a released {@code ismd-validator-common}. The optional follow-up is to deserialize that type
- * directly instead of reading the {@code message} node loosely; the raw-body fallback keeps the
- * tool independent of the release either way.
+ * <p>The raw-body fallback keeps the tool independent of the validator's release: even if the
+ * error contract drifts, the caller still gets the original body rather than a crash.
  */
 @Slf4j
 class ValidatorErrorMessageExtractor {
 
     private static final String FALLBACK = "Validační služba odmítla požadavek.";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     String extract(HttpClientErrorException e) {
         String body = e.getResponseBodyAsString();
@@ -32,10 +32,10 @@ class ValidatorErrorMessageExtractor {
             return FALLBACK;
         }
         try {
-            JsonNode root = objectMapper.readTree(body);
-            JsonNode message = root.get("message");
-            if (message != null && message.isTextual() && !message.asText().isBlank()) {
-                return message.asText();
+            ValidatorErrorResponse parsed = objectMapper.readValue(body, ValidatorErrorResponse.class);
+            String message = parsed.getMessage();
+            if (message != null && !message.isBlank()) {
+                return message;
             }
         } catch (Exception parseError) {
             log.debug("Validator error body was not the expected JSON shape; using raw body. {}",

--- a/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractor.java
@@ -1,0 +1,46 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Pulls a readable reason out of the validator's 4xx error body so the tool can surface
+ * the validator's <em>own</em> message instead of a generic rejection.
+ *
+ * <p>The validator returns a structured body {@code {error, message, timestamp, requestId}}.
+ * We read the {@code message} field loosely (no shared type yet) and <strong>fall back to the
+ * raw body string</strong> when the body is absent or not the expected shape.
+ *
+ * <p>The shared {@code com.dia.validation.ValidatorErrorResponse} (added on the validator's feat
+ * branch) has the same {@code message} field this reads, so this works unchanged once that lands
+ * in a released {@code ismd-validator-common}. The optional follow-up is to deserialize that type
+ * directly instead of reading the {@code message} node loosely; the raw-body fallback keeps the
+ * tool independent of the release either way.
+ */
+@Slf4j
+class ValidatorErrorMessageExtractor {
+
+    private static final String FALLBACK = "Validační služba odmítla požadavek.";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    String extract(HttpClientErrorException e) {
+        String body = e.getResponseBodyAsString();
+        if (body.isBlank()) {
+            return FALLBACK;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode message = root.get("message");
+            if (message != null && message.isTextual() && !message.asText().isBlank()) {
+                return message.asText();
+            }
+        } catch (Exception parseError) {
+            log.debug("Validator error body was not the expected JSON shape; using raw body. {}",
+                    parseError.getMessage());
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/GlobalExceptionHandler.java
@@ -224,6 +224,13 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDto.error(e.getEndpointLabel() + " data nejsou momentálně dostupná."));
     }
 
+    @ExceptionHandler(ValidationServiceUnavailableException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleValidationServiceUnavailable(ValidationServiceUnavailableException e) {
+        log.error("{} unavailable: {}", e.getEndpointLabel(), e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponseDto.error(e.getEndpointLabel() + " není momentálně dostupná."));
+    }
+
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponseDto<Void>> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
         log.warn("Type mismatch for parameter '{}': value='{}'", e.getName(), e.getValue());

--- a/src/main/java/com/dia/ismdtoolbackend/config/RestClientConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/RestClientConfig.java
@@ -2,7 +2,10 @@ package com.dia.ismdtoolbackend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
 
 @Configuration
 public class RestClientConfig {
@@ -10,6 +13,24 @@ public class RestClientConfig {
     @Bean
     public RestClient restClient() {
         return RestClient.builder()
+                .build();
+    }
+
+    /**
+     * Dedicated client for the external validator, with explicit connect/read timeouts so a
+     * slow or hung validator can never block a tool request thread. Kept separate from the
+     * shared {@link #restClient()} bean so validator timeouts are isolated from any other
+     * HTTP caller — mirroring the per-endpoint isolation of the SPARQL layer.
+     */
+    @Bean
+    public RestClient validationRestClient(ValidationServiceConfig config) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(config.getConnectTimeout())
+                .build();
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(config.getReadTimeout());
+        return RestClient.builder()
+                .requestFactory(requestFactory)
                 .build();
     }
 }

--- a/src/main/java/com/dia/ismdtoolbackend/config/ValidationServiceConfig.java
+++ b/src/main/java/com/dia/ismdtoolbackend/config/ValidationServiceConfig.java
@@ -1,0 +1,44 @@
+package com.dia.ismdtoolbackend.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * Configuration for the external ISMD validator integration. The validator is deployed
+ * separately (its own repo and lifecycle), so the tool treats it as untrusted-availability
+ * infrastructure — explicit timeouts and a circuit breaker keep a slow or dead validator
+ * from blocking the tool, mirroring the SPARQL-client robustness layer.
+ *
+ * <p>Bound to {@code validation.service.*}. Distinct from {@code ValidationConfig}
+ * ({@code validation.rules.*}), which carries an unrelated download flag.
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "validation.service")
+public class ValidationServiceConfig {
+
+    /** Base URL of the validator service (includes its context path, e.g. {@code .../validujeme}). */
+    private String url = "";
+
+    /** TCP connect timeout for validator calls. */
+    private Duration connectTimeout = Duration.ofSeconds(5);
+
+    /**
+     * Read timeout for validator calls. Deliberately above the validator's own 10s SHACL cap
+     * so a legitimately slow-but-working validation completes; only a true hang trips it.
+     */
+    private Duration readTimeout = Duration.ofSeconds(15);
+
+    private Breaker breaker = new Breaker();
+
+    @Data
+    public static class Breaker {
+        /** Consecutive unavailable-failures before the breaker opens. */
+        private int failureThreshold = 5;
+        /** How long the breaker stays open before letting a trial call through. */
+        private Duration cooldown = Duration.ofSeconds(30);
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
+++ b/src/main/java/com/dia/ismdtoolbackend/controller/OntologyController.java
@@ -15,6 +15,7 @@ import com.dia.ismdtoolbackend.controller.dto.ResolvedConceptDto;
 import com.dia.ismdtoolbackend.enums.NormalizeMode;
 import com.dia.ismdtoolbackend.enums.SearchSource;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
 import com.dia.ismdtoolbackend.models.OntologyCreateModel;
 import com.dia.ismdtoolbackend.models.OntologyDetailModel;
 import com.dia.ismdtoolbackend.models.OntologyEditModel;
@@ -304,14 +305,15 @@ public class OntologyController {
         log.info("Ontology validation requested, slug: {}, ontologyIRI: {}", slug, ontologyMetadata.getGraphName());
 
         String ttlContent = ontologyService.getTtlContentFromOntology(ontologyMetadata);
+
         Optional<ValidationReport> validationReport = validationClient.requestValidation(ttlContent, ontologyMetadata.getGraphName());
 
         ValidationReport report = validationReport.orElseThrow(() -> {
             log.warn("Validation report not received for ontology: {}", ontologyMetadata.getGraphName());
-            return new OntologyValidationException("Validace se nezdařila - validační služba nevrátila odpověď.");
+            return new ValidationServiceUnavailableException("Validační služba",
+                    "Validační služba nevrátila odpověď.");
         });
-        validationService.saveValidationReport(validationReport.get(), ontologyMetadata, securityUser.getUserId());
-
+        validationService.saveValidationReport(report, ontologyMetadata, securityUser.getUserId());
 
         return ResponseEntity.ok().body(ApiResponseDto.success(report, "Validace proběhla úspěšně."));
     }

--- a/src/main/java/com/dia/ismdtoolbackend/entity/OntologyMetadataEntity.java
+++ b/src/main/java/com/dia/ismdtoolbackend/entity/OntologyMetadataEntity.java
@@ -1,5 +1,6 @@
 package com.dia.ismdtoolbackend.entity;
 
+import com.dia.ismdtoolbackend.enums.OntologyValidationStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +37,15 @@ public class OntologyMetadataEntity {
 
     @Column(name = "is_published")
     private Boolean isPublished;
+
+    /** Outcome of the most recent validation; null until the ontology is first validated. */
+    @Column(name = "last_validation_status")
+    @Enumerated(EnumType.STRING)
+    private OntologyValidationStatus lastValidationStatus;
+
+    /** When validation status was last set. */
+    @Column(name = "last_validation_at", columnDefinition = "timestamptz")
+    private Instant lastValidationAt;
 
     @JsonIgnore
     @OneToMany(mappedBy = "ontologyMetadata", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/dia/ismdtoolbackend/enums/OntologyValidationStatus.java
+++ b/src/main/java/com/dia/ismdtoolbackend/enums/OntologyValidationStatus.java
@@ -1,0 +1,19 @@
+package com.dia.ismdtoolbackend.enums;
+
+/**
+ * The outcome of the most recent validation attempt for an ontology. Lets the FE distinguish
+ * "validated" from "never validated because the validator was unavailable at upload" and offer
+ * a manual re-validation in the latter case — the tool ingests the ontology regardless of
+ * validator availability.
+ */
+public enum OntologyValidationStatus {
+
+    /** The validator evaluated the ontology (the report itself carries any findings). */
+    VALIDATED,
+
+    /** Upload-time validation was skipped because the validator was unavailable; re-run manually. */
+    SKIPPED_UNAVAILABLE,
+
+    /** A validation attempt failed for a reason other than plain unavailability. */
+    FAILED
+}

--- a/src/main/java/com/dia/ismdtoolbackend/exception/ValidationServiceUnavailableException.java
+++ b/src/main/java/com/dia/ismdtoolbackend/exception/ValidationServiceUnavailableException.java
@@ -1,0 +1,33 @@
+package com.dia.ismdtoolbackend.exception;
+
+import lombok.Getter;
+
+/**
+ * The external validator service is unreachable, timing out, returning a 5xx, or returning
+ * a body we can't use. Mapped to HTTP 503 by
+ * {@link com.dia.ismdtoolbackend.config.GlobalExceptionHandler}.
+ *
+ * <p>Distinct from {@link OntologyValidationException} (HTTP 400), which the validator path
+ * uses when the validator <em>answered</em> with a 4xx rejection (e.g. malformed TTL) — that
+ * is a client-input problem, not an outage. This separation lets the tool surface "validator
+ * is down" (503, retryable) differently from "your ontology was rejected" (400, with the
+ * validator's own reason), and lets the circuit breaker count only genuine outages.
+ *
+ * <p>The validator-flavoured analogue of {@link SparqlEndpointUnavailableException}; kept a
+ * separate type so no SPARQL-named exception leaks into the validator integration.
+ */
+@Getter
+public class ValidationServiceUnavailableException extends RuntimeException {
+
+    private final String endpointLabel;
+
+    public ValidationServiceUnavailableException(String endpointLabel, String message) {
+        super(message);
+        this.endpointLabel = endpointLabel;
+    }
+
+    public ValidationServiceUnavailableException(String endpointLabel, String message, Throwable cause) {
+        super(message, cause);
+        this.endpointLabel = endpointLabel;
+    }
+}

--- a/src/main/java/com/dia/ismdtoolbackend/models/OntologyMetadataModel.java
+++ b/src/main/java/com/dia/ismdtoolbackend/models/OntologyMetadataModel.java
@@ -1,10 +1,13 @@
 package com.dia.ismdtoolbackend.models;
 
+import com.dia.ismdtoolbackend.enums.OntologyValidationStatus;
 import com.dia.ismdtoolbackend.models.concept.ConceptMetadataModel;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,4 +27,15 @@ public class OntologyMetadataModel {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Integer conceptCount;
+
+    /**
+     * Outcome of the most recent validation; null until first validated. Lets the FE badge an
+     * ontology whose upload-time validation was skipped (validator down) and offer a manual
+     * re-validation. {@code NON_NULL} so existing payloads are unchanged.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private OntologyValidationStatus lastValidationStatus;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Instant lastValidationAt;
 }

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
@@ -14,6 +14,7 @@ import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.entity.ValidationReportEntity;
 import com.dia.ismdtoolbackend.enums.ConceptType;
+import com.dia.ismdtoolbackend.enums.OntologyValidationStatus;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.models.UserModel;
 import com.dia.ismdtoolbackend.exception.OntologyAlreadyExistsException;
@@ -47,6 +48,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -219,24 +221,37 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
                 log.warn("Ontology metadata not found for graph name: {}", iri);
                 return;
             }
+            OntologyMetadataEntity ontology = ontologyOpt.get();
 
-            Optional<ValidationReportEntity> validationReportOpt = validationReportRepository.findByOntologyMetadataId(ontologyOpt.get().getId());
+            Optional<ValidationReportEntity> validationReportOpt = validationReportRepository.findByOntologyMetadataId(ontology.getId());
             validationReportOpt.ifPresent(validationReportRepository::delete);
 
-            Optional<ValidationReport> report = validationClient.requestValidation(ontologyContent, iri);
+            // Advisory (lenient): a validator outage must never block upload. An empty result
+            // means the validator was unavailable — record SKIPPED_UNAVAILABLE so the FE can
+            // surface it and offer a manual re-validation; the ontology is ingested regardless.
+            Optional<ValidationReport> report = validationClient.requestValidationLenient(ontologyContent, iri);
             if (report.isPresent()) {
                 ValidationReportEntity validationReportEntity = new ValidationReportEntity();
                 validationReportEntity.setId(report.get().getId());
                 validationReportEntity.setTimestamp(report.get().getTimestamp());
-                validationReportEntity.setOntologyMetadataId(ontologyOpt.get().getId());
-                validationReportEntity.setGetOntologyIri(ontologyOpt.get().getGraphName());
+                validationReportEntity.setOntologyMetadataId(ontology.getId());
+                validationReportEntity.setGetOntologyIri(ontology.getGraphName());
                 String validationResults = validationReportEntity.convertResultsToJson(report.get().getResults());
                 validationReportEntity.setResultsJson(validationResults);
                 validationReportRepository.save(validationReportEntity);
+                markValidationStatus(ontology, OntologyValidationStatus.VALIDATED);
+            } else {
+                markValidationStatus(ontology, OntologyValidationStatus.SKIPPED_UNAVAILABLE);
             }
         } catch (Exception e) {
             log.warn("Validation failed for ontology {}: {}", iri, e.getMessage(), e);
         }
+    }
+
+    private void markValidationStatus(OntologyMetadataEntity ontology, OntologyValidationStatus status) {
+        ontology.setLastValidationStatus(status);
+        ontology.setLastValidationAt(Instant.now());
+        ontologyMetadataRepository.save(ontology);
     }
 
     private String determineGraphName(OntModel model) {

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyUploadServiceImpl.java
@@ -28,8 +28,10 @@ import com.dia.utility.UtilityMethods;
 import com.dia.validation.ValidationReport;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.util.unit.DataSize;
 import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
@@ -72,6 +74,18 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
     private final ValidationReportRepository validationReportRepository;
     private final JenaTDB2Repository jenaTDB2Repository;
     private final PublishedResourceUtil deviationChecker;
+
+    /**
+     * Self-reference to the Spring proxy. The async validation runs from a {@code runAsync} lambda,
+     * which captures {@code this} directly — a plain call to {@code saveValidationOutcome} would
+     * bypass the proxy and its {@code @Transactional} would be inert. Calling through the proxy
+     * makes the report-save + status-mark a single atomic unit. {@code @Lazy} field injection (not
+     * a constructor arg) resolves to a lazy proxy AFTER construction, breaking the self-cycle that
+     * a {@code final} constructor parameter would otherwise form.
+     */
+    @Lazy
+    @Autowired
+    private OntologyUploadServiceImpl self;
 
     @Value("${spring.servlet.multipart.max-file-size:10MB}")
     private String maxFileSizeConfig;
@@ -202,7 +216,7 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
 
             String ontologyContent = convertOntModelToTtl(finalModel);
             CompletableFuture.runAsync(() ->
-                    requestAndSaveValidationReport(ontologyContent, graphName)
+                    self.requestAndSaveValidationReport(ontologyContent, graphName)
             ).exceptionally(ex -> {
                 log.error("Async validation failed for ontology: {}", graphName, ex);
                 return null;
@@ -214,37 +228,54 @@ public class OntologyUploadServiceImpl implements OntologyUploadService {
         }
     }
 
+    /**
+     * Advisory post-upload validation: calls the validator (lenient — a validator outage must never
+     * block ingest) and then persists the outcome. The HTTP call is deliberately OUTSIDE any DB
+     * transaction so a slow/hung validator never holds a pooled connection; only the persistence is
+     * transactional, via {@link #saveValidationOutcome} through the proxy ({@link #self}).
+     */
     public void requestAndSaveValidationReport(String ontologyContent, String iri) {
+        // Lenient client swallows outages/rejections and returns empty — never throws here.
+        Optional<ValidationReport> report = validationClient.requestValidationLenient(ontologyContent, iri);
         try {
-            Optional<OntologyMetadataEntity> ontologyOpt = ontologyMetadataRepository.findByGraphName(iri);
-            if (ontologyOpt.isEmpty()) {
-                log.warn("Ontology metadata not found for graph name: {}", iri);
-                return;
-            }
-            OntologyMetadataEntity ontology = ontologyOpt.get();
-
-            Optional<ValidationReportEntity> validationReportOpt = validationReportRepository.findByOntologyMetadataId(ontology.getId());
-            validationReportOpt.ifPresent(validationReportRepository::delete);
-
-            // Advisory (lenient): a validator outage must never block upload. An empty result
-            // means the validator was unavailable — record SKIPPED_UNAVAILABLE so the FE can
-            // surface it and offer a manual re-validation; the ontology is ingested regardless.
-            Optional<ValidationReport> report = validationClient.requestValidationLenient(ontologyContent, iri);
-            if (report.isPresent()) {
-                ValidationReportEntity validationReportEntity = new ValidationReportEntity();
-                validationReportEntity.setId(report.get().getId());
-                validationReportEntity.setTimestamp(report.get().getTimestamp());
-                validationReportEntity.setOntologyMetadataId(ontology.getId());
-                validationReportEntity.setGetOntologyIri(ontology.getGraphName());
-                String validationResults = validationReportEntity.convertResultsToJson(report.get().getResults());
-                validationReportEntity.setResultsJson(validationResults);
-                validationReportRepository.save(validationReportEntity);
-                markValidationStatus(ontology, OntologyValidationStatus.VALIDATED);
-            } else {
-                markValidationStatus(ontology, OntologyValidationStatus.SKIPPED_UNAVAILABLE);
-            }
+            self.saveValidationOutcome(iri, report.orElse(null));
         } catch (Exception e) {
-            log.warn("Validation failed for ontology {}: {}", iri, e.getMessage(), e);
+            log.warn("Persisting validation outcome failed for ontology {}: {}", iri, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Atomically persists the validation outcome: deletes any prior report, saves the new one (if
+     * the validator answered), and marks {@code last_validation_status}. {@code @Transactional} so
+     * the whole sequence commits or rolls back together — never a saved report without a status, or
+     * a status without its report. {@code report == null} means the validator was unavailable →
+     * {@code SKIPPED_UNAVAILABLE} (the ontology is ingested regardless). Public + invoked via the
+     * proxy ({@link #self}) so the annotation is honoured from the async lambda.
+     */
+    @Transactional
+    public void saveValidationOutcome(String iri, ValidationReport report) {
+        Optional<OntologyMetadataEntity> ontologyOpt = ontologyMetadataRepository.findByGraphName(iri);
+        if (ontologyOpt.isEmpty()) {
+            log.warn("Ontology metadata not found for graph name: {}", iri);
+            return;
+        }
+        OntologyMetadataEntity ontology = ontologyOpt.get();
+
+        Optional<ValidationReportEntity> validationReportOpt = validationReportRepository.findByOntologyMetadataId(ontology.getId());
+        validationReportOpt.ifPresent(validationReportRepository::delete);
+
+        if (report != null) {
+            ValidationReportEntity validationReportEntity = new ValidationReportEntity();
+            validationReportEntity.setId(report.getId());
+            validationReportEntity.setTimestamp(report.getTimestamp());
+            validationReportEntity.setOntologyMetadataId(ontology.getId());
+            validationReportEntity.setGetOntologyIri(ontology.getGraphName());
+            String validationResults = validationReportEntity.convertResultsToJson(report.getResults());
+            validationReportEntity.setResultsJson(validationResults);
+            validationReportRepository.save(validationReportEntity);
+            markValidationStatus(ontology, OntologyValidationStatus.VALIDATED);
+        } else {
+            markValidationStatus(ontology, OntologyValidationStatus.SKIPPED_UNAVAILABLE);
         }
     }
 

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/ValidationServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/ValidationServiceImpl.java
@@ -1,8 +1,10 @@
 package com.dia.ismdtoolbackend.service.impl;
 
 import com.dia.ismdtoolbackend.entity.ValidationReportEntity;
+import com.dia.ismdtoolbackend.enums.OntologyValidationStatus;
 import com.dia.ismdtoolbackend.exception.ValidationException;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
+import com.dia.ismdtoolbackend.repository.OntologyMetadataRepository;
 import com.dia.ismdtoolbackend.repository.ValidationReportRepository;
 import com.dia.ismdtoolbackend.service.ValidationService;
 import com.dia.validation.ValidationReport;
@@ -12,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Optional;
 
 @Service
@@ -20,6 +23,7 @@ import java.util.Optional;
 public class ValidationServiceImpl implements ValidationService {
 
     private final ValidationReportRepository validationReportRepository;
+    private final OntologyMetadataRepository ontologyMetadataRepository;
 
     @Override
     @Transactional
@@ -37,9 +41,21 @@ public class ValidationServiceImpl implements ValidationService {
             String validationResults = validationReportEntity.convertResultsToJson(validationReport.getResults());
             validationReportEntity.setResultsJson(validationResults);
             validationReportRepository.save(validationReportEntity);
+
+            // A successful save means the validator evaluated the ontology — clear any prior
+            // SKIPPED_UNAVAILABLE so a manual re-validation un-flags it.
+            markValidated(ontologyMetadataModel.getId());
         } catch (Exception e) {
             throw new ValidationException("Během ukládání zprávy z kontroly došlo k chybě", e);
         }
+    }
+
+    private void markValidated(Long ontologyMetadataId) {
+        ontologyMetadataRepository.findById(ontologyMetadataId).ifPresent(ontology -> {
+            ontology.setLastValidationStatus(OntologyValidationStatus.VALIDATED);
+            ontology.setLastValidationAt(Instant.now());
+            ontologyMetadataRepository.save(ontology);
+        });
     }
 
     @Override

--- a/src/main/resources/db/changelog/v1/009-add-ontology-validation-status.yaml
+++ b/src/main/resources/db/changelog/v1/009-add-ontology-validation-status.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 009-add-ontology-validation-status
+      author: richard.koubek
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: ontologies
+                columnName: last_validation_status
+                schemaName: ismd_schema
+      changes:
+        - addColumn:
+            schemaName: ismd_schema
+            tableName: ontologies
+            columns:
+              # Whether the ontology was validated, and if not, why — so the FE can badge an
+              # ontology whose upload-time validation was skipped because the validator was down,
+              # and offer a manual re-validation. Nullable: pre-existing rows have no status.
+              - column:
+                  name: last_validation_status
+                  type: VARCHAR(50)
+              - column:
+                  name: last_validation_at
+                  type: TIMESTAMP WITH TIME ZONE

--- a/src/test/java/com/dia/ismdtoolbackend/client/ValidationClientTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/ValidationClientTest.java
@@ -1,6 +1,10 @@
 package com.dia.ismdtoolbackend.client;
 
+import com.dia.ismdtoolbackend.client.validation.ValidationCallExecutor;
+import com.dia.ismdtoolbackend.config.ValidationServiceConfig;
 import com.dia.ismdtoolbackend.controller.dto.ValidationRequestDto;
+import com.dia.ismdtoolbackend.exception.OntologyValidationException;
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
 import com.dia.validation.ValidationReport;
 import com.dia.validation.ValidationReportDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,30 +16,37 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.stream.Stream;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.client.RestClientException;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * The reworked client routes every call through {@link ValidationCallExecutor}. A REAL executor
+ * (with a generous breaker so a single failure never opens it) is used so these tests exercise
+ * the actual exception mapping. The {@code validationRestClient} is mocked to drive the wire.
+ *
+ * <p>Key contract change vs the old client: the STRICT path now PROPAGATES typed exceptions
+ * (503 unavailable / 400 rejection) instead of collapsing everything to {@code Optional.empty()};
+ * only the LENIENT path swallows.
+ */
 @ExtendWith(MockitoExtension.class)
 class ValidationClientTest {
 
     @Mock
-    private RestClient restClient;
-
+    private RestClient validationRestClient;
     @Mock
     private RestClient.RequestBodyUriSpec requestBodyUriSpec;
-
     @Mock
     private RestClient.RequestBodySpec requestBodySpec;
-
     @Mock
     private RestClient.ResponseSpec responseSpec;
 
@@ -45,208 +56,157 @@ class ValidationClientTest {
 
     @BeforeEach
     void setUp() {
-        validationClient = new ValidationClient(restClient);
-        ReflectionTestUtils.setField(validationClient, "validationServiceUrl", validationServiceUrl);
+        ValidationServiceConfig config = new ValidationServiceConfig();
+        config.setUrl(validationServiceUrl);
+        // High threshold so individual failure tests never trip the breaker.
+        config.getBreaker().setFailureThreshold(1000);
+        ValidationCallExecutor executor = new ValidationCallExecutor(config);
+        validationClient = new ValidationClient(config, validationRestClient, executor);
     }
 
-    // ========== Success Scenarios ==========
-
-    @Test
-    void testRequestValidation_Success() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
-
-        ValidationReportDto mockReport = mock(ValidationReportDto.class);
-
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
+    private void stubChain() {
+        when(validationRestClient.post()).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
         when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
         when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    // ========== Success ==========
+
+    @Test
+    void requestValidation_success_returnsReport() {
+        ValidationReportDto mockReport = mock(ValidationReportDto.class);
+        stubChain();
         when(responseSpec.body(ValidationReportDto.class)).thenReturn(mockReport);
 
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
+        Optional<ValidationReport> result = validationClient.requestValidation("@prefix x: <x> .", "http://example.org/ontology");
 
-        // Assert
         assertTrue(result.isPresent());
         assertEquals(mockReport, result.get());
-
-        // Verify the URI was constructed correctly
         verify(requestBodyUriSpec).uri(validationServiceUrl + "/api/validator/validate");
         verify(requestBodySpec).header("Content-Type", "application/json");
     }
 
     @Test
-    void testRequestValidation_VerifyRequestBody() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
-
+    void requestValidation_sendsCorrectBody() {
         ValidationReportDto mockReport = mock(ValidationReportDto.class);
-        ArgumentCaptor<ValidationRequestDto> requestCaptor = ArgumentCaptor.forClass(ValidationRequestDto.class);
-
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
+        ArgumentCaptor<ValidationRequestDto> captor = ArgumentCaptor.forClass(ValidationRequestDto.class);
+        when(validationRestClient.post()).thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
         when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(requestCaptor.capture())).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(captor.capture())).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
         when(responseSpec.body(ValidationReportDto.class)).thenReturn(mockReport);
 
-        // Act
-        validationClient.requestValidation(ttlContent, iri);
+        validationClient.requestValidation("@prefix x: <x> .", "http://example.org/ontology");
 
-        // Assert
-        ValidationRequestDto capturedRequest = requestCaptor.getValue();
-        assertNotNull(capturedRequest);
-        assertEquals(ttlContent, capturedRequest.getOntologyContent());
-        assertEquals(iri, capturedRequest.getIri());
+        ValidationRequestDto sent = captor.getValue();
+        assertEquals("@prefix x: <x> .", sent.getOntologyContent());
+        assertEquals("http://example.org/ontology", sent.getIri());
     }
 
-    // ========== Null Response Scenario ==========
-
     @Test
-    void testRequestValidation_NullResponse() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
-
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+    void requestValidation_nullBody_returnsEmpty() {
+        stubChain();
         when(responseSpec.body(ValidationReportDto.class)).thenReturn(null);
 
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
+        Optional<ValidationReport> result = validationClient.requestValidation("@prefix x: <x> .", "http://example.org/ontology");
 
-        // Assert
         assertFalse(result.isPresent());
     }
 
-    // ========== Error Scenarios ==========
+    // ========== Strict path: distinct failure types ==========
 
     @Test
-    void testRequestValidation_RestClientException() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
+    void requestValidation_validatorDown_throwsUnavailable() {
+        stubChain();
+        when(responseSpec.body(ValidationReportDto.class))
+                .thenThrow(new ResourceAccessException("Connection refused"));
 
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenThrow(new RestClientException("Connection refused"));
-
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
-
-        // Assert
-        assertFalse(result.isPresent());
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> validationClient.requestValidation("@prefix x: <x> .", "http://example.org/ontology"));
     }
 
     @Test
-    void testRequestValidation_ServiceUnavailable() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
+    void requestValidation_validator5xx_throwsUnavailable() {
+        stubChain();
+        when(responseSpec.body(ValidationReportDto.class))
+                .thenThrow(HttpServerErrorException.create(HttpStatus.INTERNAL_SERVER_ERROR, "err", null, null, null));
 
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenThrow(new RestClientException("Service unavailable"));
-
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
-
-        // Assert
-        assertFalse(result.isPresent());
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> validationClient.requestValidation("@prefix x: <x> .", "http://example.org/ontology"));
     }
 
     @Test
-    void testRequestValidation_UnexpectedException() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
+    void requestValidation_validator4xx_throwsRejectionWithValidatorMessage() {
+        stubChain();
+        String body = "{\"error\":\"Bad Request\",\"message\":\"Invalid TTL syntax: line 3\"}";
+        when(responseSpec.body(ValidationReportDto.class))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request",
+                        null, body.getBytes(), null));
 
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenThrow(new RuntimeException("Unexpected error"));
+        OntologyValidationException ex = assertThrows(OntologyValidationException.class,
+                () -> validationClient.requestValidation("bad ttl", "http://example.org/ontology"));
+        assertTrue(ex.getMessage().contains("Invalid TTL syntax"),
+                "should surface the validator's own message, was: " + ex.getMessage());
+    }
 
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
+    // ========== Lenient (upload) path: swallows everything ==========
 
-        // Assert
+    @Test
+    void requestValidationLenient_validatorDown_returnsEmpty() {
+        stubChain();
+        when(responseSpec.body(ValidationReportDto.class))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        Optional<ValidationReport> result =
+                validationClient.requestValidationLenient("@prefix x: <x> .", "http://example.org/ontology");
+
         assertFalse(result.isPresent());
     }
 
     @Test
-    void testRequestValidation_NullPointerException() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .";
-        String iri = "http://example.org/ontology";
+    void requestValidationLenient_validatorRejected_returnsEmpty() {
+        stubChain();
+        when(responseSpec.body(ValidationReportDto.class))
+                .thenThrow(HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request",
+                        null, "{\"message\":\"bad\"}".getBytes(), null));
 
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenThrow(new NullPointerException("Null pointer"));
+        Optional<ValidationReport> result =
+                validationClient.requestValidationLenient("bad", "http://example.org/ontology");
 
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
-
-        // Assert
         assertFalse(result.isPresent());
     }
 
-    // ========== Input Validation Tests ==========
+    @Test
+    void requestValidationLenient_success_returnsReport() {
+        ValidationReportDto mockReport = mock(ValidationReportDto.class);
+        stubChain();
+        when(responseSpec.body(ValidationReportDto.class)).thenReturn(mockReport);
+
+        Optional<ValidationReport> result =
+                validationClient.requestValidationLenient("@prefix x: <x> .", "http://example.org/ontology");
+
+        assertTrue(result.isPresent());
+    }
+
+    // ========== Input validation (pre-network, throws) ==========
 
     private static Stream<Arguments> invalidInputProvider() {
         return Stream.of(
-                Arguments.of("", "http://example.org/ontology", "empty TTL content"),
-                Arguments.of(null, "http://example.org/ontology", "null TTL content"),
-                Arguments.of("   \t\n  ", "http://example.org/ontology", "whitespace TTL content"),
-                Arguments.of("@prefix owl: <http://www.w3.org/2002/07/owl#> .", "", "empty IRI"),
-                Arguments.of("@prefix owl: <http://www.w3.org/2002/07/owl#> .", null, "null IRI")
+                Arguments.of("", "http://example.org/ontology"),
+                Arguments.of(null, "http://example.org/ontology"),
+                Arguments.of("   \t\n  ", "http://example.org/ontology"),
+                Arguments.of("@prefix x: <x> .", ""),
+                Arguments.of("@prefix x: <x> .", (String) null)
         );
     }
 
     @ParameterizedTest
     @MethodSource("invalidInputProvider")
-    void testRequestValidation_InvalidInputs(String ttlContent, String iri, String testDescription) {
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
-
-        // Assert - should return empty Optional due to IllegalArgumentException caught by generic Exception handler
-        assertFalse(result.isPresent(), "Should return empty Optional for: " + testDescription);
-    }
-
-    // ========== Edge Cases ==========
-
-    @Test
-    void testRequestValidation_VeryLargeTtlContent() {
-        // Arrange
-        String ttlContent = "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n".repeat(10000);
-        String iri = "http://example.org/ontology";
-
-        ValidationReportDto mockReport = mock(ValidationReportDto.class);
-
-        when(restClient.post()).thenReturn(requestBodyUriSpec);
-        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
-        when(requestBodySpec.body(any(ValidationRequestDto.class))).thenReturn(requestBodySpec);
-        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(ValidationReportDto.class)).thenReturn(mockReport);
-
-        // Act
-        Optional<ValidationReport> result = validationClient.requestValidation(ttlContent, iri);
-
-        // Assert
-        assertTrue(result.isPresent());
+    void requestValidation_invalidInputs_throwIllegalArgument(String ttlContent, String iri) {
+        assertThrows(IllegalArgumentException.class,
+                () -> validationClient.requestValidation(ttlContent, iri));
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCallExecutorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCallExecutorTest.java
@@ -1,0 +1,117 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import com.dia.ismdtoolbackend.config.ValidationServiceConfig;
+import com.dia.ismdtoolbackend.exception.OntologyValidationException;
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationCallExecutorTest {
+
+    private ValidationCallExecutor executor(int threshold, Duration cooldown) {
+        ValidationServiceConfig config = new ValidationServiceConfig();
+        config.getBreaker().setFailureThreshold(threshold);
+        config.getBreaker().setCooldown(cooldown);
+        return new ValidationCallExecutor(config);
+    }
+
+    @Test
+    void strict_success_returnsValue() {
+        ValidationCallExecutor exec = executor(5, Duration.ofSeconds(30));
+        assertEquals("ok", exec.strict("t", () -> "ok"));
+    }
+
+    @Test
+    void strict_resourceAccess_mapsToUnavailable() {
+        ValidationCallExecutor exec = executor(1000, Duration.ofSeconds(30));
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> exec.strict("t", () -> { throw new ResourceAccessException("timeout"); }));
+    }
+
+    @Test
+    void strict_5xx_mapsToUnavailable() {
+        ValidationCallExecutor exec = executor(1000, Duration.ofSeconds(30));
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> exec.strict("t", () -> {
+                    throw HttpServerErrorException.create(HttpStatus.BAD_GATEWAY, "x", null, null, null);
+                }));
+    }
+
+    @Test
+    void strict_4xx_mapsToRejection_withValidatorMessage() {
+        ValidationCallExecutor exec = executor(1000, Duration.ofSeconds(30));
+        String body = "{\"message\":\"Invalid TTL syntax: foo\"}";
+        OntologyValidationException ex = assertThrows(OntologyValidationException.class,
+                () -> exec.strict("t", () -> {
+                    throw HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request",
+                            null, body.getBytes(), null);
+                }));
+        assertTrue(ex.getMessage().contains("Invalid TTL syntax: foo"));
+    }
+
+    @Test
+    void breaker_opensAfterThreshold_thenFastFailsWithoutCallingAction() {
+        ValidationCallExecutor exec = executor(2, Duration.ofSeconds(30));
+        AtomicInteger calls = new AtomicInteger();
+
+        // Two unavailable failures trip the breaker.
+        for (int i = 0; i < 2; i++) {
+            assertThrows(ValidationServiceUnavailableException.class,
+                    () -> exec.strict("t", () -> {
+                        calls.incrementAndGet();
+                        throw new ResourceAccessException("down");
+                    }));
+        }
+        assertEquals(2, calls.get());
+
+        // Breaker now open — the action must NOT be invoked.
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> exec.strict("t", () -> {
+                    calls.incrementAndGet();
+                    return "should not run";
+                }));
+        assertEquals(2, calls.get(), "open breaker must fast-fail without calling the action");
+    }
+
+    @Test
+    void breaker_rejectionDoesNotCountTowardOpening() {
+        ValidationCallExecutor exec = executor(2, Duration.ofSeconds(30));
+        AtomicInteger calls = new AtomicInteger();
+
+        // Many 4xx rejections — the validator is UP, so the breaker must never open.
+        for (int i = 0; i < 5; i++) {
+            assertThrows(OntologyValidationException.class,
+                    () -> exec.strict("t", () -> {
+                        calls.incrementAndGet();
+                        throw HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "x",
+                                null, "{\"message\":\"bad\"}".getBytes(), null);
+                    }));
+        }
+        assertEquals(5, calls.get(), "every rejection call should reach the action (breaker stays closed)");
+    }
+
+    @Test
+    void lenient_swallowsUnavailable_returnsFallback() {
+        ValidationCallExecutor exec = executor(1000, Duration.ofSeconds(30));
+        String result = exec.lenient("t",
+                () -> { throw new ResourceAccessException("down"); }, "fallback");
+        assertEquals("fallback", result);
+    }
+
+    @Test
+    void lenient_swallowsRejection_returnsFallback() {
+        ValidationCallExecutor exec = executor(1000, Duration.ofSeconds(30));
+        String result = exec.lenient("t",
+                () -> { throw HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "x",
+                        null, "{\"message\":\"bad\"}".getBytes(), null); }, "fallback");
+        assertEquals("fallback", result);
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
@@ -3,6 +3,12 @@ package com.dia.ismdtoolbackend.client.validation;
 import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ValidationCircuitBreakerTest {
@@ -73,6 +79,57 @@ class ValidationCircuitBreakerTest {
                 () -> breaker.call(() -> { ran[0] = true; throw down(); }));
         assertTrue(ran[0], "the trial call actually ran");
         assertTrue(breaker.isOpen(), "failed trial re-opens the breaker");
+    }
+
+    @Test
+    void halfOpenAdmitsExactlyOneTrialUnderConcurrency() throws InterruptedException {
+        // The crux of the half-open contract: when many threads cross the cooldown boundary at
+        // once, EXACTLY ONE runs the trial action; the rest must fast-fail. A naive read-only gate
+        // would let all of them stampede the (possibly still-dead) validator.
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 50);
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        assertTrue(breaker.isOpen());
+
+        Thread.sleep(70); // cooldown expired → first caller would be the trial
+
+        int threads = 16;
+        AtomicInteger actionRuns = new AtomicInteger(0);
+        AtomicInteger fastFails = new AtomicInteger(0);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch go = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    // The single elected trial blocks briefly so the others are guaranteed to
+                    // observe the in-progress trial window and fast-fail, not slip through.
+                    breaker.call(() -> {
+                        actionRuns.incrementAndGet();
+                        try { Thread.sleep(30); } catch (InterruptedException ignored) { Thread.currentThread().interrupt(); }
+                        throw down();
+                    });
+                } catch (ValidationServiceUnavailableException e) {
+                    fastFails.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await(2, TimeUnit.SECONDS);
+        go.countDown();
+        assertTrue(done.await(5, TimeUnit.SECONDS), "all threads finished");
+        pool.shutdownNow();
+
+        assertEquals(1, actionRuns.get(), "exactly one thread runs the half-open trial");
+        assertEquals(threads, fastFails.get(), "trial failed → every caller (trial + losers) sees unavailable");
+        assertTrue(breaker.isOpen(), "failed trial keeps the breaker open");
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
@@ -1,0 +1,62 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidationCircuitBreakerTest {
+
+    private ValidationServiceUnavailableException down() {
+        return new ValidationServiceUnavailableException("Validační služba", "down");
+    }
+
+    @Test
+    void startsClosed() {
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 2, 30_000);
+        assertFalse(breaker.isOpen());
+        assertEquals("ok", breaker.call(() -> "ok"));
+        assertFalse(breaker.isOpen());
+    }
+
+    @Test
+    void opensAfterThreshold() {
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 2, 30_000);
+
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        assertFalse(breaker.isOpen(), "one failure below threshold — still closed");
+
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        assertTrue(breaker.isOpen(), "second failure hits threshold — now open");
+    }
+
+    @Test
+    void openBreakerFastFailsWithoutCallingAction() {
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 30_000);
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        assertTrue(breaker.isOpen());
+
+        boolean[] ran = {false};
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> breaker.call(() -> { ran[0] = true; return "x"; }));
+        assertFalse(ran[0], "open breaker must not invoke the action");
+    }
+
+    @Test
+    void halfOpenTrialClosesOnSuccess() {
+        // Zero cooldown → the breaker is immediately past cooldown, so the next call is a trial.
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 0);
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        // cooldown is 0 → not "open" by the time check; a successful trial closes it.
+        assertEquals("ok", breaker.call(() -> "ok"));
+        assertFalse(breaker.isOpen());
+    }
+
+    @Test
+    void rejectionStyleExceptionsDoNotTrip() {
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 30_000);
+        // A non-unavailable exception propagates and does NOT count toward opening.
+        assertThrows(IllegalStateException.class, () -> breaker.call(() -> { throw new IllegalStateException("4xx"); }));
+        assertFalse(breaker.isOpen());
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidationCircuitBreakerTest.java
@@ -43,13 +43,36 @@ class ValidationCircuitBreakerTest {
     }
 
     @Test
-    void halfOpenTrialClosesOnSuccess() {
-        // Zero cooldown → the breaker is immediately past cooldown, so the next call is a trial.
-        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 0);
+    void halfOpenTrialClosesOnSuccess() throws InterruptedException {
+        // Small but non-zero cooldown so the breaker is genuinely OPEN, then expires into a trial.
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 50);
         assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
-        // cooldown is 0 → not "open" by the time check; a successful trial closes it.
-        assertEquals("ok", breaker.call(() -> "ok"));
-        assertFalse(breaker.isOpen());
+        assertTrue(breaker.isOpen(), "breaker is open during cooldown");
+
+        // While open, a call fast-fails without running the action.
+        boolean[] ran = {false};
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> breaker.call(() -> { ran[0] = true; return "x"; }));
+        assertFalse(ran[0], "open breaker fast-fails");
+
+        Thread.sleep(70); // past cooldown → next call is the half-open trial
+        assertEquals("ok", breaker.call(() -> "ok"), "trial call runs and succeeds");
+        assertFalse(breaker.isOpen(), "successful trial closes the breaker");
+    }
+
+    @Test
+    void halfOpenTrialFailureReopens() throws InterruptedException {
+        ValidationCircuitBreaker breaker = new ValidationCircuitBreaker("v", 1, 50);
+        assertThrows(ValidationServiceUnavailableException.class, () -> breaker.call(() -> { throw down(); }));
+        assertTrue(breaker.isOpen());
+
+        Thread.sleep(70); // past cooldown → trial allowed
+        // Trial fails → breaker re-opens for another cooldown window.
+        boolean[] ran = {false};
+        assertThrows(ValidationServiceUnavailableException.class,
+                () -> breaker.call(() -> { ran[0] = true; throw down(); }));
+        assertTrue(ran[0], "the trial call actually ran");
+        assertTrue(breaker.isOpen(), "failed trial re-opens the breaker");
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/client/validation/ValidatorErrorMessageExtractorTest.java
@@ -1,0 +1,56 @@
+package com.dia.ismdtoolbackend.client.validation;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidatorErrorMessageExtractorTest {
+
+    private final ValidatorErrorMessageExtractor extractor = new ValidatorErrorMessageExtractor();
+
+    private HttpClientErrorException with(String body) {
+        return HttpClientErrorException.create(HttpStatus.BAD_REQUEST, "Bad Request",
+                null, body == null ? null : body.getBytes(StandardCharsets.UTF_8), null);
+    }
+
+    @Test
+    void structuredBody_extractsMessageField() {
+        String result = extractor.extract(with("{\"error\":\"Validation Error\",\"message\":\"Invalid TTL syntax: line 3\"}"));
+        assertEquals("Invalid TTL syntax: line 3", result);
+    }
+
+    @Test
+    void blankBody_returnsFallback() {
+        String result = extractor.extract(with(""));
+        assertEquals("Validační služba odmítla požadavek.", result);
+    }
+
+    @Test
+    void malformedJson_fallsBackToRawBody() {
+        String raw = "this is not json at all";
+        assertEquals(raw, extractor.extract(with(raw)));
+    }
+
+    @Test
+    void jsonWithoutMessageField_fallsBackToRawBody() {
+        String raw = "{\"error\":\"X\",\"detail\":\"no message field here\"}";
+        assertEquals(raw, extractor.extract(with(raw)));
+    }
+
+    @Test
+    void jsonWithBlankMessage_fallsBackToRawBody() {
+        String raw = "{\"message\":\"   \"}";
+        assertEquals(raw, extractor.extract(with(raw)));
+    }
+
+    @Test
+    void htmlErrorPage_fallsBackToRawBody() {
+        // A reverse proxy returning an HTML 400 must not crash the extractor.
+        String raw = "<html><body>400 Bad Request</body></html>";
+        assertEquals(raw, extractor.extract(with(raw)));
+    }
+}

--- a/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/controller/OntologyControllerTest.java
@@ -855,7 +855,7 @@ class OntologyControllerTest {
 
     @Test
     @WithMockSecurityUser(userId = "user123")
-    void testValidateOntology_ServiceUnavailable() throws Exception {
+    void testValidateOntology_ServiceUnavailable_returns503() throws Exception {
         String slug = "test-ontology";
 
         OntologyMetadataModel ontologyMetadata = new OntologyMetadataModel();
@@ -866,8 +866,37 @@ class OntologyControllerTest {
         TestOntologySecurityService.setAllowModify(true);
         when(ontologyService.getTtlContentFromOntology(any()))
                 .thenReturn("@prefix owl: <http://www.w3.org/2002/07/owl#> .");
+        // Validator down → client throws the unavailable exception → 503.
         when(validationClient.requestValidation(anyString(), anyString()))
-                .thenReturn(java.util.Optional.empty());
+                .thenThrow(new com.dia.ismdtoolbackend.exception.ValidationServiceUnavailableException(
+                        "Validační služba", "validator unreachable"));
+
+        mockMvc.perform(post("/api/ontology/{slug}/validate", slug)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(ontologyMetadata)))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.message").value("Validační služba není momentálně dostupná."));
+    }
+
+    @Test
+    @WithMockSecurityUser(userId = "user123")
+    void testValidateOntology_ValidatorRejectedInput_returns400WithValidatorMessage() throws Exception {
+        String slug = "test-ontology";
+
+        OntologyMetadataModel ontologyMetadata = new OntologyMetadataModel();
+        ontologyMetadata.setId(1L);
+        ontologyMetadata.setGraphName("http://example.org/test-ontology");
+        ontologyMetadata.setSlug(slug);
+
+        TestOntologySecurityService.setAllowModify(true);
+        when(ontologyService.getTtlContentFromOntology(any()))
+                .thenReturn("bad ttl");
+        // Validator answered with a 4xx → client throws a rejection carrying the validator's message → 400.
+        when(validationClient.requestValidation(anyString(), anyString()))
+                .thenThrow(new com.dia.ismdtoolbackend.exception.OntologyValidationException(
+                        "Invalid TTL syntax: line 3"));
 
         mockMvc.perform(post("/api/ontology/{slug}/validate", slug)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -875,7 +904,7 @@ class OntologyControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data").doesNotExist())
-                .andExpect(jsonPath("$.message").value("Validace se nezdařila - validační služba nevrátila odpověď."));
+                .andExpect(jsonPath("$.message").value("Invalid TTL syntax: line 3"));
     }
 
     @Test

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
@@ -88,6 +88,10 @@ class OntologyUploadServiceImplTest {
                 jenaTDB2Repository,
                 publishedResourceUtil
         );
+        // In production `self` is the Spring proxy (so @Transactional applies through the async
+        // lambda). In this unit test there is no proxy — point it at the instance itself so the
+        // delegation to saveValidationOutcome runs the real method directly.
+        ReflectionTestUtils.setField(ontologyUploadService, "self", ontologyUploadService);
         ReflectionTestUtils.setField(ontologyUploadService, "maxFileSizeConfig", "10MB");
         ReflectionTestUtils.setField(ontologyUploadService, "rdfParsingTimeoutSeconds", 60);
     }

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyUploadServiceImplTest.java
@@ -8,6 +8,8 @@ import com.dia.ismdtoolbackend.client.ValidationClient;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.enums.NormalizeMode;
+import com.dia.ismdtoolbackend.enums.OntologyValidationStatus;
+import com.dia.validation.ValidationReport;
 import com.dia.ismdtoolbackend.exception.InSchemeDecisionRequiredException;
 import com.dia.ismdtoolbackend.models.OntologyMetadataModel;
 import com.dia.ismdtoolbackend.models.UserModel;
@@ -88,6 +90,45 @@ class OntologyUploadServiceImplTest {
         );
         ReflectionTestUtils.setField(ontologyUploadService, "maxFileSizeConfig", "10MB");
         ReflectionTestUtils.setField(ontologyUploadService, "rdfParsingTimeoutSeconds", 60);
+    }
+
+    @Test
+    void requestAndSaveValidationReport_validatorReturnsReport_marksValidated() {
+        OntologyMetadataEntity ontology = new OntologyMetadataEntity();
+        ontology.setId(7L);
+        ontology.setGraphName("http://example.org/o");
+        when(ontologyMetadataRepository.findByGraphName("http://example.org/o")).thenReturn(Optional.of(ontology));
+        when(validationReportRepository.findByOntologyMetadataId(7L)).thenReturn(Optional.empty());
+
+        ValidationReport report = mock(ValidationReport.class);
+        when(report.getResults()).thenReturn(Collections.emptyList());
+        when(validationClient.requestValidationLenient(anyString(), anyString())).thenReturn(Optional.of(report));
+
+        ontologyUploadService.requestAndSaveValidationReport("@prefix x: <x> .", "http://example.org/o");
+
+        ArgumentCaptor<OntologyMetadataEntity> captor = ArgumentCaptor.forClass(OntologyMetadataEntity.class);
+        verify(ontologyMetadataRepository).save(captor.capture());
+        assertEquals(OntologyValidationStatus.VALIDATED, captor.getValue().getLastValidationStatus());
+        assertNotNull(captor.getValue().getLastValidationAt());
+    }
+
+    @Test
+    void requestAndSaveValidationReport_validatorUnavailable_marksSkipped() {
+        OntologyMetadataEntity ontology = new OntologyMetadataEntity();
+        ontology.setId(7L);
+        ontology.setGraphName("http://example.org/o");
+        when(ontologyMetadataRepository.findByGraphName("http://example.org/o")).thenReturn(Optional.of(ontology));
+        when(validationReportRepository.findByOntologyMetadataId(7L)).thenReturn(Optional.empty());
+        // Lenient returns empty when the validator was unavailable — ingest proceeds, status flagged.
+        when(validationClient.requestValidationLenient(anyString(), anyString())).thenReturn(Optional.empty());
+
+        ontologyUploadService.requestAndSaveValidationReport("@prefix x: <x> .", "http://example.org/o");
+
+        ArgumentCaptor<OntologyMetadataEntity> captor = ArgumentCaptor.forClass(OntologyMetadataEntity.class);
+        verify(ontologyMetadataRepository).save(captor.capture());
+        assertEquals(OntologyValidationStatus.SKIPPED_UNAVAILABLE, captor.getValue().getLastValidationStatus());
+        assertNotNull(captor.getValue().getLastValidationAt());
+        verify(validationReportRepository, never()).save(any());
     }
 
     @Test


### PR DESCRIPTION
Summary

Consolidates and refactor integration with Validator module
  
  The tool calls the externally-deployed ISMD validator (POST {validation.service.url}/api/validator/validate). It was defensively coded but under-hardened versus our other external integrations (the SPARQL clients).

Closed gaps
  1. Optional.empty() collapsed down, 4xx-rejection, and null-body into one generic 400 → now 3 distinct outcomes.
  2. No HTTP timeouts → dedicated timed client.
  3. No circuit breaker → per-service breaker.
  4. Upload swallowed validation failure silently → status is now recorded and surfaced.
  5. Validator's own error message was discarded → now propagated.

  Changes

  - Distinct failure semantics — /validate now returns 503 on outage (down/timeout/5xx/null body, Czech message), 400 carrying the validator's own reason on a 4xx rejection, 200 + report on success. New ValidationServiceUnavailableException + 503 handler.
  - Dedicated timed RestClient (validationRestClient, connect 5s / read 15s — read deliberately above the validator's 10s SHACL cap) on validation.service.* config.
  - ValidationCircuitBreaker keyed on the unavailable type only (a 4xx rejection never trips it) + ValidationCallExecutor (strict for /validate, lenient for the advisory upload path).
  - ValidatorErrorMessageExtractor deserializes the shared com.dia.validation.ValidatorErrorResponse (common-lib bumped 1.0.16 → 1.0.17), with raw-body fallback so the tool stays independent of the validator's error contract.
  - Validation status — new nullable last_validation_status (VALIDATED / SKIPPED_UNAVAILABLE / FAILED) + last_validation_at on OntologyMetadataEntity (Liquibase 009), set on upload + /validate, surfaced NON_NULL on the detail DTO so the FE can surface and offer a manual re-validate. Upload stays non-blocking.

