### PR TITLE
ontology rename dropping unchanged characteristics

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditor.java
@@ -70,6 +70,12 @@ public class OntologyEditor {
 
         boolean committed = false;
         try {
+            boolean iriChanged = nameChanged && !iri.equals(newOntologyIRI);
+            if (iriChanged) {
+                renameOntologyIRI(model, iri, newOntologyIRI, statementsToRemove, statementsToAdd);
+                updateAllConceptIRIs(model, oldNamespace, newNamespace, statementsToRemove, statementsToAdd);
+            }
+
             if (editModel.getNameModel() != null) {
                 updateName(existingOntology, editModel.getNameModel(), model, statementsToRemove, statementsToAdd,
                         newOntologyIRI);
@@ -78,11 +84,6 @@ public class OntologyEditor {
             if (editModel.getDescriptionModel() != null) {
                 updateDescription(existingOntology, editModel.getDescriptionModel(), model, statementsToRemove,
                         statementsToAdd, newOntologyIRI);
-            }
-
-            if (nameChanged && !iri.equals(newOntologyIRI)) {
-                renameOntologyIRI(model, iri, newOntologyIRI, statementsToRemove, statementsToAdd);
-                updateAllConceptIRIs(model, oldNamespace, newNamespace, statementsToRemove, statementsToAdd);
             }
 
             model.remove(statementsToRemove.toArray(new Statement[0]));
@@ -122,7 +123,7 @@ public class OntologyEditor {
 
         // Name is required: an empty incoming map is a no-op (merged == existing).
         Map<String, String> existing = RdfLangValues.byLanguage(existingOntology, SKOS.prefLabel);
-        applyMergedLangProperty(existingOntology, model.getResource(newOntologyIRI), SKOS.prefLabel,
+        applyMergedLangProperty(model.getResource(newOntologyIRI), SKOS.prefLabel,
                 existing, nameModel.getName(), model, toRemove, toAdd);
     }
 
@@ -131,29 +132,33 @@ public class OntologyEditor {
         if (descModel == null) return;
 
         Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
+        Resource writeOntology = model.getResource(newOntologyIRI);
         Map<String, String> existing = RdfLangValues.byLanguage(existingOntology, descProperty);
         Map<String, String> incoming = descModel.getDescription();
 
-        // An empty/absent incoming map clears the field entirely.
+        // An empty/absent incoming map clears the field entirely. Removal targets the
+        // write IRI so a rename+clear also cancels the stale copy renameOntologyIRI
+        // staged onto the new IRI (the old-IRI live triples are removed by rename).
         if (incoming == null || incoming.isEmpty()) {
             if (!existing.isEmpty()) {
-                RdfLangValues.removeAllByPredicate(existingOntology, descProperty, toRemove, toAdd);
+                RdfLangValues.removeAllByPredicate(writeOntology, descProperty, toRemove, toAdd);
             }
             return;
         }
 
-        applyMergedLangProperty(existingOntology, model.getResource(newOntologyIRI), descProperty,
+        applyMergedLangProperty(writeOntology, descProperty,
                 existing, incoming, model, toRemove, toAdd);
     }
 
     /**
-     * Merges an incoming {@code lang -> value} map into {@code existing} and, if
-     * changed, removes the property from {@code readResource} and rewrites the
-     * merged values onto {@code writeResource}. The read/write split lets an
-     * ontology rename relocate labels onto the new IRI in the same pass. Mirrors
-     * the MERGE semantics used for concept prefLabel/description/definition.
+     * Merges {@code incoming} ({@code lang -> value}, already read from the old IRI)
+     * into {@code existing} and, if changed, removes {@code property} from
+     * {@code writeResource} and rewrites the merged values onto it. Targeting the
+     * write IRI for removal cancels the stale copy of this property that
+     * {@code renameOntologyIRI} stages onto the new IRI on a rename; with no rename
+     * the write IRI == old IRI, so it behaves as a plain remove-then-rewrite.
      */
-    private void applyMergedLangProperty(Resource readResource, Resource writeResource, Property property,
+    private void applyMergedLangProperty(Resource writeResource, Property property,
                                          Map<String, String> existing, Map<String, String> incoming,
                                          Model model, Set<Statement> toRemove, Set<Statement> toAdd) {
         Map<String, String> merged = new HashMap<>(existing);
@@ -167,7 +172,7 @@ public class OntologyEditor {
 
         if (existing.equals(merged)) return;
 
-        RdfLangValues.removeAllByPredicate(readResource, property, toRemove, toAdd);
+        RdfLangValues.removeAllByPredicate(writeResource, property, toRemove, toAdd);
         for (Map.Entry<String, String> entry : merged.entrySet()) {
             String languageTag = entry.getKey() != null && !entry.getKey().trim().isEmpty()
                     ? entry.getKey()

--- a/src/test/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/editor/OntologyEditorTest.java
@@ -31,6 +31,9 @@ class OntologyEditorTest {
     //   E2 – keep ontology IRI and concept IRIs when name is unchanged
     //   E3 – remove description when new value is blank
     //   E4 – update description when new value is provided
+    //   E5 – error when renamed ontology IRI already exists in the model
+    //   E6 – rename must not leave a stale old prefLabel/description on the new IRI
+    //   E7 – rename preserves an unedited description (descriptionModel == null)
 
     private OntologyEditor ontologyEditor;
 
@@ -195,6 +198,85 @@ class OntologyEditorTest {
             Resource sameConcept = model.getResource(namespace + "concept-1");
             assertTrue(model.containsResource(sameConcept));
             assertTrue(model.contains(sameOntology, hasConcept, sameConcept));
+        }
+
+        // --- E6. rename must not leave a stale old prefLabel/description on the new IRI ---
+        // Regression for the same class of bug fixed in ConceptEditor by commit 802104d:
+        // when the field updaters ran before renameOntologyIRI, rename re-copied the OLD
+        // prefLabel/description onto the new IRI, so the renamed ontology ended up with
+        // BOTH the new and the stale old value.
+        @Test
+        void editOntology_ShouldNotLeaveStaleLabelOrDescriptionOnNewIRI_WhenRenamed() { // E6
+            // Arrange
+            String oldOntologyIRI = "https://example.com/vocab/old-ontology";
+            String oldNamespace = UtilityMethods.ensureNamespaceEndsWithDelimiter(oldOntologyIRI);
+
+            Resource ontology = model.createResource(oldOntologyIRI);
+            ontology.addProperty(SKOS.prefLabel, model.createLiteral("Old name", "cs"));
+            Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
+            ontology.addProperty(descProperty, model.createLiteral("Old description", "cs"));
+
+            NameModel newName = createNameModel("cs", "New ontology");
+            DescriptionModel newDesc = createDescriptionModel("cs", "New description");
+
+            when(editModel.getNameModel()).thenReturn(newName);
+            when(editModel.getDescriptionModel()).thenReturn(newDesc);
+
+            // Act
+            OntologyEditor.EditResult result =
+                    ontologyEditor.editOntology(editModel, model, oldNamespace, oldOntologyIRI);
+
+            // Assert — the new IRI carries exactly the new value, with no stale copy.
+            Resource newOntology = model.getResource(result.newOntologyIRI);
+
+            assertTrue(model.contains(newOntology, SKOS.prefLabel, model.createLiteral("New ontology", "cs")),
+                    "New prefLabel not found on the renamed IRI");
+            assertFalse(model.contains(newOntology, SKOS.prefLabel, model.createLiteral("Old name", "cs")),
+                    "Stale old prefLabel leaked onto the renamed IRI");
+            assertEquals(1, newOntology.listProperties(SKOS.prefLabel).toList().size(),
+                    "Renamed IRI must carry exactly one prefLabel");
+
+            assertTrue(model.contains(newOntology, descProperty, model.createLiteral("New description", "cs")),
+                    "New description not found on the renamed IRI");
+            assertFalse(model.contains(newOntology, descProperty, model.createLiteral("Old description", "cs")),
+                    "Stale old description leaked onto the renamed IRI");
+            assertEquals(1, newOntology.listProperties(descProperty).toList().size(),
+                    "Renamed IRI must carry exactly one description");
+        }
+
+        // --- E7. rename preserves an unedited description (descriptionModel == null) ---
+        // Renaming while sending only the name (partial payload) must not drop the
+        // untouched description — rename relocates it onto the new IRI verbatim.
+        @Test
+        void editOntology_ShouldPreserveUneditedDescription_WhenRenamed() { // E7
+            // Arrange
+            String oldOntologyIRI = "https://example.com/vocab/old-ontology";
+            String oldNamespace = UtilityMethods.ensureNamespaceEndsWithDelimiter(oldOntologyIRI);
+
+            Resource ontology = model.createResource(oldOntologyIRI);
+            ontology.addProperty(SKOS.prefLabel, model.createLiteral("Old name", "cs"));
+            Property descProperty = model.createProperty("http://purl.org/dc/terms/description");
+            ontology.addProperty(descProperty, model.createLiteral("Kept description", "cs"));
+
+            NameModel newName = createNameModel("cs", "New ontology");
+
+            when(editModel.getNameModel()).thenReturn(newName);
+            when(editModel.getDescriptionModel()).thenReturn(null);
+
+            // Act
+            OntologyEditor.EditResult result =
+                    ontologyEditor.editOntology(editModel, model, oldNamespace, oldOntologyIRI);
+
+            // Assert
+            Resource newOntology = model.getResource(result.newOntologyIRI);
+
+            assertTrue(model.contains(newOntology, descProperty, model.createLiteral("Kept description", "cs")),
+                    "Unedited description was dropped on rename");
+            assertEquals(1, newOntology.listProperties(descProperty).toList().size(),
+                    "Renamed IRI must carry exactly one (preserved) description");
+            assertFalse(model.contains(model.getResource(oldOntologyIRI), descProperty,
+                            model.createLiteral("Kept description", "cs")),
+                    "Description must no longer remain on the old IRI");
         }
     }
 


### PR DESCRIPTION
Summary

fixes the same bug found in concept edit rename workflow, see commit 802104d410eb82d000b6d0708b15d4cc4aa250ea