### PR TITLE
Fuseki-Tool error mapping

### DIFF
--- a/src/main/java/com/dia/ismdtoolbackend/outbox/OutboxRelay.java
+++ b/src/main/java/com/dia/ismdtoolbackend/outbox/OutboxRelay.java
@@ -1,6 +1,7 @@
 package com.dia.ismdtoolbackend.outbox;
 
 import com.dia.ismdtoolbackend.exception.JenaTDB2Exception;
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
 import com.dia.ismdtoolbackend.repository.JenaTDB2Repository;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -97,8 +98,11 @@ public class OutboxRelay {
                 row.setStatus(OutboxStatus.DONE);
                 row.setCompletedAt(Instant.now());
                 applied++;
-            } catch (JenaTDB2Exception e) {
+            } catch (JenaTDB2Exception | SparqlEndpointUnavailableException e) {
                 // Transient/store failure — retry until the attempts cap, then FAILED.
+                // SparqlEndpointUnavailableException is how the executor now reports a Fuseki
+                // outage (503/connection drop); like a JenaTDB2Exception it must retry, not
+                // permanent-fail down the generic RuntimeException branch below.
                 recordTransientFailure(row, e);
                 haltedAggregates.add(aggregate); // preserve order: no later row for this aggregate
             } catch (IllegalArgumentException e) {

--- a/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
+++ b/src/main/java/com/dia/ismdtoolbackend/service/impl/OntologyServiceImpl.java
@@ -6,6 +6,7 @@ import com.dia.ismdtoolbackend.entity.CommentEntity;
 import com.dia.ismdtoolbackend.entity.ConceptMetadataEntity;
 import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.entity.ValidationReportEntity;
+import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
 import com.dia.ismdtoolbackend.mapper.ConceptMetadataMapper;
 import com.dia.ismdtoolbackend.models.*;
@@ -161,7 +162,7 @@ public class OntologyServiceImpl implements OntologyService {
         Optional<OntologyMetadataEntity> ontologyMetadataOpt = ontologyMetadataRepository.findBySlug(ontologySlug);
         if (ontologyMetadataOpt.isEmpty()) {
             log.error("ontologySlug {} not found", ontologySlug);
-            throw new OntologyException("Metadata slovníku s názvem " + ontologySlug + " nebyla nalezena.");
+            throw new OntologyNotFoundException("Metadata slovníku s názvem " + ontologySlug + " nebyla nalezena.");
         }
 
         OntologyMetadataEntity metadataEntity = ontologyMetadataOpt.get();
@@ -171,7 +172,7 @@ public class OntologyServiceImpl implements OntologyService {
 
         if (rawModel.isEmpty()) {
             log.error("Ontology model is empty for graph: {}", graphName);
-            throw new OntologyException("Slovník je prázdný, nebo nebyl nalezen.");
+            throw new OntologyNotFoundException("Slovník je prázdný, nebo nebyl nalezen.");
         }
 
         // OFN transform is expensive (filter + reformat over the full graph);
@@ -219,12 +220,12 @@ public class OntologyServiceImpl implements OntologyService {
         Optional<OntologyMetadataEntity> ontologyMetadataOpt = ontologyMetadataRepository.findByGraphName(ontologyIri);
         if (ontologyMetadataOpt.isEmpty()) {
             log.info("ISMD ontology not found for IRI: {}", ontologyIri);
-            throw new OntologyException("Slovník s IRI " + ontologyIri + " nebyl nalezen.");
+            throw new OntologyNotFoundException("Slovník s IRI " + ontologyIri + " nebyl nalezen.");
         }
 
         Model rawModel = jenaTDB2Repository.fetchGraph(ontologyIri);
         if (rawModel.isEmpty()) {
-            throw new OntologyException("Slovník je prázdný, nebo nebyl nalezen.");
+            throw new OntologyNotFoundException("Slovník je prázdný, nebo nebyl nalezen.");
         }
 
         Model processedModel = detailExtractor.applyOFNTransformations(rawModel);

--- a/src/main/java/com/dia/ismdtoolbackend/utility/sparql/FusekiSparqlExecutor.java
+++ b/src/main/java/com/dia/ismdtoolbackend/utility/sparql/FusekiSparqlExecutor.java
@@ -1,10 +1,14 @@
 package com.dia.ismdtoolbackend.utility.sparql;
 
 import com.dia.ismdtoolbackend.exception.JenaTDB2Exception;
+import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+
+import java.net.HttpURLConnection;
 
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -62,8 +66,7 @@ public final class FusekiSparqlExecutor {
         try (RDFConnection conn = connectionFactory.get()) {
             return operation.apply(conn);
         } catch (QueryExceptionHTTP | HttpException e) {
-            log.error("Fuseki HTTP error during {}: {}", operationLabel, e.getMessage());
-            throw new JenaTDB2Exception(userFacingErrorMessage, e);
+            throw mapHttpFailure(operationLabel, userFacingErrorMessage, e);
         } catch (JenaTDB2Exception e) {
             // Operation already wrapped its own failure (e.g. via a nested executor call);
             // pass through so the inner message survives.
@@ -101,5 +104,44 @@ public final class FusekiSparqlExecutor {
                     semaphoreTimeoutMs, semaphore.availablePermits());
             throw new JenaTDB2Exception("Fuseki server is busy, try again later");
         }
+    }
+
+    /**
+     * Translate a Jena HTTP failure into the right domain exception so the status code
+     * survives to the frontend instead of collapsing into a blanket HTTP 500:
+     * <ul>
+     *   <li><b>404</b> — the graph genuinely isn't there → {@link OntologyNotFoundException} (HTTP 404).</li>
+     *   <li><b>502/503/504</b> and connection-level failures (status {@code <= 0}, how Jena
+     *       reports a dropped/reset connection) — Fuseki is unreachable, not the data missing →
+     *       {@link SparqlEndpointUnavailableException} (HTTP 503), which the outbox treats as transient.</li>
+     *   <li>everything else → {@link JenaTDB2Exception} (HTTP 500), the original behaviour.</li>
+     * </ul>
+     */
+    private RuntimeException mapHttpFailure(String operationLabel, String userFacingErrorMessage, Exception e) {
+        int status = statusCodeOf(e);
+        if (status == HttpURLConnection.HTTP_NOT_FOUND) {
+            log.info("Fuseki returned 404 (graph not found) during {}: {}", operationLabel, e.getMessage());
+            return new OntologyNotFoundException("Slovník nebyl nalezen.", e);
+        }
+        if (status <= 0
+                || status == HttpURLConnection.HTTP_BAD_GATEWAY
+                || status == HttpURLConnection.HTTP_UNAVAILABLE
+                || status == HttpURLConnection.HTTP_GATEWAY_TIMEOUT) {
+            log.error("Fuseki unavailable (status {}) during {}: {}", status, operationLabel, e.getMessage());
+            return new SparqlEndpointUnavailableException("Fuseki", userFacingErrorMessage, e);
+        }
+        log.error("Fuseki HTTP error (status {}) during {}: {}", status, operationLabel, e.getMessage());
+        return new JenaTDB2Exception(userFacingErrorMessage, e);
+    }
+
+    /** Both {@link HttpException} and {@link QueryExceptionHTTP} expose {@code getStatusCode()}, with no common supertype. */
+    private static int statusCodeOf(Exception e) {
+        if (e instanceof HttpException he) {
+            return he.getStatusCode();
+        }
+        if (e instanceof QueryExceptionHTTP qe) {
+            return qe.getStatusCode();
+        }
+        return 0;
     }
 }

--- a/src/test/java/com/dia/ismdtoolbackend/service/OntologyServiceImplTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/service/OntologyServiceImplTest.java
@@ -9,6 +9,7 @@ import com.dia.ismdtoolbackend.entity.OntologyMetadataEntity;
 import com.dia.ismdtoolbackend.entity.ValidationReportEntity;
 import com.dia.ismdtoolbackend.mapper.ConceptMetadataMapper;
 import com.dia.ismdtoolbackend.mapper.OntologyMetadataMapper;
+import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
 import com.dia.ismdtoolbackend.exception.OntologyValidationException;
 import com.dia.ismdtoolbackend.models.*;
 import com.dia.ismdtoolbackend.models.concept.ConceptMetadataModel;
@@ -363,7 +364,7 @@ class OntologyServiceImplTest {
     void getOntologyDetailModel_OntologyNotFound() {
         when(ontologyMetadataRepository.findBySlug(TEST_ONTOLOGY_SLUG)).thenReturn(Optional.empty());
 
-        OntologyException exception = assertThrows(OntologyException.class,
+        OntologyNotFoundException exception = assertThrows(OntologyNotFoundException.class,
                 () -> ontologyService.getOntologyDetailModel(TEST_ONTOLOGY_SLUG));
 
         assertTrue(exception.getMessage().contains("nebyla nalezena"));
@@ -374,7 +375,7 @@ class OntologyServiceImplTest {
         when(ontologyMetadataRepository.findBySlug(TEST_ONTOLOGY_SLUG)).thenReturn(Optional.of(testOntologyEntity));
         when(jenaTDB2Repository.fetchGraph(TEST_GRAPH_NAME)).thenReturn(ModelFactory.createDefaultModel());
 
-        OntologyException exception = assertThrows(OntologyException.class,
+        OntologyNotFoundException exception = assertThrows(OntologyNotFoundException.class,
                 () -> ontologyService.getOntologyDetailModel(TEST_ONTOLOGY_SLUG));
 
         assertTrue(exception.getMessage().contains("prázdný"));
@@ -575,7 +576,7 @@ class OntologyServiceImplTest {
     void getConceptsByIri_ontologyNotFound_throws() {
         when(ontologyMetadataRepository.findByGraphName(TEST_GRAPH_NAME)).thenReturn(Optional.empty());
 
-        OntologyException ex = assertThrows(OntologyException.class,
+        OntologyNotFoundException ex = assertThrows(OntologyNotFoundException.class,
                 () -> ontologyService.getConceptsByIri(TEST_GRAPH_NAME));
         assertTrue(ex.getMessage().contains(TEST_GRAPH_NAME));
     }
@@ -586,7 +587,7 @@ class OntologyServiceImplTest {
                 .thenReturn(Optional.of(testOntologyEntity));
         when(jenaTDB2Repository.fetchGraph(TEST_GRAPH_NAME)).thenReturn(ModelFactory.createDefaultModel());
 
-        OntologyException ex = assertThrows(OntologyException.class,
+        OntologyNotFoundException ex = assertThrows(OntologyNotFoundException.class,
                 () -> ontologyService.getConceptsByIri(TEST_GRAPH_NAME));
         assertTrue(ex.getMessage().toLowerCase().contains("prázdn")
                 || ex.getMessage().toLowerCase().contains("empty"));

--- a/src/test/java/com/dia/ismdtoolbackend/utility/sparql/FusekiSparqlExecutorTest.java
+++ b/src/test/java/com/dia/ismdtoolbackend/utility/sparql/FusekiSparqlExecutorTest.java
@@ -1,0 +1,113 @@
+package com.dia.ismdtoolbackend.utility.sparql;
+
+import com.dia.ismdtoolbackend.exception.JenaTDB2Exception;
+import com.dia.ismdtoolbackend.exception.OntologyNotFoundException;
+import com.dia.ismdtoolbackend.exception.SparqlEndpointUnavailableException;
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@link FusekiSparqlExecutor} maps Jena HTTP failures to the right
+ * domain exception so the Fuseki status code survives to the frontend:
+ * 404 → {@link OntologyNotFoundException} (HTTP 404),
+ * 502/503/504 + connection drops → {@link SparqlEndpointUnavailableException} (HTTP 503),
+ * everything else → {@link JenaTDB2Exception} (HTTP 500).
+ *
+ * <p>This is the regression guard for the dev incident where a missing graph (Fuseki 404)
+ * was reported to the FE as a blanket 500, indistinguishable from a real Fuseki outage.
+ */
+class FusekiSparqlExecutorTest {
+
+    private static final String LABEL = "fetching graph X";
+    private static final String USER_MSG = "Failed to fetch graph";
+
+    /** Executor backed by a mock connection and a semaphore with permits to spare so acquire never blocks. */
+    private FusekiSparqlExecutor executorThrowing(RuntimeException ignored) {
+        RDFConnection conn = Mockito.mock(RDFConnection.class);
+        return new FusekiSparqlExecutor(new Semaphore(4), 1_000, () -> conn);
+    }
+
+    /** Runs an operation that always raises {@code toThrow}, exercising the executor's HTTP catch/mapping. */
+    private <T> T run(FusekiSparqlExecutor executor, RuntimeException toThrow) {
+        Function<RDFConnection, T> op = conn -> {
+            throw toThrow;
+        };
+        return executor.execute(LABEL, USER_MSG, op);
+    }
+
+    @Test
+    void httpException404_mapsToOntologyNotFound() {
+        HttpException notFound = new HttpException(404, "Not Found", "graph absent");
+        FusekiSparqlExecutor executor = executorThrowing(notFound);
+
+        OntologyNotFoundException ex = assertThrows(OntologyNotFoundException.class,
+                () -> run(executor, notFound));
+        assertSame(notFound, ex.getCause());
+    }
+
+    @Test
+    void httpException503_mapsToEndpointUnavailable() {
+        HttpException unavailable = new HttpException(503, "Service Unavailable", "down");
+        FusekiSparqlExecutor executor = executorThrowing(unavailable);
+
+        SparqlEndpointUnavailableException ex = assertThrows(SparqlEndpointUnavailableException.class,
+                () -> run(executor, unavailable));
+        assertEquals("Fuseki", ex.getEndpointLabel());
+        assertSame(unavailable, ex.getCause());
+    }
+
+    @Test
+    void httpException502_mapsToEndpointUnavailable() {
+        HttpException badGateway = new HttpException(502, "Bad Gateway", "proxy");
+        FusekiSparqlExecutor executor = executorThrowing(badGateway);
+
+        assertThrows(SparqlEndpointUnavailableException.class, () -> run(executor, badGateway));
+    }
+
+    @Test
+    void httpException504_mapsToEndpointUnavailable() {
+        HttpException gatewayTimeout = new HttpException(504, "Gateway Timeout", "slow");
+        FusekiSparqlExecutor executor = executorThrowing(gatewayTimeout);
+
+        assertThrows(SparqlEndpointUnavailableException.class, () -> run(executor, gatewayTimeout));
+    }
+
+    @Test
+    void connectionDrop_unsetStatus_mapsToEndpointUnavailable() {
+        // A reset/dropped connection is how Jena reports the `content-length 62 != 0 written`
+        // tear-down — no HTTP status, getStatusCode() <= 0.
+        HttpException dropped = new HttpException("Connection reset");
+        FusekiSparqlExecutor executor = executorThrowing(dropped);
+
+        assertThrows(SparqlEndpointUnavailableException.class, () -> run(executor, dropped));
+    }
+
+    @Test
+    void httpException500_staysJenaTDB2Exception() {
+        HttpException serverError = new HttpException(500, "Internal Server Error", "boom");
+        FusekiSparqlExecutor executor = executorThrowing(serverError);
+
+        JenaTDB2Exception ex = assertThrows(JenaTDB2Exception.class,
+                () -> run(executor, serverError));
+        assertEquals(USER_MSG, ex.getMessage());
+        assertSame(serverError, ex.getCause());
+    }
+
+    @Test
+    void queryExceptionHttp404_mapsToOntologyNotFound() {
+        QueryExceptionHTTP notFound = new QueryExceptionHTTP(404, "Not Found");
+        FusekiSparqlExecutor executor = executorThrowing(notFound);
+
+        assertThrows(OntologyNotFoundException.class, () -> run(executor, notFound));
+    }
+}


### PR DESCRIPTION
 Summary

  Problem: On the graph-detail path, every Fuseki failure — a missing graph (404), an empty graph, and a real Fuseki outage (503/dropped connection) — collapsed into the same HTTP 500 to the FE. So stale-localStorage pointer to the wiped testovací-slovník-dvě produced a 500, indistinguishable from "the store is broken."

  Fix (3 production files):

  1. FusekiSparqlExecutor.java — the core change. The HTTP catch block now reads getStatusCode() (from both HttpException and QueryExceptionHTTP) and routes:
    - 404 → OntologyNotFoundException → HTTP 404
    - 502/503/504 + connection drops (status ≤ 0, the content-length 62 != 0 tear-down) → SparqlEndpointUnavailableException("Fuseki", …) → HTTP 503
    - everything else → JenaTDB2Exception → HTTP 500 (unchanged)

  Both target exceptions and their handler mappings already existed, no GlobalExceptionHandler change.
  2. OntologyServiceImpl.java — the 4 not-found/empty-model throw sites on the two detail methods now throw OntologyNotFoundException (404) instead of Jena's OntologyException (500). This also covers the variant where Jena's fetch returns an empty model rather than throwing 404.
  3. OutboxRelay.java — a needed safety catch: a Fuseki outage during outbox drain used to be a JenaTDB2Exception (transient → retry). Since it now throws SparqlEndpointUnavailableException, added it to the transient-retry catch so an outage still retries rather than permanent-failing.

  Tests: new FusekiSparqlExecutorTest (7 cases covering 404/502/503/504/conn-drop/500/QueryExceptionHTTP), 4 updated service-test assertions, full suite green (1294/0).